### PR TITLE
Restyles password reset page

### DIFF
--- a/project/npda/templates/registration/password_reset.html
+++ b/project/npda/templates/registration/password_reset.html
@@ -4,51 +4,45 @@
 {% block content %}
 
 <div class=" flex flex-col justify-center items-center">
-
-  
-  {% csrf_token %}
-      
-  <div>
-    <h2 class="font-montserrat text-lg font-semibold mt-5">Password Reset</h2>
-  </div>
-  <img src='{% static "npda-logo.png" %}' class="w-15 h-15 mt-5 mb-5">
-
-                    {% if form.errors %}
-                        <div class="alert alert-danger alert-dismissible" role="alert">
-                            <div id="form_errors">
-                                {% for key, value in form.errors.items %}<strong>{{ value }}</strong>{% endfor %}
-                            </div>
-                            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                    {% endif %}
-                    <p class="font-montserrat">
-                        Forgotten your password or password expired?
-                    </p>
-                    <p class="font-montserrat mb-4">
-                        Enter your email address below, and we'll email you instructions for setting a new one.
-                    </p>
-                    <form method="POST">
-                        {% csrf_token %}
-                        <div class="field">
-                            <input type="email"
-                                   name="email"
-                                   autocomplete="email"
-                                   maxlength="254"
-                                   required
-                                   id="id_email"
-                                   class="border-rcpch_light_blue px-3 py-2 border-2"
-                                   placeholder="Enter your email address">
-                        </div>
-                        <span>
-                            <button type="submit" class="bg-rcpch_light_blue border-white text-white font-semibold hover:text-white py-2.5 px-3 mt-40 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Submit</button>
-                            <a href="{% url 'two_factor:login' %}" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-40 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Back To Login</a>
-                        </span>
-                    </form>
-                    <br>
-                </div>
-                
-
+    {% csrf_token %}
+    <div>
+        <h2 class="font-montserrat text-lg font-semibold mt-5">Password Reset</h2>
     </div>
+    <img src='{% static "npda-logo.png" %}' class="w-15 h-15 mt-5 mb-5">
+    {% if form.errors %}
+        <div class="alert alert-danger alert-dismissible" role="alert">
+            <div id="form_errors">
+                {% for key, value in form.errors.items %}<strong>{{ value }}</strong>{% endfor %}
+            </div>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+    {% endif %}
+    <p class="font-montserrat">
+        Forgotten your password or password expired?
+    </p>
+    <p class="font-montserrat mb-4">
+        Enter your email address below, and we'll email you instructions for setting a new one.
+    </p>
+    <form method="POST">
+        {% csrf_token %}
+        <div class="field">
+            <input type="email"
+                    name="email"
+                    autocomplete="email"
+                    maxlength="254"
+                    required
+                    id="id_email"
+                    class="border-rcpch_light_blue px-3 py-2 border-2"
+                    placeholder="Enter your email address">
+        </div>
+        <span>
+            <button type="submit" class="bg-rcpch_light_blue border-white text-white font-semibold hover:text-white py-2.5 px-3 mt-40 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Submit</button>
+            <a href="{% url 'two_factor:login' %}" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-40 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Back To Login</a>
+        </span>
+    </form>
+    <br>
+    </div>
+</div>
 {% endblock %}

--- a/project/npda/templates/registration/password_reset_confirm.html
+++ b/project/npda/templates/registration/password_reset_confirm.html
@@ -18,33 +18,39 @@
 
     {% if validlink %}
     <div class="font-montserrat">
-      <p>Please enter (and confirm) your new password.</p>
+      <p>Please enter (and confirm) your new password:</p>
       <form action="" method="post" >
           <div style="display:none">
               <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken">
           </div>
-          <div class="field">
+          <div class="field mt-4">
             {{ form.new_password1.errors }}
             <label for="id_new_password1">New password:</label>
-            {{ form.new_password1 }}
+            <div class="input rcpch-input-text">
+              {{ form.new_password1 }}
+            </div>
           </div>
-          <div class="small italic text-rcpch_red">
-              {{ form.new_password2.errors }}
-              <label for="id_new_password2" class="font-montserrat text-black regular">Confirm password:</label>
+          <div class="small italic mt-4">
+            {{ form.new_password2.errors }}
+            <label for="id_new_password2" class="font-montserrat text-black regular">Confirm password:</label>
+            <div class="input rcpch-input-text">
               {{ form.new_password2 }}
+            </div>
           </div>
           <div class='field'>
-            <button class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-40 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue" type="submit">Change Password</button>
+            <button class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-14 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue" type="submit">Change Password</button>
           </div>
       </form>
-      <h5>Password Guidance</h5>
-      <li><small>Minimum of 10 characters (minimum 16 for RCPCH Audit team)</small></li>
-      <li><small>Must contain ONE capital</small></li>
-      <li><small>Must contain ONE number</small></li>
-      <li><small>Must contain ONE symbol from !@£$%^&*()_-+=|~</small></li>
-      <li><small>Must NOT be exclusively numbers</small></li>
-      <li><small>Must NOT be same as your email, name, surname</small></li>
-      <i><small>Note passwords must be changed every 90 days.</small></i>
+      <div class='mt-4'>
+        <h5>Password Guidance</h5>
+        <li><small>Minimum of 10 characters (minimum 16 for RCPCH Audit team)</small></li>
+        <li><small>Must contain ONE capital</small></li>
+        <li><small>Must contain ONE number</small></li>
+        <li><small>Must contain ONE symbol from !@£$%^&*()_-+=|~</small></li>
+        <li><small>Must NOT be exclusively numbers</small></li>
+        <li><small>Must NOT be same as your email, name, surname</small></li>
+        <i><small>Note passwords must be changed every 90 days.</small></i>
+      </div>
     </div>
         
     {% else %}


### PR DESCRIPTION
**Before this PR:**

The page that opened upon clicking the password reset link sent to user inbox was previously unstyled without the rcpch styles.

**After this PR:**

Adds the daisy and rcpch styled text input box and removes excess margin top of change password button, adds small margin to password guidance:

<img width="681" alt="image" src="https://github.com/rcpch/national-paediatric-diabetes-audit/assets/65614251/ee8c81d9-41f1-4cd8-8b4e-0f0467bb2456">


**Code changes:**

As above & fixes tabbing