### PR TITLE
Show GP details errors inline in new patients form

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -53,6 +53,8 @@ class PatientForm(forms.ModelForm):
         date_of_birth = cleaned_data.get("date_of_birth")
         diagnosis_date = cleaned_data.get("diagnosis_date")
         death_date = cleaned_data.get("death_date")
+        gp_practice_ods_code = cleaned_data.get("gp_practice_ods_code")
+        gp_practice_postcode = cleaned_data.get("gp_practice_postcode")
 
         if diagnosis_date is None:
             raise ValidationError(
@@ -89,5 +91,12 @@ class PatientForm(forms.ModelForm):
                         ]
                     }
                 )
+        
+        if gp_practice_ods_code is None and gp_practice_postcode is None:
+            raise ValidationError({
+                "gp_practice_ods_code": [
+                    "GP Practice ODS code and GP Practice postcode cannot both be empty. At least one must be supplied."
+                ]
+            })
 
         return cleaned_data

--- a/project/npda/general_functions/nhs_ods_requests.py
+++ b/project/npda/general_functions/nhs_ods_requests.py
@@ -33,7 +33,10 @@ def gp_practice_for_postcode(postcode: str):
         print(e.response.text)
         raise Exception(f"{postcode} not found")
 
-    return response.json()["Organisations"][0]["OrgId"]
+    organisations = response.json()["Organisations"]
+
+    if len(organisations) > 0:
+        return organisations[0]["OrgId"]
 
 
 def gp_details_for_ods_code(ods_code: str):

--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -166,11 +166,6 @@ class Patient(models.Model):
                         )
                         pass
 
-        if self.gp_practice_ods_code is None and self.gp_practice_postcode is None:
-            raise ValidationError(
-                "GP Practice ODS code and GP Practice postcode cannot both be empty. At least one must be supplied."
-            )
-
         if not self.gp_practice_ods_code and self.gp_practice_postcode:
             """
             calculate the GP Practice ODS Code from the GP practice postcode

--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -166,15 +166,4 @@ class Patient(models.Model):
                         )
                         pass
 
-        if not self.gp_practice_ods_code and self.gp_practice_postcode:
-            """
-            calculate the GP Practice ODS Code from the GP practice postcode
-            """
-            try:
-                ods_code = gp_practice_for_postcode(self.gp_practice_postcode)
-            except Exception as error:
-                raise ValidationError(error)
-
-            self.gp_practice_ods_code = ods_code
-
         return super().save(*args, **kwargs)

--- a/project/npda/serializers/patient_serializer.py
+++ b/project/npda/serializers/patient_serializer.py
@@ -55,7 +55,8 @@ class PatientSerializer(serializers.HyperlinkedModelSerializer):
 
         if data["gp_practice_postcode"] is not None:
             try:
-                gp_practice_for_postcode(data["gp_practice_postcode"])
+                if not gp_practice_for_postcode(data["gp_practice_postcode"]):
+                    raise serializers.ValidationError("Could not find GP practice with that postcode")
             except Exception as error:
                 raise serializers.ValidationError(error)
 


### PR DESCRIPTION
Fixes #163 

At the moment if either GP ODS code and GP postcode are missing or the postcode doesn't match any GP we show a full page error, which in production is a blank page.

This PR changes that to be an inline error on the fields themselves. I've moved the code out of `Patient.save` and in to the `PatientForm`. This is safe because the CSV upload path doesn't perform any validation, taking the ODS code as given.

![Screenshot 2024-07-09 14 05 47](https://github.com/rcpch/national-paediatric-diabetes-audit/assets/395805/8db32f5b-243d-44f2-a379-b8edf06a1662)

> [!WARNING]  
> Postcodes must contain a space (see #164)

