### PR TITLE
Creates logging folder and log file when docker image is built for npda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,11 @@ WORKDIR /app/
 # (Excludes any files/dirs matched by patterns in .dockerignore)
 COPY . /app/
 
+# Copy the startup script into the image
+COPY logging_startup.sh /logging_startup.sh
+
+# Make the startup script executable
+RUN chmod +x /logging_startup.sh
+
+# Run the startup script
+ENTRYPOINT ["/logging_startup.sh"]

--- a/logging_startup.sh
+++ b/logging_startup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Create the logs directory if it doesn't exist
+mkdir -p /app/logs
+
+# Create the npda.log file if it doesn't exist
+touch /app/logs/npda.log
+
+# Execute
+exec "$@"


### PR DESCRIPTION
Fixes bug where logger config wasn't functioning without an npda.log file.

Adds a startup script to create a logs folder and an npda.log file if they don't already exist, to alleviate this error for any users running the code locally.