### PR TITLE
Retain fields on validation error in new child form

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -41,6 +41,9 @@ class PatientForm(forms.ModelForm):
         }
 
     def clean_postcode(self):
+        if not self.cleaned_data["postcode"]:
+            raise ValidationError("This field is required")
+
         postcode = (
             self.cleaned_data["postcode"].upper().replace(" ", "").replace("-", "")
         )

--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -18,10 +18,20 @@
                 <option {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %} value="{{choice.0}}">{{choice.1}}</option>
                 {% endfor %}
               </select>
-            {% elif field.field.widget|is_dateinput %}
-              <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value={{ field.value|date:"Y-m-d" }} {% endif %} class="input rcpch-input-text">
             {% else %}
-              <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" {% if field.value %} value="{{ field.value }}" {% endif %} class="input rcpch-input-text">
+              <input
+                id="{{ field.id_for_label }}"
+                name="{{ field.html_name }}"
+                class="input rcpch-input-text"
+                {% if field.field.widget|is_dateinput %}
+                  type="date"
+                {% else %}
+                  type="text"
+                {% endif %}
+                {% if field.value %}
+                  value="{{ field.value }}"
+                {% endif %}
+              >
             {% endif %}
             {% for error in field.errors %}
               <div role="alert" class="alert alert-error py-1 my-0 rounded-none">

--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -15,7 +15,14 @@
             {% if field.field.widget|is_select %}
               <select id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="select rcpch-select">
                 {% for choice in field.field.choices %}
-                <option {% if field.value == choice.0 %} selected="{{ field.value }}" {% endif %} value="{{choice.0}}">{{choice.1}}</option>
+                  <option
+                    value="{{choice.0}}"
+                    {% if field.value == choice.0|stringformat:'s' %}
+                      selected="true"
+                    {% endif %}
+                  >
+                    {{choice.1}}
+                  </option>
                 {% endfor %}
               </select>
             {% else %}


### PR DESCRIPTION
Fixes #167.

*Before*
![Screenshot 2024-07-09 15 00 27](https://github.com/rcpch/national-paediatric-diabetes-audit/assets/395805/5a507f6b-99c6-4c98-9d6c-14744eb02b4b)



*After*
![Screenshot 2024-07-09 14 59 20](https://github.com/rcpch/national-paediatric-diabetes-audit/assets/395805/9a03029d-33b9-4f44-8902-e67cc6d49dfc)



Also changes missing postcode entirely into a validation error rather than a full screen crash