### PR TITLE
Logs folder addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 envs/.env
 staticdocs
 staticfiles
-logs
+logs/npda.log
+npda.log.*
+
 
 __pycache__
 .DS_Store


### PR DESCRIPTION
Adds an empty placeholder file (named .gitkeep) to enable the logs folder to be committed to repository after it was deleted in an earlier commit.

This solution creates less files and less changes in other files than our alternative one in #56 , which modifies the dockerfile. We need this capability so the logger can assign a directory for the npda.log file to go (without tracking the file itself)