### PR TITLE
Adds a check to template tag to prevent NoneType error being thrown

### DIFF
--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -109,6 +109,8 @@ def error_for_field(messages, field):
     Returns all errors for a given field
     """
     concatenated_fields = ""
+    if messages is None:
+        messages = []
     if field in VISIT_FIELD_FLAT_LIST:
         return "There are errors associated with one or more of this child's visits."
     if len(messages) > 0:


### PR DESCRIPTION
This PR resolves a small bug found in a template tag. A parameter called 'messages' is set in the tag error_for_field, but if messages is a NoneType (ie there are no messages to pass in, then we can't perform the later len(messages) operation.

This sets messages equal to an empty list (if it is equal to None) so that the len(messages) operation can be performed