### PR TITLE
Fixes value in Patient update form missing / Nonetype error

### DIFF
--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -15,13 +15,13 @@
             {% if field.field.widget|is_select %}
               <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select">
                 {% for choice in field.field.choices %}
-                <option value="{{choice.0}}">{{choice.1}}</option>
+                <option {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
                 {% endfor %}
               </select>
             {% elif field.field.widget|is_dateinput %}
-              <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value|date:"Y-m-d" }}" class="input rcpch-input-text">
+              <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %} class="input rcpch-input-text">
             {% else %}
-              <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" value="{{ field.value }}" class="input rcpch-input-text">
+              <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value="{{ field.value }}" {% endif %} class="input rcpch-input-text">
             {% endif %}
               {% for error in field.errors %}
               <div role="alert" class="alert alert-error py-1 my-0 rounded-none">


### PR DESCRIPTION
Error noted in PR #67 and also found when investigating Patient creation form (noted in #70):

- When updating a patient's information via the patient form, those fields of type 'select' were not filling with preloaded data of the already-entered patient.
- When creating a new patient, fields of type 'text' were autofilling with None, which would require the user to remove that text and then replace it with the new patient information

This PR fixes both of these issues. 'None' is no longer in the new patient creation form, and fields of type 'select' are filled with the relevant information when updating an already-existing patient's information.

Fixes #70 