### PR TITLE
Fix PDU filter in mixin

### DIFF
--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -71,7 +71,7 @@ class CheckPDUListMixin(AccessMixin):
         model = self.get_model().__name__
 
         # get PDU assigned to user
-        user_pdus = request.user.organisation_employers.values_list("pz_code")
+        user_pdus = request.user.organisation_employers.values_list("pz_code", flat=True)
 
         # get pdu that user is requesting access of
         requested_pdu = ""


### PR DESCRIPTION
`values_list` by default returns a tuple, even if there's only one field in each entry. As such the check lower down didn't work, as it was looking for the PDU string in a list of tuples.

The fix is to pass flat=True which makes it return a list of values not tuples.

Before this fix a standard user (whatever role but not a superuser or RCPCH team) would get a full-screen 403 accessing either the list of patients or users.