### PR TITLE
Bypass 2FA Token in local development

### DIFF
--- a/project/npda/templates/two_factor/_wizard_actions.html
+++ b/project/npda/templates/two_factor/_wizard_actions.html
@@ -1,32 +1,33 @@
 {% load i18n %}
 
 <div class="flex flex-col justify-center items-center">
-  
-    <button type="submit" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">
-      {% trans "Next" %}
-    </button>
-  
+
+  <button type="submit"
+    class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">
+    {% trans "Next" %}
+  </button>
+
   {% if wizard.steps.prev %}
-  <!-- <div> -->
-    <button
-      name="wizard_goto_step"
-      type="submit"
-      value="{{ wizard.steps.prev }}"
-      class="justify-center items-center bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue"
-    >
-      Back
-    </button>
-  </div>
-  {% endif %}
-<!-- </div> -->
+  <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}"
+    class="justify-center items-center bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">
+    Back
+  </button>
+</div>
+{% endif %}
 
 <!--IF NO PREV BUTTON -> MUST BE AT FIRST SIGNIN PAGE -->
 {% if not wizard.steps.prev %}
 <div class="flex flex-col justify-center items-center">
-  <a href="{% url 'password_reset' %}" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Reset Password</a>
+  <a href="{% url 'password_reset' %}"
+    class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Reset
+    Password</a>
   <div class="mt-5">
-    <div class="mt-2 bg-gray-100 border border-gray-200 text-sm text-gray-800 rounded-lg p-4 dark:bg-white/10 dark:border-white/20 dark:text-white font-montserrat" role="alert">
-      <span class="font-bold">NOTE</span> For users of the old platform, you will require a new username and password to access this new platform. Please contact your Lead Clinician or <a href="mailto:npda@rcpch.ac.uk">npda@rcpch.ac.uk</a> for assistance. 
+    <div
+      class="mt-2 bg-gray-100 border border-gray-200 text-sm text-gray-800 rounded-lg p-4 dark:bg-white/10 dark:border-white/20 dark:text-white font-montserrat"
+      role="alert">
+      <span class="font-bold">NOTE</span> For users of the old platform, you will require a new username and password to
+      access this new platform. Please contact your Lead Clinician or <a
+        href="mailto:npda@rcpch.ac.uk">npda@rcpch.ac.uk</a> for assistance.
     </div>
   </div>
 </div>

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path, include
-from django.contrib.auth.views import PasswordResetConfirmView, LogoutView
+from django.contrib.auth.views import PasswordResetConfirmView
 from django.contrib.auth import urls as auth_urls
 from project.npda.views import (
     VisitCreateView,
@@ -13,8 +13,6 @@ from project.npda.forms.npda_user_form import NPDAUpdatePasswordForm
 from .views import *
 
 urlpatterns = [
-    path("captcha/", include("captcha.urls")),
-    path("account/", include(auth_urls)),
     path("home", view=home, name="home"),
     # Patient views
     path("patients", view=PatientListView.as_view(), name="patients"),
@@ -68,7 +66,7 @@ urlpatterns = [
         view=NPDAUserDeleteView.as_view(),
         name="npdauser-delete",
     ),
-    # authentication
+    # Authentication -> NOTE: 2FA is implemented in project-level URLS with tf_urls
     path("captcha/", include("captcha.urls")),
     path("account/", include(auth_urls)),
     path(
@@ -84,6 +82,4 @@ urlpatterns = [
         ),
         name="password_reset_confirm",
     ),
-    path("account/login", view=RCPCHLoginView.as_view(), name="login"),
-    path("account/logout", view=LogoutView.as_view(), name="logout"),
 ]

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -1,0 +1,47 @@
+# python imports
+import logging
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.decorators import login_required
+
+# Logging setup
+logger = logging.getLogger(__name__)
+
+def login_and_otp_required():
+    """
+    Must have verified via 2FA
+    """
+
+    def decorator(view):
+        # First use login_required on decorator
+        login_required(view)
+        
+        
+
+        def wrapper(request, *args, **kwargs):
+            # Then, ensure 2fa verified
+            user = request.user
+
+            # Bypass 2fa if local dev, with warning message
+            if settings.DEBUG and user.is_superuser:
+                logger.warning(
+                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user is superuser",
+                    user,
+                    view,
+                    settings.DEBUG,
+                )
+                return view(request, *args, **kwargs)
+
+            # Prevent unverified users
+            if not user.is_verified():
+                user_list = user.__dict__
+                epilepsy12_user = user_list['_wrapped']
+                logger.info("User %s is unverified. Tried accessing %s", epilepsy12_user , view.__qualname__)
+                raise PermissionDenied('Unverified user')
+
+            return view(request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 # Logging setup
 logger = logging.getLogger(__name__)
 
+
 def login_and_otp_required():
     """
     Must have verified via 2FA
@@ -16,17 +17,15 @@ def login_and_otp_required():
     def decorator(view):
         # First use login_required on decorator
         login_required(view)
-        
-        
 
         def wrapper(request, *args, **kwargs):
             # Then, ensure 2fa verified
             user = request.user
 
             # Bypass 2fa if local dev, with warning message
-            if settings.DEBUG and user.is_superuser:
+            if settings.DEBUG:
                 logger.warning(
-                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user is superuser",
+                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
                     user,
                     view,
                     settings.DEBUG,
@@ -36,9 +35,13 @@ def login_and_otp_required():
             # Prevent unverified users
             if not user.is_verified():
                 user_list = user.__dict__
-                epilepsy12_user = user_list['_wrapped']
-                logger.info("User %s is unverified. Tried accessing %s", epilepsy12_user , view.__qualname__)
-                raise PermissionDenied('Unverified user')
+                epilepsy12_user = user_list["_wrapped"]
+                logger.info(
+                    "User %s is unverified. Tried accessing %s",
+                    epilepsy12_user,
+                    view.__qualname__,
+                )
+                raise PermissionDenied("Unverified user")
 
             return view(request, *args, **kwargs)
 

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -1,28 +1,26 @@
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.contrib.auth.decorators import login_required
-from django_otp.decorators import otp_required
 from django.contrib import messages
+
 from ..general_functions import csv_upload
 from ..forms.upload import UploadFileForm
 from ..models import Patient, Visit
+from .decorators import login_and_otp_required
 
 
-@login_required
+@login_and_otp_required()
 def home(request):
-    if request.user.is_verified():
-        file_uploaded = False
-        if request.method == "POST":
-            form = UploadFileForm(request.POST, request.FILES)
-            file = request.FILES["csv_upload"]
-            file_uploaded = csv_upload(csv_file=file)
-            if file_uploaded["status"]==500:
-                messages.error(request=request,message=f"{file_uploaded["errors"]}")
-                return redirect('home')
-        else:
-            form = UploadFileForm()
-        context = {"file_uploaded": file_uploaded, "form": form}
-        template = "home.html"
-        return render(request=request, template_name=template, context=context)
+
+    file_uploaded = False
+    if request.method == "POST":
+        form = UploadFileForm(request.POST, request.FILES)
+        file = request.FILES["csv_upload"]
+        file_uploaded = csv_upload(csv_file=file)
+        if file_uploaded["status"]==500:
+            messages.error(request=request,message=f"{file_uploaded["errors"]}")
+            return redirect('home')
     else:
-        return redirect(reverse("two_factor:profile"))
+        form = UploadFileForm()
+    context = {"file_uploaded": file_uploaded, "form": form}
+    template = "home.html"
+    return render(request=request, template_name=template, context=context)

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -1,0 +1,44 @@
+"""Defines custom mixins used throughout our Class Based Views"""
+
+import logging
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.mixins import AccessMixin
+
+logger = logging.getLogger(__name__)
+
+
+class LoginAndOTPRequiredMixin(AccessMixin):
+    """
+    Mixin that ensures the user is logged in and has verified via OTP.
+
+    Bypassed in local development is user.is_superuser AND settings.DEBUG==True.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        logger.warning('inside MIXIN')
+        # Check if the user is authenticated
+        if not request.user.is_authenticated:
+            return self.handle_no_permission()
+
+        # Check if the user is superuser and bypass 2FA in debug mode
+        if settings.DEBUG and request.user.is_superuser:
+            logger.warning(
+                "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user is superuser",
+                request.user,
+                self.__class__.__name__,
+                settings.DEBUG,
+            )
+            return super().dispatch(request, *args, **kwargs)
+
+        # Check if the user is verified
+        if not request.user.is_verified():
+            logger.info(
+                "User %s is unverified. Tried accessing %s",
+                request.user,
+                self.__class__.__name__,
+            )
+            raise PermissionDenied()
+
+        return super().dispatch(request, *args, **kwargs)

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -17,7 +17,7 @@ class LoginAndOTPRequiredMixin(AccessMixin):
     """
 
     def dispatch(self, request, *args, **kwargs):
-        logger.warning('inside MIXIN')
+        
         # Check if the user is authenticated
         if not request.user.is_authenticated:
             return self.handle_no_permission()

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -229,8 +229,8 @@ class RCPCHLoginView(TwoFactorLoginView):
         self.form_list["auth"] = CaptchaAuthenticationForm
 
     def post(self, *args, **kwargs):
-        
-        # In local development, override the token workflow, just sign in 
+
+        # In local development, override the token workflow, just sign in
         # the user without 2FA token
         if settings.DEBUG:
             request = self.request
@@ -242,14 +242,11 @@ class RCPCHLoginView(TwoFactorLoginView):
             )
             if user is not None:
                 login(request, user)
-                return redirect('home')
+                return redirect("home")
 
         # Otherwise, continue with usual workflow
         response = super().post(*args, **kwargs)
         return self.delete_cookies_from_response(response)
-        
-        
-        
 
     # Override successful login redirect to org summary page
     def done(self, form_list, **kwargs):

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -221,7 +221,7 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
         return super().form_valid(form)
 
 
-class RCPCHLoginView(TwoFactorLoginView, LoginAndOTPRequiredMixin):
+class RCPCHLoginView(TwoFactorLoginView):
     template_name = "two_factor/core/login.html"
 
     def __init__(self, **kwargs):

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -1,19 +1,19 @@
 from datetime import datetime, timedelta
 import logging
+
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from django.shortcuts import redirect
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic import ListView
 from django.contrib.auth.views import PasswordResetView
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse_lazy, reverse
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib import messages
 from django.utils.html import strip_tags
 from django.conf import settings
 from two_factor.views import LoginView as TwoFactorLoginView
-from two_factor.views.mixins import OTPRequiredMixin
+
 from ..models import NPDAUser, VisitActivity
 from ..forms.npda_user_form import NPDAUserForm, CaptchaAuthenticationForm
 from ..general_functions import (
@@ -23,6 +23,7 @@ from ..general_functions import (
     construct_transfer_npda_site_outcome_email,
     group_for_role,
 )
+from .mixins import LoginAndOTPRequiredMixin
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ NPDAUser list and NPDAUser creation, deletion and update
 """
 
 
-class NPDAUserListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
+class NPDAUserListView(LoginAndOTPRequiredMixin, ListView):
     template_name = "npda_users.html"
 
     def get_queryset(self):
@@ -39,7 +40,7 @@ class NPDAUserListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
 
 
 class NPDAUserCreateView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, CreateView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, CreateView
 ):
     """
     Handle creation of new patient in audit
@@ -115,7 +116,7 @@ class NPDAUserCreateView(
 
 
 class NPDAUserUpdateView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, UpdateView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, UpdateView
 ):
     """
     Handle update of patient in audit
@@ -166,7 +167,7 @@ class NPDAUserUpdateView(
 
 
 class NPDAUserDeleteView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, DeleteView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, DeleteView
 ):
     """
     Handle deletion of child from audit
@@ -177,7 +178,7 @@ class NPDAUserDeleteView(
     success_url = reverse_lazy("npda_users")
 
 
-class NPDAUserLogsListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
+class NPDAUserLogsListView(LoginAndOTPRequiredMixin, ListView):
     template_name = "npda_user_logs.html"
     model = VisitActivity
 
@@ -220,7 +221,7 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
         return super().form_valid(form)
 
 
-class RCPCHLoginView(TwoFactorLoginView):
+class RCPCHLoginView(TwoFactorLoginView, LoginAndOTPRequiredMixin):
     template_name = "two_factor/core/login.html"
 
     def __init__(self, **kwargs):

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -14,9 +14,10 @@ from two_factor.views.mixins import OTPRequiredMixin
 # RCPCH imports
 from ..models import Patient
 from ..forms.patient_form import PatientForm
+from .mixins import LoginAndOTPRequiredMixin
 
 
-class PatientListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
+class PatientListView(LoginAndOTPRequiredMixin, ListView):
     model = Patient
     template_name = "patients.html"
 
@@ -49,7 +50,7 @@ class PatientListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
 
 
 class PatientCreateView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, CreateView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, CreateView
 ):
     """
     Handle creation of new patient in audit
@@ -76,7 +77,7 @@ class PatientCreateView(
 
 
 class PatientUpdateView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, UpdateView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, UpdateView
 ):
     """
     Handle update of patient in audit
@@ -103,7 +104,7 @@ class PatientUpdateView(
 
 
 class PatientDeleteView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, DeleteView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, DeleteView
 ):
     """
     Handle deletion of child from audit

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -16,11 +16,10 @@ from two_factor.views.mixins import OTPRequiredMixin
 from ..models import Visit, Patient
 from ..forms.visit_form import VisitForm
 from ..general_functions import get_visit_categories
+from .mixins import LoginAndOTPRequiredMixin
 
 
-
-
-class PatientVisitsListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
+class PatientVisitsListView(LoginAndOTPRequiredMixin, ListView):
     model = Visit
     template_name = "visits.html"
 
@@ -39,7 +38,7 @@ class PatientVisitsListView(LoginRequiredMixin, OTPRequiredMixin, ListView):
 
 
 class VisitCreateView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, CreateView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, CreateView
 ):
     model = Visit
     form_class = VisitForm
@@ -73,7 +72,7 @@ class VisitCreateView(
         return HttpResponseRedirect(self.get_success_url())
 
 
-class VisitUpdateView(LoginRequiredMixin, OTPRequiredMixin, UpdateView):
+class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
     model = Visit
     form_class = VisitForm
 
@@ -126,7 +125,7 @@ class VisitUpdateView(LoginRequiredMixin, OTPRequiredMixin, UpdateView):
 
 
 class VisitDeleteView(
-    LoginRequiredMixin, OTPRequiredMixin, SuccessMessageMixin, DeleteView
+    LoginAndOTPRequiredMixin, SuccessMessageMixin, DeleteView
 ):
     model = Visit
     success_url = reverse_lazy("patient_visits")


### PR DESCRIPTION
Got working with help of @eatyourpeas thanks!

### Overview

When in local development (`settings.DEBUG=True`), bypass the 2FA token step on login. 

This improves the developer experience.

### Code changes
- Update various URLs in both project and `npda` app to only use 2FA / custom auth urls
- Adds `LoginAndOTPRequired` and `login_and_otp_required` mixin&decorator
- Specifically overrides the `.post()` method of the `RCPCHLoginView` class to skip past the normal auth workflow if in debug mode

### Documentation changes (done or required as a result of this PR)
- nil

### Related Issues
- #40 

### Mentions

