### PR TITLE
(Fixes #68) added main protection and run pytest on every push or merge

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Run Pytest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Pytest
+        run: pytest


### PR DESCRIPTION
In this PR,  have changed the setting of repo, main branch to add rules for the protection of min branch. and created .github/workflows folders inside that created pytest.yml. in this file i have added code which will  will trigger on every push or pull request to the main branch, install dependencies, and run Pytest. 



Fixes https://github.com/rcpch/national-paediatric-diabetes-audit/issues/68

from my above mistake you might have guessed that I am new to open source. so, I will look forward to the feedbacks .
If there is any correction please explain, that will help me understand the poblem.