### PR TITLE
Remove npda logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 envs/.env
 staticdocs
 staticfiles
-logs/npda.log.*
+logs
 
 __pycache__
 .DS_Store

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -109,6 +109,8 @@ def error_for_field(messages, field):
     Returns all errors for a given field
     """
     concatenated_fields = ""
+    if messages is None:
+        messages = []
     if field in VISIT_FIELD_FLAT_LIST:
         return "There are errors associated with one or more of this child's visits."
     if len(messages) > 0:


### PR DESCRIPTION
Removes npda.log from git tracking history and adds entire log directory to .gitignore

Closes #54 