### PR TITLE
Add errors into Visit form for error localisation

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -51,35 +51,41 @@
                 outline outline-8 outline-rcpch_red
               {% endif %}"
             >
-            {% for field in form %}
+              {% for field in form %}
                 {% if field.field.category == field_category %}
-                <div class="flex flex-row my-2 mx-2">
-                  <div class="flex items-center justify-center md:w-1/3">
-                    <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
+                  <div class="flex flex-row my-2 mx-2">
+                    <div class="flex items-center justify-center md:w-1/3">
+                      <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-center mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
+                    </div>
+                    <div class="flex space-between md:w-2/3">
+                      {% if field.field.widget|is_select %}
+                          <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
+                            {% for choice in field.field.choices %}
+                            <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
+                            {% endfor %}
+                          </select>
+                      {% elif field.field.widget|is_dateinput %}
+                        <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
+                        <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
+                        <button type='button' _="on click set #{{ field.id_for_label}}'s value to #id_visit_date.value" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Fill with Visit Date</button>
+                      {% else %}
+                          <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
+                      {% endif %}
+                      {% for error in field.errors %}
+                          <p>
+                            <strong class="text-gray-700">{{ error|escape }}</strong>
+                          </p>  
+                      {% endfor %}  
+                    </div>
                   </div>
-                  <div class="flex space-between md:w-2/3">
-                  {% if field.field.widget|is_select %}
-                      <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
-                        {% for choice in field.field.choices %}
-                        <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
-                        {% endfor %}
-                      </select>
-                  {% elif field.field.widget|is_dateinput %}
-                    <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %}>
-                    <button type='button' _="on click set #{{ field.id_for_label}}'s value to '{% today_date %}'" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Today</button>
-                    <button type='button' _="on click set #{{ field.id_for_label}}'s value to #id_visit_date.value" class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Fill with Visit Date</button>
-                  {% else %}
-                      <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none" {% if field.field.required %} placeholder="Required" {% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
-                  {% endif %}
-                  {% for error in field.errors %}
-                      <p>
-                        <strong class="text-gray-700">{{ error|escape }}</strong>
-                      </p>  
-                  {% endfor %}
-                  </div>
-                </div>
                 {% endif %}
-            {% endfor %}
+              {% endfor %}
+              {% if field_category in categories_with_errors %}
+                <div>
+                  <p class="text-rcpch_red_dark_tint italic font-bold">Errors for category:</p>
+                  <p class="text-rcpch_red_dark_tint italic">{{ field_category|errors_for_category:visit_instance.errors }}</p>
+                </div>
+              {% endif %}
             </div>
           {% endif %}
           {% endwith %}
@@ -151,6 +157,12 @@
                     </div>
                     {% endif %}
                   {% endfor %}
+                  {% if field_category in categories_with_errors %}
+                    <div>
+                      <p class="text-white italic font-bold">Errors for category:</p>
+                      <p class="text-white italic">{{ field_category|errors_for_category:visit_instance.errors }}</p>
+                    </div>
+                  {% endif %}
                 </div>
               </div>
             {% endif %}
@@ -207,6 +219,12 @@
                     </div>
                     {% endif %}
                 {% endfor %}
+                {% if field_category in categories_with_errors %}
+                  <div>
+                    <p class="text-rcpch_red_dark_tint italic font-bold">Errors for category:</p>
+                    <p class="text-rcpch_red_dark_tint italic">{{ field_category|errors_for_category:visit_instance.errors }}</p>
+                  </div>
+                {% endif %}
                 </div>
               {% endif %}
             {% endwith %}

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -80,6 +80,8 @@ class VisitUpdateView(LoginAndOTPRequiredMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
         visit_categories = get_visit_categories(visit_instance)
+        context["visit_instance"] = visit_instance
+        context["visit_errors"] = [visit_instance.errors]
         context["patient_id"] = self.kwargs["patient_id"]
         context["visit_id"] = self.kwargs["pk"]
         context["title"] = "Edit Visit Details"


### PR DESCRIPTION
### Before this PR

Errors would not load into the Visit form, and the user who is reviewing an entered visit would have to dart back and forth between the VisitsListView template and the Visit itself.

### After this PR

Errors now load into the form in the category where they are relevant. They do however still need formatting, as they are raw errors that are not incredibly user-friendly:

<img width="770" alt="image" src="https://github.com/rcpch/national-paediatric-diabetes-audit/assets/65614251/4e843073-db8a-4ac7-ad7d-b293d9bfeaee">

n.b. these are also the errors in the tooltips in the VisitsListView. Tidying them up (potentially in the template tag which finds and loads them into the template) would fix both the tooltips and form in this regard.