### PR TITLE
Mount whitenoise to serve static files when deployed

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     # "django.forms",
     "rest_framework",
@@ -106,6 +107,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -10,7 +10,10 @@ https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise import WhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_wsgi_application()
+
+application = WhiteNoise(application)


### PR DESCRIPTION
Fixes #181 

I'm getting a warning we don't get with e12:

```
django-1   | /usr/local/lib/python3.12/site-packages/django/core/handlers/base.py:61: UserWarning: No directory at: /app/static/root/
django-1   |   mw_instance = middleware(adapted_handler)

```

But it doesn't seem to stop serving the static files so I'm not worrying about it for now.