### PR TITLE
refactor all instances of RCPCH NHS Organisations API URL

### DIFF
--- a/envs/example.env
+++ b/envs/example.env
@@ -8,6 +8,8 @@ RCPCH_CENSUS_PLATFORM_UR=##########
 NHS_ODS_API_URL=##########
 NHS_ODS_API_URL_SUBSCRIPTION_KEY=##########
 
+RCPCH_NHS_ORGANISATIONS_API_URL="https://api.rcpch.ac.uk/nhs-organisations/v1"
+
 NHS_SPINE_SERVICES_URL="https://uat.directory.spineservices.nhs.uk/ORD/2-0-0"
 
 POSTCODE_API_BASE_URL="https://findthatpostcode.uk/"

--- a/project/npda/general_functions/rcpch_nhs_organisations.py
+++ b/project/npda/general_functions/rcpch_nhs_organisations.py
@@ -40,7 +40,7 @@ def get_all_nhs_organisations():
     These are typically used in Django forms as choices.
     """
 
-    url = f"https://rcpch-nhs-organisations.azurewebsites.net/organisations/limited"
+    url = f"{settings.RCPCH_NHS_ORGANISATIONS_API_URL}/organisations/limited"
 
     try:
         response = requests.get(

--- a/project/npda/general_functions/retrieve_pdu.py
+++ b/project/npda/general_functions/retrieve_pdu.py
@@ -33,7 +33,7 @@ def retrieve_pdu_list():
     """
 
     url = settings.RCPCH_NHS_ORGANISATIONS_API_URL
-    request_url = f"{url}/paediatric_diabetes_units/extended"
+    request_url = f"{url}/paediatric_diabetes_units/extended/"
 
     try:
         response = requests.get(
@@ -80,7 +80,7 @@ def retrieve_pdu_from_organisation_ods_code(ods_code):
     ods_code = ods_code.upper()
 
     url = settings.RCPCH_NHS_ORGANISATIONS_API_URL
-    request_url = f"{url}/paediatric_diabetes_units/sibling-organisations/{ods_code}"
+    request_url = f"{url}/paediatric_diabetes_units/sibling-organisations/{ods_code}/"
 
     try:
         response = requests.get(

--- a/project/settings.py
+++ b/project/settings.py
@@ -48,9 +48,8 @@ SECRET_KEY = os.getenv("NPDA_DJANGO_SECRET", get_random_secret_key())
 # This is the token required for getting deprivation quintiles from the RCPCH Census Platform
 RCPCH_CENSUS_PLATFORM_URL = os.getenv("RCPCH_CENSUS_PLATFORM_URL")
 RCPCH_CENSUS_PLATFORM_TOKEN = os.getenv("RCPCH_CENSUS_PLATFORM_TOKEN")
-# TODO #83  - Fix the broken env in Azure and remove hardcoded URL
+
 RCPCH_NHS_ORGANISATIONS_API_URL = os.getenv("RCPCH_NHS_ORGANISATIONS_API_URL")
-RCPCH_NHS_ORGANISATIONS_API_URL = "https://rcpch-nhs-organisations.azurewebsites.net"
 
 # This is the NHS Spine services - it does not require authentication
 # It is possible to retrieve the ods code from the NHS API above, but not to narrow down


### PR DESCRIPTION
Fixes #83 

### Overview
`RCPCH_NHS_ORGANISATIONS_API_URL` was hardcoded because of difficulties on the azure side for this API that are now fixed.

This PR adds RCPCH_NHS_ORGANISATIONS_API_URL to the .env **please add RCPCH_NHS_ORGANISATIONS_API_URL="https://api.rcpch.ac.uk/nhs-organisations/v1" to your local untracked .env**
There are not keys for this API

Any uses across the codebase have been refactored