### PR TITLE
Adds Today button to each date field

### DIFF
--- a/project/npda/templates/base.html
+++ b/project/npda/templates/base.html
@@ -19,15 +19,16 @@
   <link href="{% static 'tailwind.css' %}" rel="stylesheet">
   <link href="https://fonts.cdnfonts.com/css/arial-2" rel="stylesheet">
   <script src="https://unpkg.com/htmx.org@1.9.11/dist/htmx.js" integrity="sha384-l9bYT9SL4CAW0Hl7pAOpfRc18mys1b0wK4U8UtGnWOxPVbVMgrOdB+jyz/WY8Jue" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
   <!-- not for production -->
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4.11.1/dist/full.min.css" rel="stylesheet" type="text/css" />
   <style type="text/tailwindcss">
     @layer components {
       .rcpch-light-blue-btn {
-        @apply bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue rounded-none;
+        @apply bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue rounded-none;
       }
       .rcpch-btn {
-        @apply text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_yellow_light_tint1 hover:bg-rcpch_yellow hover:border-rcpch_yellow rounded-none;
+        @apply text-white font-semibold hover:text-white py-2.5 px-3 border border-rcpch_yellow_light_tint1 hover:bg-rcpch_yellow hover:border-rcpch_yellow rounded-none;
       }
       .rcpch-input-text {
         @apply shadow appearance-none border border-rcpch_light_blue border-4 focus:border-rcpch_pink hover:border-rcpch_pink w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none rounded-none;

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -13,9 +13,10 @@
             <div class="md:w-1/3">
                 <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
             </div>
-            <div class="md:w-2/3">
+            <div class="flex space-between md:w-2/3">
               {% if field.id_for_label == "id_visit_date" %}
                 <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
               {% endif %}
               {% for error in field.errors %}
                 <p>

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -164,7 +164,7 @@
         <button type="submit" value="Submit" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">{{button_title}}</button>
         <a class="btn rcpch-btn bg-rcpch_yellow_light_tint1 border border-rcpch_yellow_light_tint1 hover:bg-rcpch_yellow hover:border-rcpch_yellow" href="{% url 'patient_visits' patient_id=patient_id %}">Cancel</a>
         {% if form_method == 'update' %}
-        <a class="btn rcpch-btn bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint" href="{% url 'visit-delete' patient_id visit.pk %}">Delete</a>
+        <a class="btn rcpch-btn bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint" href="{% url 'visit-delete' patient_id visit.pk %}">Delete</a>
         {% endif %}
       </div>
     </form>

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -15,7 +15,7 @@
             </div>
             <div class="md:w-2/3">
               {% if field.id_for_label == "id_visit_date" %}
-                <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% elif form_method == "create" %} value={% today_date %} {% endif %}>
+                <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
               {% endif %}
               {% for error in field.errors %}
                 <p>
@@ -48,7 +48,8 @@
                         {% endfor %}
                       </select>
                   {% elif field.field.widget|is_dateinput %}
-                    <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% elif form_method == "create" %} value={% today_date %} {% endif %}>
+                    <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                    <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
                   {% else %}
                       <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
                   {% endif %}
@@ -92,7 +93,8 @@
                             {% endfor %}
                           </select>
                       {% elif field.field.widget|is_dateinput %}
-                          <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% elif form_method == "create" %} value={% today_date %} {% endif %}>
+                          <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                          <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
                       {% else %}
                           <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
                       {% endif %}
@@ -133,6 +135,7 @@
                       </select>
                   {% elif field.field.widget|is_dateinput %}
                       <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                      <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
                   {% else %}
                       <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
                   {% endif %}


### PR DESCRIPTION
Purpose of PR is to remove a preset value for each date field, which was previously today's date. However, this activated the category, meaning that it showed up as 'addressed' even if the user had not entered anything - the preset value was enough for it to show user activity.

Instead, a button with 'Today' next to each date field has been implemented with Hyperscript to fill the date field if the user wishes so, fixing the bug above and also removing the number of clicks to enter today's date.

Closes #60