### PR TITLE
Eatyourpeas/issue22

### DIFF
--- a/project/npda/general_functions/time_elapsed.py
+++ b/project/npda/general_functions/time_elapsed.py
@@ -15,6 +15,8 @@ def stringify_time_elapsed(start_date, end_date):
     Calculated field. Returns time elapsed between two dates as a string.
     """
     if end_date and start_date:
+        if end_date < start_date:
+            raise ValueError("End date cannot be before start date")
         elapsed = relativedelta(end_date, start_date)
         # Initialise empty string
         string_delta = ""

--- a/project/npda/tests/UserDataClasses.py
+++ b/project/npda/tests/UserDataClasses.py
@@ -1,0 +1,81 @@
+"""
+Set up dataclasses for E12 User Test Fixtures
+"""
+
+# Standard Imports
+from dataclasses import dataclass
+from npda.general_functions import group_for_role
+
+# RCPCH Imports
+from project.constants.user import (
+    AUDIT_CENTRE_ADMINISTRATOR,
+    AUDIT_CENTRE_CLINICIAN,
+    AUDIT_CENTRE_LEAD_CLINICIAN,
+    RCPCH_AUDIT_TEAM,
+    TRUST_AUDIT_TEAM_VIEW_ONLY,
+    TRUST_AUDIT_TEAM_EDIT_ACCESS,
+    TRUST_AUDIT_TEAM_FULL_ACCESS,
+    NPDA_AUDIT_TEAM_FULL_ACCESS,
+)
+
+
+@dataclass
+class TestUser:
+    role: int
+    role_str: str
+    is_clinical_audit_team: bool = False
+    is_active: bool = False
+    is_staff: bool = False
+    is_rcpch_audit_team_member: bool = False
+    is_rcpch_staff: bool = False
+
+    @property
+    def group_name(self):
+        return group_for_role(self.role)
+
+
+test_user_audit_centre_administrator_data = TestUser(
+    role=AUDIT_CENTRE_ADMINISTRATOR,
+    is_active=True,
+    is_staff=False,
+    role_str="AUDIT_CENTRE_ADMINISTRATOR",
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+)
+
+test_user_audit_centre_clinician_data = TestUser(
+    role=AUDIT_CENTRE_CLINICIAN,
+    role_str="AUDIT_CENTRE_CLINICIAN",
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+)
+
+test_user_audit_centre_lead_clinician_data = TestUser(
+    role=AUDIT_CENTRE_LEAD_CLINICIAN,
+    role_str="AUDIT_CENTRE_LEAD_CLINICIAN",
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+)
+
+test_user_clinicial_audit_team_data = TestUser(
+    role=AUDIT_CENTRE_LEAD_CLINICIAN,
+    role_str="CLINICAL_AUDIT_TEAM",
+    is_active=True,
+    is_staff=False,
+    is_clinical_audit_team=True,
+    is_rcpch_audit_team_member=True,
+    is_rcpch_staff=False,
+)
+
+test_user_rcpch_audit_team_data = TestUser(
+    role=RCPCH_AUDIT_TEAM,
+    role_str="RCPCH_AUDIT_TEAM",
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=True,
+    is_rcpch_staff=True,
+)

--- a/project/npda/tests/UserDataClasses.py
+++ b/project/npda/tests/UserDataClasses.py
@@ -4,7 +4,7 @@ Set up dataclasses for E12 User Test Fixtures
 
 # Standard Imports
 from dataclasses import dataclass
-from npda.general_functions import group_for_role
+from project.npda.general_functions import group_for_role
 
 # RCPCH Imports
 from project.constants.user import (

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 
 # rcpch imports
-from npda.tests.factories import (
+from project.npda.tests.factories import (
     seed_groups_fixture,
     seed_users_fixture,
     seed_cases_fixture,
@@ -18,7 +18,7 @@ from npda.tests.factories import (
     PatientVisitFactory,
     NPDAUserFactory,
 )
-from npda.models import Organisation, Patient
+from project.npda.models import Patient
 
 
 # register factories to be used across test directory
@@ -29,31 +29,31 @@ register(PatientVisitFactory)  # => patient_visit_factory
 register(NPDAUserFactory)  # => npdauser_factory
 
 
-@pytest.fixture
-@pytest.mark.django_db
-def GOSH():
-    return Organisation.objects.get(
-        ods_code="RP401",
-        trust__ods_code="RP4",
-    )
+# @pytest.fixture
+# @pytest.mark.django_db
+# def GOSH():
+#     return Organisation.objects.get(
+#         ods_code="RP401",
+#         trust__ods_code="RP4",
+#     )
 
 
-@pytest.fixture
-@pytest.mark.django_db
-def PATIENT_GOSH():
-    return Case.objects.get(first_name=f"child_{GOSH.name}")
+# @pytest.fixture
+# @pytest.mark.django_db
+# def PATIENT_GOSH():
+#     return Patient.objects.get(first_name=f"child_{GOSH.name}")
 
 
-@pytest.fixture
-@pytest.mark.django_db
-def ADDENBROOKES():
-    Organisation.objects.get(
-        ods_code="RGT01",
-        trust__ods_code="RGT",
-    )
+# @pytest.fixture
+# @pytest.mark.django_db
+# def ADDENBROOKES():
+#     Organisation.objects.get(
+#         ods_code="RGT01",
+#         trust__ods_code="RGT",
+#     )
 
 
-@pytest.fixture
-@pytest.mark.django_db
-def PATIENT_ADDENBROOKES():
-    Patient.objects.get(first_name=f"child_{ADDENBROOKES.name}")
+# @pytest.fixture
+# @pytest.mark.django_db
+# def PATIENT_ADDENBROOKES():
+#     Patient.objects.get(first_name=f"child_{ADDENBROOKES.name}")

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -1,0 +1,59 @@
+"""conftest.py
+Configures pytest fixtures for npda app tests.
+"""
+
+# standard imports
+
+# third-party imports
+from pytest_factoryboy import register
+import pytest
+
+
+# rcpch imports
+from npda.tests.factories import (
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_cases_fixture,
+    PatientFactory,
+    PatientVisitFactory,
+    NPDAUserFactory,
+)
+from npda.models import Organisation, Patient
+
+
+# register factories to be used across test directory
+
+# factory object becomes lowercase-underscore form of the class name
+register(PatientFactory)  # => patient_factory
+register(PatientVisitFactory)  # => patient_visit_factory
+register(NPDAUserFactory)  # => npdauser_factory
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def GOSH():
+    return Organisation.objects.get(
+        ods_code="RP401",
+        trust__ods_code="RP4",
+    )
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def PATIENT_GOSH():
+    return Case.objects.get(first_name=f"child_{GOSH.name}")
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def ADDENBROOKES():
+    Organisation.objects.get(
+        ods_code="RGT01",
+        trust__ods_code="RGT",
+    )
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def PATIENT_ADDENBROOKES():
+    Patient.objects.get(first_name=f"child_{ADDENBROOKES.name}")

--- a/project/npda/tests/factories/NPDAUserFactory.py
+++ b/project/npda/tests/factories/NPDAUserFactory.py
@@ -1,0 +1,18 @@
+"""Factory fn to create new NPDAUser.
+"""
+
+# standard imports
+from datetime import timedelta
+
+# third-party imports
+import factory
+
+# rcpch imports
+from project.npda.models import NPDAUser
+
+
+class NPDAUserFactory(factory.django.DjangoModelFactory):
+    """Dependency factory for creating a minimum viable NPDAUser."""
+
+    class Meta:
+        model = NPDAUser

--- a/project/npda/tests/factories/PatientFactory.py
+++ b/project/npda/tests/factories/PatientFactory.py
@@ -1,0 +1,18 @@
+"""Factory fn to create new Patient.
+"""
+
+# standard imports
+from datetime import timedelta
+
+# third-party imports
+import factory
+
+# rcpch imports
+from project.npda.models import Patient
+
+
+class PatientFactory(factory.django.DjangoModelFactory):
+    """Dependency factory for creating a minimum viable Patient."""
+
+    class Meta:
+        model = Patient

--- a/project/npda/tests/factories/PatientVisitFactory.py
+++ b/project/npda/tests/factories/PatientVisitFactory.py
@@ -1,0 +1,24 @@
+"""Factory fn to create new Visit, related to a Patient.
+"""
+
+# standard imports
+from datetime import timedelta
+
+# third-party imports
+import factory
+
+# rcpch imports
+from project.npda.models import Patient, Visit
+
+
+class PatientVisitFactory(factory.django.DjangoModelFactory):
+    """Dependency factory for creating a minimum viable E12Management.
+
+    This Factory is generated AFTER a Patient has been generated.
+    """
+
+    class Meta:
+        model = Visit
+
+    # Once Patient instance made, it will attach to this instance
+    patient = None

--- a/project/npda/tests/factories/__init__.py
+++ b/project/npda/tests/factories/__init__.py
@@ -1,0 +1,6 @@
+from .seed_groups_permissions import *
+from .seed_patients import *
+from .seed_users import *
+from .NPDAUserFactory import *
+from .PatientFactory import *
+from .PatientVisitFactory import *

--- a/project/npda/tests/factories/seed_groups_permissions.py
+++ b/project/npda/tests/factories/seed_groups_permissions.py
@@ -1,0 +1,23 @@
+import pytest
+
+from django.contrib.auth.models import Group
+
+from npda.management.commands.create_groups import groups_seeder
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope="session")
+def seed_groups_fixture(django_db_setup, django_db_blocker):
+    """
+    Fixture which runs once per session to seed groups
+    verbose=False
+    """
+    with django_db_blocker.unblock():
+
+        if not Group.objects.all().exists():
+            groups_seeder(
+                run_create_groups=True,
+                verbose=False,
+            )
+        else:
+            print("Groups already seeded. Skipping")

--- a/project/npda/tests/factories/seed_groups_permissions.py
+++ b/project/npda/tests/factories/seed_groups_permissions.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.contrib.auth.models import Group
 
-from npda.management.commands.create_groups import groups_seeder
+from project.npda.management.commands.create_groups import groups_seeder
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/factories/seed_patients.py
+++ b/project/npda/tests/factories/seed_patients.py
@@ -1,0 +1,37 @@
+"""
+Seeds 2 Patients in test db once per session. One user in GOSH. One user in different Trust (Addenbrooke's)
+"""
+
+# Standard imports
+import pytest
+
+# 3rd Party imports
+
+# E12 Imports
+from npda.models import Organisation, Patient
+from .PatientFactory import PatientFactory
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope="session")
+def seed_cases_fixture(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        # prevent repeat seed
+        if not Patient.objects.all().exists():
+            GOSH = Organisation.objects.get(
+                ods_code="RP401",
+                trust__ods_code="RP4",
+            )
+
+            ADDENBROOKES = Organisation.objects.get(
+                ods_code="RGT01",
+                trust__ods_code="RGT",
+            )
+
+            for organisation in [GOSH, ADDENBROOKES]:
+                Patient(
+                    first_name=f"child_{organisation.name}",
+                    organisations__organisation=organisation,
+                )
+        else:
+            print("Test cases seeded. Skipping")

--- a/project/npda/tests/factories/seed_patients.py
+++ b/project/npda/tests/factories/seed_patients.py
@@ -8,7 +8,7 @@ import pytest
 # 3rd Party imports
 
 # E12 Imports
-from npda.models import Organisation, Patient
+from project.npda.models import Patient
 from .PatientFactory import PatientFactory
 
 
@@ -18,20 +18,20 @@ def seed_cases_fixture(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
         # prevent repeat seed
         if not Patient.objects.all().exists():
-            GOSH = Organisation.objects.get(
-                ods_code="RP401",
-                trust__ods_code="RP4",
-            )
+            # GOSH = Organisation.objects.get(
+            #     ods_code="RP401",
+            #     trust__ods_code="RP4",
+            # )
 
-            ADDENBROOKES = Organisation.objects.get(
-                ods_code="RGT01",
-                trust__ods_code="RGT",
-            )
+            # ADDENBROOKES = Organisation.objects.get(
+            #     ods_code="RGT01",
+            #     trust__ods_code="RGT",
+            # )
 
-            for organisation in [GOSH, ADDENBROOKES]:
-                Patient(
-                    first_name=f"child_{organisation.name}",
-                    organisations__organisation=organisation,
-                )
+            # for organisation in [GOSH, ADDENBROOKES]:
+            Patient(
+                # first_name=f"child_{organisation.name}",
+                # organisations__organisation=organisation,
+            )
         else:
             print("Test cases seeded. Skipping")

--- a/project/npda/tests/factories/seed_users.py
+++ b/project/npda/tests/factories/seed_users.py
@@ -9,18 +9,18 @@ import pytest
 from django.contrib.auth.models import Group
 
 # E12 Imports
-from npda.tests.UserDataClasses import (
+from project.npda.tests.UserDataClasses import (
     test_user_audit_centre_administrator_data,
     test_user_audit_centre_clinician_data,
     test_user_audit_centre_lead_clinician_data,
     test_user_rcpch_audit_team_data,
     test_user_clinicial_audit_team_data,
 )
-from npda.models import (
-    Epilepsy12User,
-    Organisation,
+from project.npda.models import (
+    NPDAUser,
+    # Organisation,
 )
-from .NPDAUserFactory import E12UserFactory
+from .NPDAUserFactory import NPDAUserFactory
 from project.constants.user import (
     RCPCH_AUDIT_TEAM,
 )
@@ -39,11 +39,11 @@ def seed_users_fixture(django_db_setup, django_db_blocker):
 
     with django_db_blocker.unblock():
         # Don't repeat seed
-        if not Epilepsy12User.objects.exists():
-            TEST_USER_ORGANISATION = Organisation.objects.get(
-                ods_code="RP401",
-                trust__ods_code="RP4",
-            )
+        if not NPDAUser.objects.exists():
+            # TEST_USER_ORGANISATION = Organisation.objects.get(
+            #     ods_code="RP401",
+            #     trust__ods_code="RP4",
+            # )
 
             is_active = True
             is_staff = False
@@ -71,7 +71,7 @@ def seed_users_fixture(django_db_setup, django_db_blocker):
                     is_staff=is_staff,
                     is_rcpch_audit_team_member=is_rcpch_audit_team_member,
                     is_rcpch_staff=is_rcpch_staff,
-                    organisation_employer=TEST_USER_ORGANISATION,
+                    # organisation_employer=TEST_USER_ORGANISATION,
                     groups=[user.group_name],
                 )
         else:

--- a/project/npda/tests/factories/seed_users.py
+++ b/project/npda/tests/factories/seed_users.py
@@ -1,0 +1,78 @@
+"""
+Seeds E12 Users in test db once per session.
+"""
+
+# Standard imports
+import pytest
+
+# 3rd Party imports
+from django.contrib.auth.models import Group
+
+# E12 Imports
+from npda.tests.UserDataClasses import (
+    test_user_audit_centre_administrator_data,
+    test_user_audit_centre_clinician_data,
+    test_user_audit_centre_lead_clinician_data,
+    test_user_rcpch_audit_team_data,
+    test_user_clinicial_audit_team_data,
+)
+from npda.models import (
+    Epilepsy12User,
+    Organisation,
+)
+from .NPDAUserFactory import E12UserFactory
+from project.constants.user import (
+    RCPCH_AUDIT_TEAM,
+)
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope="session")
+def seed_users_fixture(django_db_setup, django_db_blocker):
+    users = [
+        test_user_audit_centre_administrator_data,
+        test_user_audit_centre_clinician_data,
+        test_user_audit_centre_lead_clinician_data,
+        test_user_rcpch_audit_team_data,
+        test_user_clinicial_audit_team_data,
+    ]
+
+    with django_db_blocker.unblock():
+        # Don't repeat seed
+        if not Epilepsy12User.objects.exists():
+            TEST_USER_ORGANISATION = Organisation.objects.get(
+                ods_code="RP401",
+                trust__ods_code="RP4",
+            )
+
+            is_active = True
+            is_staff = False
+            is_rcpch_audit_team_member = False
+            is_rcpch_staff = False
+
+            # seed a user of each type at GOSH
+            for user in users:
+                first_name = user.role_str
+
+                # set RCPCH AUDIT TEAM MEMBER ATTRIBUTE
+                if user.role == RCPCH_AUDIT_TEAM:
+                    is_rcpch_audit_team_member = True
+                    is_rcpch_staff = True
+
+                if user.is_clinical_audit_team:
+                    is_rcpch_audit_team_member = True
+                    first_name = "CLINICAL_AUDIT_TEAM"
+
+                E12UserFactory(
+                    first_name=first_name,
+                    role=user.role,
+                    # Assign flags based on user role
+                    is_active=is_active,
+                    is_staff=is_staff,
+                    is_rcpch_audit_team_member=is_rcpch_audit_team_member,
+                    is_rcpch_staff=is_rcpch_staff,
+                    organisation_employer=TEST_USER_ORGANISATION,
+                    groups=[user.group_name],
+                )
+        else:
+            print("Test users already seeded. Skipping")

--- a/project/npda/tests/misc_py_shell_code.py
+++ b/project/npda/tests/misc_py_shell_code.py
@@ -1,0 +1,79 @@
+"""
+This file houses code to be copied and pasted easily into the Django Python shell.
+"""
+
+# Seeds test db users according to role + permissions.
+
+from django.contrib.auth.models import Group
+from npda.tests.UserDataClasses import (
+    test_user_audit_centre_administrator_data,
+    test_user_audit_centre_clinician_data,
+    test_user_audit_centre_lead_clinician_data,
+    test_user_rcpch_audit_team_data,
+    test_user_clinicial_audit_team_data,
+)
+
+from npda.models import Organisation
+from project.npda.tests.factories.NPDAUserFactory import NPDAUserFactory
+from project.constants.user import RCPCH_AUDIT_TEAM
+
+users = [
+    test_user_audit_centre_administrator_data,
+    test_user_audit_centre_clinician_data,
+    test_user_audit_centre_lead_clinician_data,
+    test_user_rcpch_audit_team_data,
+    test_user_clinicial_audit_team_data,
+]
+
+TEST_USER_ORGANISATION = Organisation.objects.get(
+    ods_code="RP401",
+    trust__ods_code="RP4",
+)
+
+NPDAUserFactory(
+    first_name=test_user_audit_centre_administrator_data.role_str,
+    role=test_user_audit_centre_administrator_data.role,
+    # Assign flags based on user role
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+    organisation_employer=TEST_USER_ORGANISATION,
+    groups=[test_user_audit_centre_administrator_data.group_name],
+)
+E12UserFactory(
+    first_name=test_user_audit_centre_clinician_data.role_str,
+    role=test_user_audit_centre_clinician_data.role,
+    # Assign flags based on user role
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+    organisation_employer=TEST_USER_ORGANISATION,
+    groups=[test_user_audit_centre_clinician_data.group_name],
+)
+
+NPDAUserFactory(
+    first_name=test_user_rcpch_audit_team_data.role_str,
+    role=test_user_rcpch_audit_team_data.role,
+    # Assign flags based on user role
+    is_active=True,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+    organisation_employer=TEST_USER_ORGANISATION,
+    groups=[test_user_rcpch_audit_team_data.group_name],
+)
+
+# Welsh Lead Clinician
+NPDAUserFactory(
+    first_name=test_user_audit_centre_lead_clinician_data.role_str,
+    role=test_user_audit_centre_lead_clinician_data.role,
+    surname="WELSH",
+    is_active=False,
+    is_staff=False,
+    is_rcpch_audit_team_member=False,
+    is_rcpch_staff=False,
+    organisation_employer=Organisation.objects.get(pk=333),
+    groups=[test_user_audit_centre_lead_clinician_data.group_name],
+)

--- a/project/npda/tests/test_general_functions/test_stringify_time_elapsed.py
+++ b/project/npda/tests/test_general_functions/test_stringify_time_elapsed.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+import pytest
+from project.npda.general_functions import stringify_time_elapsed
+
+
+@pytest.mark.django_db
+def test_one_year_three_months_difference():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2023, 4, 1)
+    assert stringify_time_elapsed(start_date, end_date) == "1 year, 3 months"
+
+
+@pytest.mark.django_db
+def test_six_months_difference():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2022, 7, 1)
+    assert stringify_time_elapsed(start_date, end_date) == "6 months"
+
+
+@pytest.mark.django_db
+def test_one_month_difference():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2022, 2, 1)
+    assert stringify_time_elapsed(start_date, end_date) == "1 month"
+
+
+@pytest.mark.django_db
+def test_one_week_difference():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2022, 1, 8)
+    assert stringify_time_elapsed(start_date, end_date) == "1 week"
+
+
+@pytest.mark.django_db
+def test_one_day_difference():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2022, 1, 2)
+    assert stringify_time_elapsed(start_date, end_date) == "1 day"
+
+
+@pytest.mark.django_db
+def test_same_day():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2022, 1, 1)
+    assert stringify_time_elapsed(start_date, end_date) == "Same day"
+
+
+@pytest.mark.django_db
+def test_invalid_input_end_date_none():
+    start_date = datetime(2022, 1, 1)
+    end_date = None
+    with pytest.raises(ValueError) as e:
+        stringify_time_elapsed(start_date, end_date)
+    assert str(e.value) == "Both start and end dates must be provided"
+
+
+@pytest.mark.django_db
+def test_invalid_input_start_date_none():
+    start_date = None
+    end_date = datetime(2022, 1, 1)
+    with pytest.raises(ValueError) as e:
+        stringify_time_elapsed(start_date, end_date)
+    assert str(e.value) == "Both start and end dates must be provided"
+
+
+@pytest.mark.django_db
+def test_end_date_before_start_date():
+    start_date = datetime(2022, 1, 1)
+    end_date = datetime(2021, 1, 1)
+    with pytest.raises(ValueError) as e:
+        stringify_time_elapsed(start_date, end_date)
+    assert str(e.value) == "End date cannot be before start date"
+
+
+@pytest.mark.django_db
+def test_very_large_time_difference():
+    start_date = datetime(2020, 1, 1)
+    end_date = datetime(2025, 8, 24)
+    assert stringify_time_elapsed(start_date, end_date) == "5 years, 7 months"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,16 @@
+[pytest]
+
+# POINT PYTEST AT PROJECT SETTINGS
+DJANGO_SETTINGS_MODULE = project.settings
+
+# SET FILENAME FORMATS OF TESTS
+python_files = test_*.py
+
+# RE USE TEST DB AS DEFAULT
+addopts = 
+    --reuse-db
+    -k "not examples"
+
+markers =
+    examples: mark test as workshop-type / example test
+    seed: mark test as 'meta test', just used for seeding


### PR DESCRIPTION
### Overview
This adds django-pytest, factory-boy and registers the models as factories.

It has not been possible fully to implement tests relating to models because the factories depend on the Organisation model which has not been included yet, pending decision on how to include in NPDA.

## Changes
 - add tests folder and `__init__.py`
- add `conftest.py`, `pytest.ini`, a factories folder with one for each model.
- 10 new tests as a concept testing `stringify_time_elapsed.py`

## Issues
closes #22