### PR TITLE
Fixes error validation messages in Add New User form

### DIFF
--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 class NPDAUserForm(forms.ModelForm):
 
+    use_required_attribute = False
+
     class Meta:
         model = NPDAUser
         fields = [

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -18,19 +18,14 @@
                   <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
                   {% endfor %}
                 </select>
-                {% for error in field.errors %}
-                <p>
-                  <strong class="text-gray-700">{{ error|escape }}</strong>
-                </p>  
-                {% endfor %}
               {% else %}
                 {{ field }}
-                {% for error in field.errors %}
+              {% endif %}
+              {% for error in field.errors %}
                 <p>
                   <strong class="text-gray-700">{{ error|escape }}</strong>
                 </p>  
-                {% endfor %}
-              {% endif %}
+              {% endfor %}
           </div>
         </div>
       {% endfor %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -18,6 +18,11 @@
                   <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
                   {% endfor %}
                 </select>
+                {% for error in field.errors %}
+                <p>
+                  <strong class="text-gray-700">{{ error|escape }}</strong>
+                </p>  
+                {% endfor %}
               {% else %}
                 {{ field }}
                 {% for error in field.errors %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -18,6 +18,8 @@
                   <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
                   {% endfor %}
                 </select>
+              {% elif field.field.widget|is_textinput %}
+                <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value="{{ field.value }}" {% endif %} class="input rcpch-input-text">
               {% else %}
                 {{ field }}
               {% endif %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -24,10 +24,11 @@
                 {{ field }}
               {% endif %}
               {% for error in field.errors %}
-                <p>
-                  <strong class="text-gray-700">{{ error|escape }}</strong>
-                </p>  
-              {% endfor %}
+                <div role="alert" class="alert alert-error py-1 my-0 rounded-none">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+                  <span>{{ error|escape }}</span>
+                </div>
+            {% endfor %}
           </div>
         </div>
       {% endfor %}

--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -23,14 +23,11 @@
             {% else %}
               <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value="{{ field.value }}" {% endif %} class="input rcpch-input-text">
             {% endif %}
-              {% for error in field.errors %}
+            {% for error in field.errors %}
               <div role="alert" class="alert alert-error py-1 my-0 rounded-none">
                 <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                 <span>{{ error|escape }}</span>
               </div>
-              {% comment %} <p>
-                <strong class="text-gray-700">{{ error|escape }}</strong>
-              </p>   {% endcomment %}
             {% endfor %}
           </div>
         </div>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -108,6 +108,14 @@ def site_contact_email():
 def is_select(widget):
     return isinstance(widget, (forms.Select, forms.SelectMultiple))
 
+@register.filter
+def is_dateinput(widget):
+    return isinstance(widget, (forms.DateInput))
+
+@register.filter
+def is_textinput(widget):
+    return isinstance(widget, (forms.CharField, forms.TextInput, forms.EmailField))
+
 
 @register.filter
 def error_for_field(messages, field):
@@ -148,11 +156,6 @@ def errors_for_category(category, error_list):
                 if error["field"] in error_field_list:
                     final_string += f"{error['message']}\n"
     return final_string
-
-
-@register.filter
-def is_dateinput(widget):
-    return isinstance(widget, (forms.DateInput))
 
 
 @register.simple_tag


### PR DESCRIPTION
**Before this PR:**

Upon submitting the Add New User form, if there were any errors, the validation messages would not show on the screen and as such the user would not be shown a clear reason why their form had not sucessfully been submitted

**After this PR:**

The Add New User form now has validation for the relevant fields, as seen below:

<img width="843" alt="image" src="https://github.com/rcpch/national-paediatric-diabetes-audit/assets/65614251/470f30a3-f6e0-410f-9628-10640c452172">


**Code changes:**

- Creates `is_textinput` template tag
- Calls `is_textinput` template tag in Add New User form
- Adds Daisy's error message to render if appropriate for each field in Add New User form
- Explicitly removes html's tooltip that pops up upon erroneous form submission saying 'Please fill out this field'. This would stop the form being submitted and as such validated, meaning no errors would show. Done by setting `use_required_attribute = False` in NPDAUserForm
- Tidies code (removes comments, tabbing in html)