### PR TITLE
Change design of Visit form to load errors into form

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -2,8 +2,8 @@
 {% load npda_tags %}
 {% csrf_token %}
 {% block content %}
-<div class="bg-rcpch_light_blue py-8">
-  <div class="w-full max-w-3xl mx-auto px-2 py-4 m-2 shadow-md bg-white font-montserrat">
+<div class="flex justify-center bg-white py-8">
+  <div class="w-full mx-96 px-2 py-4 m-2 shadow-md bg-white font-montserrat">
     <strong>{{title}}</strong>
     <form id="update-form" method="post" {% if form_method == "create" %} action="{% url 'visit-create' patient_id %}" {% else %} action="{% url 'visit-update' patient_id=patient_id pk=visit.pk %}" {% endif %}>
       {% csrf_token %}
@@ -29,10 +29,10 @@
 
       <div role="tablist" class="tabs tabs-bordered">
         <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Routine&nbsp;Measurements" checked/>
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none p-6">
+        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none">
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
-          {% if field_category == "Measurements" or field_category == "HBA1c" or field_category == "Treatment" or field_category == "CGM" %}
+          {% if field_category == "Measurements" or field_category == "HBA1c" or field_category == "Treatment" or field_category == "CGM" or field_category == "BP"%}
             <div class="flex flex-col mb-6 {% if background_colour %} bg-{{background_colour}} {% endif %}">
             {% for field in form %}
                 {% if field.field.category == field_category %}
@@ -71,18 +71,18 @@
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none p-6">
           {% for field_category in form.categories %}
             {% with field_category|colour_for_category as background_colour %}
-            {% if field_category == "BP" or field_category == "Foot Care" or field_category == "DECS" or field_category == "ACR" or field_category == "Cholesterol" or field_category == "Thyroid" or field_category == "Coeliac" or field_category == "Psychology" or field_category == "Smoking" or field_category == "Dietician" or field_category == "Sick Day Rules" or field_category == "Immunisation (flu)" %}
-              <div class="collapse collapse-arrow my-2 bg-base-200">
+            {% if field_category == "Foot Care" or field_category == "DECS" or field_category == "ACR" or field_category == "Cholesterol" or field_category == "Thyroid" or field_category == "Coeliac" or field_category == "Psychology" or field_category == "Smoking" or field_category == "Dietician" or field_category == "Sick Day Rules" or field_category == "Immunisation (flu)" %}
+              <div class="collapse collapse-arrow my-2 bg-base-200 rounded-none {% if field_category in categories_with_errors %} bg-rcpch_red {% elif field_category in categories_without_errors %} bg-rcpch_pink {% else %} bg-rcpch_dark_blue {% endif %}">
                 <input type="radio" name="my-accordion-3" checked="checked" /> 
-                <div class="collapse-title text-xl font-medium">
+                <div class="collapse-title text-xl font-medium text-white">
                   <strong>{{field_category}}</strong>
                 </div>
-                <div class="collapse-content flex flex-col mb-6 {% if background_colour %} bg-{{background_colour}} {% endif %}">
+                <div class="collapse-content flex flex-col mb-6 text-lg {% if field_category in categories_with_errors %} bg-rcpch_red {% elif field_category in categories_without_errors %} bg-rcpch_pink {% else %} bg-rcpch_dark_blue {% endif %}">
                   {% for field in form %}
                     {% if field.field.category == field_category %}
                     <div class="flex flex-row my-2 mx-2">
                       <div class="flex items-center justify-center md:w-1/3">
-                        <label for="{{ field.id_for_label }}" class="{% if background_colour == "rcpch_dark_blue" %} text-white-700 {% else %} text-gray-700 {% endif %} block font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
+                        <label for="{{ field.id_for_label }}" class="text-white block font-bold mb-1 md:mb-0 pr-4 text-left"><small>{{ field.label }}</small></label>
                       </div>
                       <div class="flex space-between md:w-2/3">
                       {% if field.field.widget|is_select %}

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -8,6 +8,7 @@ from django.shortcuts import render
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic import ListView
 from django.urls import reverse_lazy, reverse
+import logging
 
 # Third party imports
 from two_factor.views.mixins import OTPRequiredMixin
@@ -16,6 +17,8 @@ from two_factor.views.mixins import OTPRequiredMixin
 from ..models import Visit, Patient
 from ..forms.visit_form import VisitForm
 from ..general_functions import get_visit_categories
+
+logger = logging.getLogger(__name__)
 
 
 class PatientVisitsListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
@@ -81,6 +84,21 @@ class VisitUpdateView(LoginRequiredMixin, OTPRequiredMixin, UpdateView):
         context["title"] = "Edit Visit Details"
         context["button_title"] = "Edit Visit Details"
         context["form_method"] = "update"
+        visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
+        visit_categories = get_visit_categories(visit_instance)
+        context["visit_categories"] = visit_categories
+        categories_with_errors = []
+        categories_without_errors = []
+        for category in visit_categories:
+            print(category)
+            if category["has_error"] == False:
+                print("BELOW is category.category")
+                print(category["category"])
+                categories_without_errors.append(category["category"])
+            else:
+                categories_with_errors.append(category["category"])
+        context["categories_with_errors"] = categories_with_errors
+        context["categories_without_errors"] = categories_without_errors
         return context
 
     def get_success_url(self):

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -8,7 +8,6 @@ from django.shortcuts import render
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic import ListView
 from django.urls import reverse_lazy, reverse
-import logging
 
 # Third party imports
 from two_factor.views.mixins import OTPRequiredMixin
@@ -18,7 +17,7 @@ from ..models import Visit, Patient
 from ..forms.visit_form import VisitForm
 from ..general_functions import get_visit_categories
 
-logger = logging.getLogger(__name__)
+
 
 
 class PatientVisitsListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
@@ -90,10 +89,7 @@ class VisitUpdateView(LoginRequiredMixin, OTPRequiredMixin, UpdateView):
         categories_with_errors = []
         categories_without_errors = []
         for category in visit_categories:
-            print(category)
             if category["has_error"] == False:
-                print("BELOW is category.category")
-                print(category["category"])
                 categories_without_errors.append(category["category"])
             else:
                 categories_with_errors.append(category["category"])


### PR DESCRIPTION
Before this PR, a user would have to go to a patient, and view all visits, in order to see which parts of the Visit form they have submitted have errors / aren't validated. These parts of the form, which we have named 'categories', would be highlighted in red if they had errors. However, when the user clicks on the form, they would have to memorise which parts of the form had errors as this information was not sustained in anyway on the next page by error messages or anything similar.

This PR introduces a colour-coordination to this problem. Any part of the form that has not had information filled into it will appear as dark blue, any part of the form where there are no errors (and the form is valid) will be pink, and any category part of the form where there are errors will show up as red.

This PR also incorporates a couple of minor bug fixes, such as removing rounded corners from the accordion in line with RCPCH styling.

Closes #77