### PR TITLE
Fix redirect to two factor registration

### DIFF
--- a/project/npda/templates/two_factor/core/setup.html
+++ b/project/npda/templates/two_factor/core/setup.html
@@ -25,7 +25,12 @@
           <li><p>Ensure you have the <a class="text-rcpch_light_blue" href="https://www.microsoft.com/en-gb/security/mobile-authenticator-app">Microsoft Authenticator app</a> downloaded on your mobile device.</p></li>
           <li>Click on the <code>+</code> button on the top right to add a <em>Work or school account</em>.</li>
           <li>Choose <em>'Scan QR code'</em> and scan below:</li>
-          <p class="flex flex-row justify-center"><img src="{{ QR_URL }}" alt="QR Code" class="bg-white" /></p>
+          <p class="flex flex-row justify-center">
+            <img src="{{ QR_URL }}" alt="QR Code" class="bg-white" />
+          </p>
+          <li class="flex flex-row justify-center text-xs">
+            <code>{{ secret_key }}</code>
+          </li>
           <li>Finally, enter the 6 digit number token provided:</li>
         </ol>
         </div>

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -42,7 +42,7 @@ def login_and_otp_required():
                     view.__qualname__,
                 )
                 # raise PermissionDenied("Unverified user")
-                return redirect("two_factor:login")
+                return redirect("two_factor:setup")
 
             return view(request, *args, **kwargs)
 


### PR DESCRIPTION
Fixes #162 by redirecting to two factor setup instead of login if you haven't registered it yet.

Also add the two factor secret as text in the UI to allow registration with apps that don't have access to the camera easily (eg Bitwarden).

![Screenshot 2024-07-09 13 21 25](https://github.com/rcpch/national-paediatric-diabetes-audit/assets/395805/b8aae5c7-6cfb-4bd7-999e-fc8ea0a9f6c7)
