### PR TITLE
122 add patient number visit number to the top of visit form page

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="flex justify-center bg-white py-8">
   <div class="w-full mx-96 px-2 py-4 m-2 shadow-md bg-white font-montserrat">
-    <strong>{{ title }} - NPDA Patient {{ patient_id }} - NPDA Visit No. {{ visit_id }}</strong>
+    <strong>{{ title }} - NPDA Patient {{ patient_id }} {% if visit_id %}- NPDA Visit No. {{ visit_id }} {% endif %}</strong>
     <form id="update-form" method="post" {% if form_method == "create" %} action="{% url 'visit-create' patient_id %}" {% else %} action="{% url 'visit-update' patient_id=patient_id pk=visit.pk %}" {% endif %}>
       {% csrf_token %}
       {% for field in form %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="flex justify-center bg-white py-8">
   <div class="w-full mx-96 px-2 py-4 m-2 shadow-md bg-white font-montserrat">
-    <strong>{{title}}</strong>
+    <strong>{{ title }} - NPDA Patient {{ patient_id }} - Visit No. {{ visit_id }}</strong>
     <form id="update-form" method="post" {% if form_method == "create" %} action="{% url 'visit-create' patient_id %}" {% else %} action="{% url 'visit-update' patient_id=patient_id pk=visit.pk %}" {% endif %}>
       {% csrf_token %}
       {% for field in form %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="flex justify-center bg-white py-8">
   <div class="w-full mx-96 px-2 py-4 m-2 shadow-md bg-white font-montserrat">
-    <strong>{{ title }} - NPDA Patient {{ patient_id }} - Visit No. {{ visit_id }}</strong>
+    <strong>{{ title }} - NPDA Patient {{ patient_id }} - NPDA Visit No. {{ visit_id }}</strong>
     <form id="update-form" method="post" {% if form_method == "create" %} action="{% url 'visit-create' patient_id %}" {% else %} action="{% url 'visit-update' patient_id=patient_id pk=visit.pk %}" {% endif %}>
       {% csrf_token %}
       {% for field in form %}

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -78,12 +78,13 @@ class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
+        visit_categories = get_visit_categories(visit_instance)
         context["patient_id"] = self.kwargs["patient_id"]
+        context["visit_id"] = self.kwargs["pk"]
         context["title"] = "Edit Visit Details"
         context["button_title"] = "Edit Visit Details"
         context["form_method"] = "update"
-        visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
-        visit_categories = get_visit_categories(visit_instance)
         context["visit_categories"] = visit_categories
         context["routine_measurements_categories"] = ["Measurements", "HBA1c", "Treatment", "CGM", "BP"]
         context["annual_review_categories"] = ["Foot Care", "DECS", "ACR", "Cholesterol", "Thyroid", "Coeliac", "Psychology", "Smoking", "Dietician", "Sick Day Rules", "Immunisation (flu)"]


### PR DESCRIPTION
### Before this PR

On clicking onto a patient's visit details, the user would not be able to locate the patient's NPDA id or the visit number associated with this patient's visit

### After this PR

This PR integrates this information into the visit form as shown below:

<img width="756" alt="image" src="https://github.com/rcpch/national-paediatric-diabetes-audit/assets/65614251/50ac92e7-139a-4b52-b85a-7067563ef865">

The text for the patient's id is always shown - even if creating a new visit. However, if creating a new visit manually (ie with the form, not csv input) then the visit number would not yet exist and as such the associated text would not be rendered in.

### Related Issues

Closes #122 
