### PR TITLE
Fix-create-user-employer-organisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 /.cache
 
 *.code-workspace
+
+node_modules

--- a/project/npda/management/commands/create_groups.py
+++ b/project/npda/management/commands/create_groups.py
@@ -44,14 +44,11 @@ def groups_seeder(
         {"codename": "view_patient", "content_type": patientContentType},
         {"codename": "change_patient", "content_type": patientContentType},
         {"codename": "add_patient", "content_type": patientContentType},
-
         # visit-related permissions
         {"codename": "view_visit", "content_type": visitContentType},
         {"codename": "change_visit", "content_type": visitContentType},
         {"codename": "add_visit", "content_type": visitContentType},
-
         # site-related permissions = None
-
         # NPDA-user related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
         {"codename": "change_npdauser", "content_type": npdauserContentType},
@@ -62,13 +59,10 @@ def groups_seeder(
     READER_PERMISSIONS = [
         # patient-related permissions
         {"codename": "view_patient", "content_type": patientContentType},
-
         # visit-related permissions
         {"codename": "view_visit", "content_type": visitContentType},
-
         # site-related permissions
         {"codename": "view_site", "content_type": siteContentType},
-
         # NPDA-user related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
     ]
@@ -78,17 +72,13 @@ def groups_seeder(
         {"codename": "view_patient", "content_type": patientContentType},
         {"codename": "change_patient", "content_type": patientContentType},
         {"codename": "add_patient", "content_type": patientContentType},
-
         # visit-related permissions
         {"codename": "view_visit", "content_type": visitContentType},
         {"codename": "change_visit", "content_type": visitContentType},
         {"codename": "add_visit", "content_type": visitContentType},
-
         # site-related permissions = None
-
         # user-related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
-
     ]
 
     RCPCH_AUDIT_TEAM_PERMISSIONS = [
@@ -97,25 +87,20 @@ def groups_seeder(
         {"codename": "change_patient", "content_type": patientContentType},
         {"codename": "add_patient", "content_type": patientContentType},
         {"codename": "delete_patient", "content_type": patientContentType},
-
         # visit-related permissions
         {"codename": "view_visit", "content_type": visitContentType},
-
         # visit-related permissions
         {"codename": "view_visit", "content_type": visitContentType},
         {"codename": "change_visit", "content_type": visitContentType},
         {"codename": "add_visit", "content_type": visitContentType},
         {"codename": "delete_visit", "content_type": visitContentType},
-
         # site-related permissions
         {"codename": "view_site", "content_type": siteContentType},
-
         # site-related permissions
         {"codename": "view_site", "content_type": siteContentType},
         {"codename": "change_site", "content_type": siteContentType},
         {"codename": "add_site", "content_type": siteContentType},
         {"codename": "delete_site", "content_type": siteContentType},
-
         # NPDA-user related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
         {"codename": "change_npdauser", "content_type": npdauserContentType},
@@ -124,7 +109,7 @@ def groups_seeder(
     ]
 
     PATIENT_PERMISSIONS = [
-        {"codename": "view_patient", "content_type": patientContentType}, 
+        {"codename": "view_patient", "content_type": patientContentType},
     ]
 
     EDITOR_CUSTOM_PERMISSIONS = [
@@ -269,7 +254,6 @@ def groups_seeder(
                 # add permissions to group
 
                 # NPDA_AUDIT_TEAM_FULL_ACCESS = RCPCH AUDIT TEAM
-                # NPDA_AUDIT_TEAM_FULL_ACCESS = RCPCH AUDIT TEAM
                 if group == NPDA_AUDIT_TEAM_FULL_ACCESS:
                     # basic permissions
                     add_permissions_to_group(RCPCH_AUDIT_TEAM_PERMISSIONS, newGroup)
@@ -302,8 +286,6 @@ def groups_seeder(
                 else:
                     if verbose:
                         print("Error: group does not exist!")
-
-
 
         if not verbose:
             print("groups_seeder(verbose=False), no output, groups seeded.")

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% load npda_tags %}
 {% block content %}
-<div class="bg-rcpch_light_blue py-8">
-  <div class="w-full max-w-3xl mx-auto px-2 py-4 m-2 shadow-md bg-white font-montserrat">
-    <strong>{{title}}{% if form_method == 'update' %} for {{npda_user.get_full_name}}{% endif %}</strong>
-    <form id="update-form" method="post" action="">
+
+  <div class="w-full max-w-3xl mx-auto bg-white font-montserrat border-rcpch_light_blue border-solid border-4 border-t-0">
+    <div class="text-center text-white bg-rcpch_strong_blue py-5 border-solid border-4 border-rcpch_strong_blue"><strong>{{title}}{% if form_method == 'update' %} for {{npda_user.get_full_name}}{% endif %}</strong></div>
+    <form id="update-form" method="post" action="" class="mt-5 px-5">
       {% csrf_token %}
       {% for field in form %}
 
@@ -59,7 +59,7 @@
         </div>
       {% endfor %}
         
-      <button type="submit" value="Submit" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">{{button_title}}</button>
+      <button type="submit" value="Submit" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue mb-5">{{button_title}}</button>
       <a class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue" href="{% url 'npda_users' %}">Back to list</a>
       {% if form_method == 'update' %}
         {% if not npda_user.email_confirmed %}
@@ -69,5 +69,5 @@
       {% endif %}
     </form>
   </div>
-</div>
+
 {% endblock %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -7,21 +7,35 @@
     <form id="update-form" method="post" action="">
       {% csrf_token %}
       {% for field in form %}
+
+        <div class="flex flex-row">
+          {% if field.id_for_label == 'id_add_employer' %}
+            {% if npda_user.organisation_employers %}
+              <strong class="font-montserrat font-bold md:w-1/3 text-right pr-2 mb-2">Employer(s)</strong>
+              {% for employer in npda_user.organisation_employers.all %}
+                    <div class="text-left md:w-2/3 mb-2">
+                      {{ employer }}
+                    </div>
+              {% endfor %}       
+            {% endif %}
+          {% endif %}
+        </div>
+
         <div class="md:flex md:items-center mb-6">
           <div class="md:w-1/3">
               <label for="{{ field.id_for_label }}" class="block text-gray-700 font-bold md:text-right mb-1 md:mb-0 pr-4"><small>{{ field.label }}</small></label>
           </div>
           <div class="md:w-2/3">
               {% if field.field.widget|is_select %}
-                <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
-                  {% for choice in field.field.choices %}
-                    {% if not show_rcpch_team and choice.1 == "RCPCH Audit Team" %}
-                    <!-- Do nothing, hide Audit Team option if not already in audit team-->
-                    {% else %}
-                      <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
-                    {% endif %}
-                  {% endfor %}
-                </select>
+                  <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select rounded-none">
+                    {% for choice in field.field.choices %}
+                      {% if not show_rcpch_team and choice.1 == "RCPCH Audit Team" %}
+                      <!-- Do nothing, hide Audit Team option if not already in audit team-->
+                      {% else %}
+                        <option value="{{choice.0}}" {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %}>{{choice.1}}</option>
+                      {% endif %}
+                    {% endfor %}
+                  </select>
               {% elif field.field.widget|is_emailfield %}
                 {{ field }}
               {% elif field.field.widget|is_textinput %}
@@ -44,6 +58,7 @@
           </div>
         </div>
       {% endfor %}
+        
       <button type="submit" value="Submit" class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">{{button_title}}</button>
       <a class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue" href="{% url 'npda_users' %}">Back to list</a>
       {% if form_method == 'update' %}

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -52,13 +52,14 @@ class LoginAndOTPRequiredMixin(AccessMixin):
 
 
 class CheckPDUListMixin(AccessMixin):
-    '''
+    """
     A mixin that checks whether a user can access a specific list view for a PDU
-    '''
+    """
+
     def get_model(self):
-        if hasattr(self, 'model') and self.model:
+        if hasattr(self, "model") and self.model:
             return self.model
-        if hasattr(self, 'get_queryset'):
+        if hasattr(self, "get_queryset"):
             return self.get_queryset().model
         return None
 
@@ -66,44 +67,48 @@ class CheckPDUListMixin(AccessMixin):
         # Check if the user is authenticated
         if not request.user.is_authenticated:
             return self.handle_no_permission()
-        
+
         model = self.get_model().__name__
 
         # get PDU assigned to user
         user_pdus = request.user.organisation_employers.values_list("pz_code")
-        print(user_pdus)
 
         # get pdu that user is requesting access of
         requested_pdu = ""
         if model == "Visit":
             requested_patient = Patient.objects.get(pk=self.kwargs["patient_id"])
             requested_pdu = requested_patient.site.paediatric_diabetes_unit_pz_code
-        
+
         elif model == "NPDAUser" or model == "Patient":
             requested_pdu = request.session.get("sibling_organisations").get("pz_code")
 
-        if request.user.is_superuser or request.user.is_rcpch_audit_team_member or (requested_pdu in user_pdus):
+        if (
+            request.user.is_superuser
+            or request.user.is_rcpch_audit_team_member
+            or (requested_pdu in user_pdus)
+        ):
             return super().dispatch(request, *args, **kwargs)
-        
+
         else:
             logger.info(
-                    "User %s is unverified. Tried accessing %s but only has access to %s",
-                    request.user,
-                    requested_pdu,
-                    user_pdus
-                )
+                "User %s is unverified. Tried accessing %s but only has access to %s",
+                request.user,
+                requested_pdu,
+                user_pdus,
+            )
             raise PermissionDenied()
-    
+
 
 class CheckPDUInstanceMixin(AccessMixin):
-    '''
-    A mixin which checks whether an instance's PDU (be it Patient, NPDAUser, Visit) that is having access attempted matches that of the 
+    """
+    A mixin which checks whether an instance's PDU (be it Patient, NPDAUser, Visit) that is having access attempted matches that of the
     active user, or the active user is superuser/rcpch audit team
-    '''
+    """
+
     def get_model(self):
-        if hasattr(self, 'model') and self.model:
+        if hasattr(self, "model") and self.model:
             return self.model
-        if hasattr(self, 'get_queryset'):
+        if hasattr(self, "get_queryset"):
             return self.get_queryset().model
         return None
 
@@ -111,7 +116,7 @@ class CheckPDUInstanceMixin(AccessMixin):
         # Check if the user is authenticated
         if not request.user.is_authenticated:
             return self.handle_no_permission()
-        
+
         model = self.get_model().__name__
 
         # get PDU assigned to user who is trying to access a view
@@ -122,24 +127,28 @@ class CheckPDUInstanceMixin(AccessMixin):
 
         if model == "NPDAUser":
             requested_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
-            requested_pdu =  requested_user.organisation_employers.first().pz_code
-        
+            requested_pdu = requested_user.organisation_employers.first().pz_code
+
         elif model == "Patient":
             requested_patient = Patient.objects.get(pk=self.kwargs["pk"])
             requested_pdu = requested_patient.site.paediatric_diabetes_unit_pz_code
-        
+
         elif model == "Visit":
             requested_patient = Patient.objects.get(pk=self.kwargs["patient_id"])
             requested_pdu = requested_patient.site.paediatric_diabetes_unit_pz_code
 
-        if request.user.is_superuser or request.user.is_rcpch_audit_team_member or (requested_pdu == user_pdu):
+        if (
+            request.user.is_superuser
+            or request.user.is_rcpch_audit_team_member
+            or (requested_pdu == user_pdu)
+        ):
             return super().dispatch(request, *args, **kwargs)
-        
+
         else:
             logger.warning(
-                    "User %s is unverified. Tried accessing %s but only has access to %s",
-                    request.user,
-                    requested_pdu,
-                    user_pdu
-                )
+                "User %s is unverified. Tried accessing %s but only has access to %s",
+                request.user,
+                requested_pdu,
+                user_pdu,
+            )
             raise PermissionDenied()

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -33,9 +33,6 @@ from ..general_functions import (
     group_for_role,
 )
 from .mixins import CheckPDUInstanceMixin, CheckPDUListMixin, LoginAndOTPRequiredMixin
-from django.utils.decorators import method_decorator
-from .decorators import login_and_otp_required
-from django.contrib.auth.decorators import login_required
 from project.constants import VIEW_PREFERENCES
 from .mixins import LoginAndOTPRequiredMixin
 

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -50,7 +50,7 @@ class NPDAUserListView(
     LoginAndOTPRequiredMixin, CheckPDUListMixin, PermissionRequiredMixin, ListView
 ):
     permission_required = "npda.view_npdauser"
-    permission_denied_message = 'You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance.'
+    permission_denied_message = "You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance."
 
     template_name = "npda_users.html"
 
@@ -207,7 +207,7 @@ class NPDAUserCreateView(
     """
 
     permission_required = "npda.add_npdauser"
-    permission_denied_message = 'You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance.'
+    permission_denied_message = "You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance."
 
     model = NPDAUser
     form_class = NPDAUserForm
@@ -247,11 +247,10 @@ class NPDAUserCreateView(
             )
             return redirect(
                 "npda_users",
-                # organisation_id=organisation_id,
             )
 
+        # add the user to the appropriate group
         new_group = group_for_role(new_user.role)
-
         try:
             new_user.groups.add(new_group)
         except Exception as error:
@@ -261,8 +260,46 @@ class NPDAUserCreateView(
             )
             return redirect(
                 "npda_users",
-                # organisation_id=organisation_id,
             )
+
+        # add the user to the appropriate organisation
+        new_employer_ods_code = form.cleaned_data["add_employer"]
+        if new_employer_ods_code:
+            # a new employer has been added
+            # fetch the organisation object from the API using the ODS code
+            organisation = organisations_adapter.get_single_pdu_from_ods_code(
+                new_employer_ods_code
+            )
+
+            if "error" in organisation:
+                messages.error(
+                    self.request,
+                    f"Error: {organisation['error']}. Organisation not added. Please contact the NPDA team if this issue persists.",
+                )
+                return HttpResponseRedirect(self.get_success_url())
+
+            # Get the name of the organistion from the API response
+            matching_organisation = next(
+                (
+                    org
+                    for org in organisation["organisations"]
+                    if org["ods_code"] == new_employer_ods_code
+                ),
+                None,
+            )
+
+            if matching_organisation:
+                # creat or update  the OrganisationEmployer object
+                new_employer, created = OrganisationEmployer.objects.update_or_create(
+                    ods_code=new_employer_ods_code,
+                    defaults=dict(
+                        pz_code=organisation["pz_code"],
+                        name=matching_organisation["name"],
+                    ),
+                )
+                # add the new employer to the user's employer list
+                new_user.organisation_employers.add(new_employer)
+                new_user.refresh_from_db()
 
         # user created - send email with reset link to new user
         subject = "Password Reset Requested"
@@ -277,10 +314,7 @@ class NPDAUserCreateView(
             f"Account created successfully. Confirmation email has been sent to {new_user.email}.",
         )
 
-        return redirect(
-            "npda_users",
-            # organisation_id=organisation_id,
-        )
+        return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self) -> str:
         return reverse(
@@ -301,7 +335,7 @@ class NPDAUserUpdateView(
     """
 
     permission_required = "npda.change_npdauser"
-    permission_denied_message = 'You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance.'
+    permission_denied_message = "You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance."
 
     model = NPDAUser
     form_class = NPDAUserForm
@@ -352,7 +386,7 @@ class NPDAUserUpdateView(
             matching_organisation = next(
                 (
                     org
-                    for org in organisation['organisations']
+                    for org in organisation["organisations"]
                     if org["ods_code"] == new_employer_ods_code
                 ),
                 None,
@@ -414,7 +448,7 @@ class NPDAUserDeleteView(
     """
 
     permission_required = "npda.delete_npdauser"
-    permission_denied_message = 'You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance.'
+    permission_denied_message = "You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance."
 
     model = NPDAUser
     success_message = "NPDA User removed from database"


### PR DESCRIPTION
FIxes the npda user form to remove the organisation employer select in favour of a list of organisations as labels, and implement a new dropdown to add employer, populated either with the sibling organisations in a PDU, or all organisations if a superuser or RCPCH user.

On save the new organisation is added to the user.

The form has been restyled a little to fit the tables a little better.

fixes #151 #156 #155