### PR TITLE
91 styling for tabs in visit form

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -30,9 +30,13 @@
 
       <div role="tablist" class="tabs tabs-bordered">
         <input type="radio" name="my_tabs_1" role="tab" class="tab font-bold
-          {% for category in routine_measurements_categories %} 
-          {% if category in categories_with_errors %} bg-rcpch_red 
-          {% else %} bg-rcpch_pink {% endif %} {% endfor %}" 
+          {% if routine_measurements_categories_with_errors and form_method == 'update' %} 
+            bg-rcpch_red 
+          {% elif form_method == 'create' %} 
+            bg-white 
+          {% else %} 
+            bg-rcpch_pink
+          {% endif %}" 
           aria-label="Routine&nbsp;Measurements" checked
         />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none">
@@ -76,9 +80,13 @@
         </div>
         
         <input type="radio" name="my_tabs_1" role="tab" class="tab rounded-none font-bold
-          {% for category in annual_review_categories %} 
-          {% if category in categories_with_errors %} bg-rcpch_red 
-          {% elif category in categories_without_errors %} bg-rcpch_pink {% endif %} {% endfor %}" 
+          {% if annual_review_categories_with_errors %} 
+            bg-rcpch_red 
+          {% elif form_method == 'create' %} 
+            bg-white 
+          {% else %} 
+            bg-rcpch_pink
+          {% endif %}" 
           aria-label="Annual&nbsp;Review"
         />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none p-6">

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -100,12 +100,28 @@
           {% for field_category in form.categories %}
             {% with field_category|colour_for_category as background_colour %}
             {% if field_category == "Foot Care" or field_category == "DECS" or field_category == "ACR" or field_category == "Cholesterol" or field_category == "Thyroid" or field_category == "Coeliac" or field_category == "Psychology" or field_category == "Smoking" or field_category == "Dietician" or field_category == "Sick Day Rules" or field_category == "Immunisation (flu)" %}
-              <div class="collapse collapse-arrow my-2 bg-base-200 rounded-none {% if field_category in categories_with_errors %} bg-rcpch_red {% elif field_category in categories_without_errors %} bg-rcpch_pink {% else %} bg-rcpch_dark_blue {% endif %}">
+              <div class="collapse collapse-arrow my-2 bg-base-200 rounded-none 
+                {% if field_category in categories_with_errors %} 
+                  bg-rcpch_red 
+                {% elif field_category in categories_without_errors %} 
+                  bg-rcpch_pink 
+                {% else %} 
+                  bg-rcpch_dark_blue 
+                {% endif %}
+              ">
                 <input type="radio" name="my-accordion-3" checked="checked" /> 
                 <div class="collapse-title text-xl font-medium text-white">
                   <strong>{{field_category}}</strong>
                 </div>
-                <div class="collapse-content flex flex-col mb-6 text-lg {% if field_category in categories_with_errors %} bg-rcpch_red {% elif field_category in categories_without_errors %} bg-rcpch_pink {% else %} bg-rcpch_dark_blue {% endif %}">
+                <div class="collapse-content flex flex-col mb-6 text-lg 
+                  {% if field_category in categories_with_errors %} 
+                    bg-rcpch_red 
+                  {% elif field_category in categories_without_errors %} 
+                    bg-rcpch_pink 
+                  {% else %} 
+                    bg-rcpch_dark_blue 
+                  {% endif %}
+                ">
                   {% for field in form %}
                     {% if field.field.category == field_category %}
                     <div class="flex flex-row my-2 mx-2">
@@ -151,50 +167,50 @@
         "/>
         <div role="tabpanel" class="
           tab-content bg-base-100 border-base-300 rounded-none p-6">
-        {% for field_category in form.categories %}
-          {% with field_category|colour_for_category as background_colour %}
-            {% if field_category == "Hospital Admission" %}
-            <div class="flex flex-col mb-6 
-              {% if background_colour %} 
-                bg-{{background_colour}} 
-              {% endif %}
-              {% if "Hospital Admission" in categories_with_errors %}
-                outline outline-8 outline-rcpch_red
-              {% endif %}"
-            >
-            {% for field in form %}
-                {% if field.field.category == field_category %}
-                <div class="flex flex-row my-2 mx-2">
-                  <div class="flex items-center justify-center md:w-1/3">
-                    <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
-                  </div>
-                  <div class="flex space-between md:w-2/3">
-                  {% if field.field.widget|is_select %}
-                      <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
-                        {% for choice in field.field.choices %}
-                        <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
-                        {% endfor %}
-                      </select>
-                  {% elif field.field.widget|is_dateinput %}
-                      <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
-                      <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
-                      <button type='button' _="on click set #{{ field.id_for_label}}'s value to #id_visit_date.value" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Fill with Visit Date</button>
-                  {% else %}
-                      <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
+          {% for field_category in form.categories %}
+            {% with field_category|colour_for_category as background_colour %}
+              {% if field_category == "Hospital Admission" %}
+                <div class="flex flex-col mb-6 
+                  {% if background_colour %} 
+                    bg-{{background_colour}} 
                   {% endif %}
-                  {% for error in field.errors %}
-                      <p>
-                        <strong class="text-gray-700">{{ error|escape }}</strong>
-                      </p>  
-                  {% endfor %}
-                  </div>
+                  {% if "Hospital Admission" in categories_with_errors %}
+                    outline outline-8 outline-rcpch_red
+                  {% endif %}"
+                >
+                {% for field in form %}
+                    {% if field.field.category == field_category %}
+                    <div class="flex flex-row my-2 mx-2">
+                      <div class="flex items-center justify-center md:w-1/3">
+                        <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
+                      </div>
+                      <div class="flex space-between md:w-2/3">
+                      {% if field.field.widget|is_select %}
+                          <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
+                            {% for choice in field.field.choices %}
+                            <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
+                            {% endfor %}
+                          </select>
+                      {% elif field.field.widget|is_dateinput %}
+                          <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                          <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
+                          <button type='button' _="on click set #{{ field.id_for_label}}'s value to #id_visit_date.value" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Fill with Visit Date</button>
+                      {% else %}
+                          <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
+                      {% endif %}
+                      {% for error in field.errors %}
+                          <p>
+                            <strong class="text-gray-700">{{ error|escape }}</strong>
+                          </p>  
+                      {% endfor %}
+                      </div>
+                    </div>
+                    {% endif %}
+                {% endfor %}
                 </div>
-                {% endif %}
-            {% endfor %}
-            </div>
-          {% endif %}
-          {% endwith %}
-        {% endfor %}
+              {% endif %}
+            {% endwith %}
+          {% endfor %}
         </div>
 
         

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -39,7 +39,7 @@
           {% endif %}" 
           aria-label="Routine&nbsp;Measurements" checked
         />
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none">
+        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none mt-4">
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
           {% if field_category == "Measurements" or field_category == "HBA1c" or field_category == "Treatment" or field_category == "CGM" or field_category == "BP"%}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -43,7 +43,14 @@
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
           {% if field_category == "Measurements" or field_category == "HBA1c" or field_category == "Treatment" or field_category == "CGM" or field_category == "BP"%}
-            <div class="flex flex-col mb-6 {% if background_colour %} bg-{{background_colour}} {% endif %}">
+            <div class="flex flex-col mb-6 
+            {% if background_colour %} 
+              bg-{{background_colour}} 
+            {% endif %} 
+            {% if field_category in routine_measurements_categories_with_errors %}
+              outline outline-8 outline-rcpch_red
+            {% endif %}"
+            >
             {% for field in form %}
                 {% if field.field.category == field_category %}
                 <div class="flex flex-row my-2 mx-2">

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -29,7 +29,12 @@
       {% endfor %}
 
       <div role="tablist" class="tabs tabs-bordered">
-        <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="Routine&nbsp;Measurements" checked/>
+        <input type="radio" name="my_tabs_1" role="tab" class="tab
+          {% for category in routine_measurements_categories %} 
+          {% if category in categories_with_errors %} bg-rcpch_red 
+          {% else %} bg-rcpch_pink {% endif %} {% endfor %}" 
+          aria-label="Routine&nbsp;Measurements" checked
+        />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none">
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
@@ -70,7 +75,12 @@
         {% endfor %}
         </div>
         
-        <input type="radio" name="my_tabs_1" role="tab" class="tab rounded-none" aria-label="Annual&nbsp;Review"/>
+        <input type="radio" name="my_tabs_1" role="tab" class="tab rounded-none 
+          {% for category in annual_review_categories %} 
+          {% if category in categories_with_errors %} bg-rcpch_red 
+          {% elif category in categories_without_errors %} bg-rcpch_pink {% endif %} {% endfor %}" 
+          aria-label="Annual&nbsp;Review"
+        />
         <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none p-6">
           {% for field_category in form.categories %}
             {% with field_category|colour_for_category as background_colour %}
@@ -117,8 +127,15 @@
           {% endfor %}
         </div>
 
-        <input type="radio" name="my_tabs_1" role="tab" class="tab w" aria-label="Inpatient&nbsp;Entry"/>
-        <div role="tabpanel" class="tab-content bg-base-100 border-base-300 rounded-none p-6">
+        <input type="radio" name="my_tabs_1" role="tab" aria-label="Inpatient&nbsp;Entry" class="tab w
+          {% if "Hospital Admission" in categories_with_errors %}
+          bg-rcpch_red
+          {% elif "Hospital Admission" in categories_without_errors %}
+          bg-rcpch_pink
+          {% endif %}
+        "/>
+        <div role="tabpanel" class="
+          tab-content bg-base-100 border-base-300 rounded-none p-6">
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
             {% if field_category == "Hospital Admission" %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -44,12 +44,12 @@
           {% with field_category|colour_for_category as background_colour %}
           {% if field_category == "Measurements" or field_category == "HBA1c" or field_category == "Treatment" or field_category == "CGM" or field_category == "BP"%}
             <div class="flex flex-col mb-6 
-            {% if background_colour %} 
-              bg-{{background_colour}} 
-            {% endif %} 
-            {% if field_category in routine_measurements_categories_with_errors %}
-              outline outline-8 outline-rcpch_red
-            {% endif %}"
+              {% if background_colour %} 
+                bg-{{background_colour}} 
+              {% endif %} 
+              {% if field_category in routine_measurements_categories_with_errors %}
+                outline outline-8 outline-rcpch_red
+              {% endif %}"
             >
             {% for field in form %}
                 {% if field.field.category == field_category %}
@@ -144,9 +144,9 @@
 
         <input type="radio" name="my_tabs_1" role="tab" aria-label="Inpatient&nbsp;Entry" class="tab w font-bold
           {% if "Hospital Admission" in categories_with_errors %}
-          bg-rcpch_red
+            bg-rcpch_red
           {% elif "Hospital Admission" in categories_without_errors %}
-          bg-rcpch_pink
+            bg-rcpch_pink
           {% endif %}
         "/>
         <div role="tabpanel" class="
@@ -154,7 +154,14 @@
         {% for field_category in form.categories %}
           {% with field_category|colour_for_category as background_colour %}
             {% if field_category == "Hospital Admission" %}
-            <div class="flex flex-col mb-6 {% if background_colour %} bg-{{background_colour}} {% endif %}">
+            <div class="flex flex-col mb-6 
+              {% if background_colour %} 
+                bg-{{background_colour}} 
+              {% endif %}
+              {% if "Hospital Admission" in categories_with_errors %}
+                outline outline-8 outline-rcpch_red
+              {% endif %}"
+            >
             {% for field in form %}
                 {% if field.field.category == field_category %}
                 <div class="flex flex-row my-2 mx-2">

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -29,7 +29,7 @@
       {% endfor %}
 
       <div role="tablist" class="tabs tabs-bordered">
-        <input type="radio" name="my_tabs_1" role="tab" class="tab
+        <input type="radio" name="my_tabs_1" role="tab" class="tab font-bold
           {% for category in routine_measurements_categories %} 
           {% if category in categories_with_errors %} bg-rcpch_red 
           {% else %} bg-rcpch_pink {% endif %} {% endfor %}" 
@@ -75,7 +75,7 @@
         {% endfor %}
         </div>
         
-        <input type="radio" name="my_tabs_1" role="tab" class="tab rounded-none 
+        <input type="radio" name="my_tabs_1" role="tab" class="tab rounded-none font-bold
           {% for category in annual_review_categories %} 
           {% if category in categories_with_errors %} bg-rcpch_red 
           {% elif category in categories_without_errors %} bg-rcpch_pink {% endif %} {% endfor %}" 
@@ -127,7 +127,7 @@
           {% endfor %}
         </div>
 
-        <input type="radio" name="my_tabs_1" role="tab" aria-label="Inpatient&nbsp;Entry" class="tab w
+        <input type="radio" name="my_tabs_1" role="tab" aria-label="Inpatient&nbsp;Entry" class="tab w font-bold
           {% if "Hospital Admission" in categories_with_errors %}
           bg-rcpch_red
           {% elif "Hospital Admission" in categories_without_errors %}

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -47,7 +47,7 @@ def colour_for_category(category):
     # returns a colour for a given category
     colours = [
         {"category": VisitCategories.HBA1, "colour": "rcpch_red_light_tint2"},
-        {"category": VisitCategories.MEASUREMENT, "colour": "rcpch_red"},
+        {"category": VisitCategories.MEASUREMENT, "colour": "rcpch_vivid_green"},
         {"category": VisitCategories.TREATMENT, "colour": "rcpch_orange"},
         {"category": VisitCategories.CGM, "colour": "rcpch_orange_light_tint2"},
         {"category": VisitCategories.BP, "colour": "rcpch_yellow"},

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -84,16 +84,24 @@ class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
         context["form_method"] = "update"
         visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
         visit_categories = get_visit_categories(visit_instance)
+        context["visit_categories"] = visit_categories
         context["routine_measurements_categories"] = ["Measurements", "HBA1c", "Treatment", "CGM", "BP"]
         context["annual_review_categories"] = ["Foot Care", "DECS", "ACR", "Cholesterol", "Thyroid", "Coeliac", "Psychology", "Smoking", "Dietician", "Sick Day Rules", "Immunisation (flu)"]
-        context["visit_categories"] = visit_categories
         categories_with_errors = []
         categories_without_errors = []
+        routine_measurements_categories_with_errors = []
+        annual_review_categories_with_errors = [] 
         for category in visit_categories:
             if category["has_error"] == False:
                 categories_without_errors.append(category["category"])
             else:
                 categories_with_errors.append(category["category"])
+                if category["category"] in context["routine_measurements_categories"]:
+                    routine_measurements_categories_with_errors.append(category["category"])
+                elif category["category"] in context["annual_review_categories"]:
+                    annual_review_categories_with_errors.append(category["category"])
+        context["routine_measurements_categories_with_errors"] = routine_measurements_categories_with_errors
+        context["annual_review_categories_with_errors"] = annual_review_categories_with_errors
         context["categories_with_errors"] = categories_with_errors
         context["categories_without_errors"] = categories_without_errors
         

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -84,6 +84,8 @@ class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
         context["form_method"] = "update"
         visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
         visit_categories = get_visit_categories(visit_instance)
+        context["routine_measurements_categories"] = ["Measurements", "HBA1c", "Treatment", "CGM", "BP"]
+        context["annual_review_categories"] = ["Foot Care", "DECS", "ACR", "Cholesterol", "Thyroid", "Coeliac", "Psychology", "Smoking", "Dietician", "Sick Day Rules", "Immunisation (flu)"]
         context["visit_categories"] = visit_categories
         categories_with_errors = []
         categories_without_errors = []
@@ -94,6 +96,7 @@ class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
                 categories_with_errors.append(category["category"])
         context["categories_with_errors"] = categories_with_errors
         context["categories_without_errors"] = categories_without_errors
+        
         return context
 
     def get_success_url(self):


### PR DESCRIPTION
Adds error localisation capabilities to tabs on form as described in #91 

If opening a new visit, the tabs will be white. If an error is present on the categories in the form, it will be red. If the contents of the tab have been validated, the tab will be pink.

Also in this PR is a boldening of the tab fonts:

<img width="801" alt="image" src="https://github.com/rcpch/national-paediatric-diabetes-audit/assets/65614251/86b0ef85-f0ba-4fcc-b030-adc5443141f9">
