### PR TITLE
Set session data in user_logged_in signal

### DIFF
--- a/project/npda/signals.py
+++ b/project/npda/signals.py
@@ -11,6 +11,9 @@ from django.dispatch import receiver
 
 # RCPCH
 from .models import VisitActivity, NPDAUser
+from .general_functions.create_session import (
+    create_session_object
+)
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -18,7 +21,12 @@ logger = logging.getLogger(__name__)
 
 @receiver(user_logged_in)
 def log_user_login(sender, request, user, **kwargs):
-    logger.info(f"{user} ({user.email}) logged in from {get_client_ip(request)}.")
+    # Set up the session data so that views are filtered correctly (eg by PDU)
+    new_session_object = create_session_object(user)
+    request.session.update(new_session_object)
+
+    logger.info(f"{user} ({user.email}) logged in from {get_client_ip(request)}. ods_code: {new_session_object['ods_code']}. pz_code: {new_session_object['pz_code']}.")
+
     VisitActivity.objects.create(
         activity=1, ip_address=get_client_ip(request), npdauser=user
     )

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -81,15 +81,14 @@ def test_npda_user_list_view_rcpch_audit_team_can_view_all_users(
     # This is the request made when you click the "All" button on the switcher in the UI
     set_view_preference_response = client.post(url, {
         "view_preference": 2
+    }, headers = {
+        "HX-Request": "true"
     })
 
     assert set_view_preference_response.status_code == HTTPStatus.OK
 
     response = client.get(url)
-
     assert response.status_code == HTTPStatus.OK
 
     users = response.context_data['object_list']
-    print(f"!! {users}")
-    
     assert(users.count() > ah_users.count())

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -11,7 +11,7 @@ from django.test import Client
 
 # E12 imports
 from project.npda.models import NPDAUser
-from project.npda.tests.utils import set_session_attributes_for_signedin_user
+from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
 from project.npda.views.npda_users import NPDAUserListView
 
@@ -46,15 +46,14 @@ def test_npda_user_list_view_get_query_set_with_users_cannot_view_user_table_fro
 
     # For each user, ensure the queryset does not contain users from a PDU they are not part of Alder Hey (other seeded users are at GOSH).
     for test_user in test_users_ah:
-
-        client = set_session_attributes_for_signedin_user(client=client, user=test_user)
+        client = login_and_verify_user(client=client, user=test_user)
 
         # Simulate a GET request to the NPDAUserListView
         url = reverse("npda_users")
         response = client.get(url)
 
         # Check that the response is successful
-        assert response.status_code in [HTTPStatus.OK, HTTPStatus.FOUND]
+        assert response.status_code == HTTPStatus.OK, HTTPStatus.FOUND
 
         # Extract the queryset from the context
         view = NPDAUserListView()
@@ -88,7 +87,7 @@ def test_npda_user_list_view_get_query_set_with_rcpch_audit_team_can_view_all_np
     all_user_count = all_users.count()
 
     # Set the session for the RCPCH_AUDIT_TEAM user
-    client = set_session_attributes_for_signedin_user(
+    client = login_and_verify_user(
         client=client, user=test_user_rcpch_audit_team
     )
 
@@ -97,7 +96,7 @@ def test_npda_user_list_view_get_query_set_with_rcpch_audit_team_can_view_all_np
     response = client.get(url)
 
     # Check that the response is successful
-    assert response.status_code in [HTTPStatus.OK, HTTPStatus.FOUND]
+    assert response.status_code == HTTPStatus.OK
 
     # Extract the queryset from the context
     view = NPDAUserListView()

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -14,62 +14,48 @@ from project.npda.models import NPDAUser
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
 from project.npda.views.npda_users import NPDAUserListView
-
+from project.constants.user import RCPCH_AUDIT_TEAM
 
 logger = logging.getLogger(__name__)
 
+ALDER_HEY_PZ_CODE = "PZ074"
+ALDER_HEY_ODS_CODE = "RBS25"
+
 
 @pytest.mark.django_db
-def test_npda_user_list_view_get_query_set_with_users_cannot_view_user_table_from_different_pdus(
+def test_npda_user_list_view_users_can_only_see_users_from_their_pdu(
     seed_groups_fixture,
     seed_users_fixture,
     seed_patients_fixture,
     client,
 ):
-    """Except for RCPCH_AUDIT_TEAM, users cannot view the user table from different PDUs."""
+    """Except for RCPCH_AUDIT_TEAM, users should only see users from their own PDU."""
 
-    ALDER_HEY_PZ_CODE = "PZ074"
-    ALDER_HEY_ODS_CODE = "RBS25"
+    ah_users = NPDAUser.objects.filter(organisation_employers__pz_code=ALDER_HEY_PZ_CODE)
+    # Check there are users from outside Alder Hey so this test doesn't pass by accident
+    non_ah_users = NPDAUser.objects.exclude(organisation_employers__pz_code=ALDER_HEY_PZ_CODE)
+    assert(non_ah_users.count() > 0)
 
-    # Get users which cannot view the user table from different PDUs.
-    test_users_ah = NPDAUser.objects.exclude(
-        first_name=test_user_rcpch_audit_team_data.role_str,
-    ).filter(organisation_employers__pz_code=ALDER_HEY_PZ_CODE)
+    ah_user = ah_users.first()
 
-    test_user_count = test_users_ah.count()
+    client = login_and_verify_user(client, ah_user)
 
-    # Check we have the correct number.
-    expected_test_user_count_excluding_rcpch_audit_team = 3
-    assert (
-        test_user_count == expected_test_user_count_excluding_rcpch_audit_team
-    ), f"Expected {expected_test_user_count_excluding_rcpch_audit_team} test users, got {test_user_count=}"
+    url = reverse("npda_users")
+    response = client.get(url)
 
-    # For each user, ensure the queryset does not contain users from a PDU they are not part of Alder Hey (other seeded users are at GOSH).
-    for test_user in test_users_ah:
-        client = login_and_verify_user(client=client, user=test_user)
+    assert response.status_code == HTTPStatus.OK
 
-        # Simulate a GET request to the NPDAUserListView
-        url = reverse("npda_users")
-        response = client.get(url)
+    users = response.context_data['object_list']
 
-        # Check that the response is successful
-        assert response.status_code == HTTPStatus.OK, HTTPStatus.FOUND
+    for user in users:
+        pz_codes = [org['pz_code'] for org in user.organisation_employers.values()]
 
-        # Extract the queryset from the context
-        view = NPDAUserListView()
-        view.request = response.wsgi_request
-        view.request.user = test_user  # Explicitly set the user in the request
-        queryset = view.get_queryset()
-
-        # Ensure the queryset does not contain users from a PDU they are not part of
-        assert (
-            queryset.exclude(organisation_employers__pz_code=ALDER_HEY_PZ_CODE).count()
-            == 0
-        ), f"User {test_user} from {ALDER_HEY_PZ_CODE=} can see NPDAUsers from other PDUs."
+        if not ALDER_HEY_PZ_CODE in pz_codes:
+            pytest.fail(f"{ah_user} in {ALDER_HEY_PZ_CODE} should not be able to see {user} in {pz_codes}")
 
 
 @pytest.mark.django_db
-def test_npda_user_list_view_get_query_set_with_rcpch_audit_team_can_view_all_npdausers(
+def test_npda_user_list_view_rcpch_audit_team_can_view_all_users(
     seed_groups_fixture,
     seed_users_fixture,
     seed_patients_fixture,
@@ -77,36 +63,33 @@ def test_npda_user_list_view_get_query_set_with_rcpch_audit_team_can_view_all_np
 ):
     """RCPCH_AUDIT_TEAM users can view all users."""
 
-    # Get an RCPCH_AUDIT_TEAM user
-    test_user_rcpch_audit_team = NPDAUser.objects.filter(
-        first_name=test_user_rcpch_audit_team_data.role_str
+    ah_users = NPDAUser.objects.filter(organisation_employers__pz_code=ALDER_HEY_PZ_CODE)
+    # Check there are users from outside Alder Hey so this test doesn't pass by accident
+    non_ah_users = NPDAUser.objects.exclude(organisation_employers__pz_code=ALDER_HEY_PZ_CODE)
+    assert(non_ah_users.count() > 0)
+
+    ah_audit_team_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=RCPCH_AUDIT_TEAM
     ).first()
 
-    # Get all users
-    all_users = NPDAUser.objects.all()
-    all_user_count = all_users.count()
+    client = login_and_verify_user(client, ah_audit_team_user)
 
-    # Set the session for the RCPCH_AUDIT_TEAM user
-    client = login_and_verify_user(
-        client=client, user=test_user_rcpch_audit_team
-    )
-
-    # Simulate a GET request to the NPDAUserListView
     url = reverse("npda_users")
+
+    # The user still defaults to seeing users from just their PDU
+    # This is the request made when you click the "All" button on the switcher in the UI
+    set_view_preference_response = client.post(url, {
+        "view_preference": 2
+    })
+
+    assert set_view_preference_response.status_code == HTTPStatus.OK
+
     response = client.get(url)
 
-    # Check that the response is successful
     assert response.status_code == HTTPStatus.OK
 
-    # Extract the queryset from the context
-    view = NPDAUserListView()
-    view.request = response.wsgi_request
-    view.request.user = (
-        test_user_rcpch_audit_team  # Explicitly set the user in the request
-    )
-    queryset = view.get_queryset()
-
-    # Ensure the queryset contains all users
-    assert (
-        queryset.count() == all_user_count
-    ), f"RCPCH_AUDIT_TEAM user cannot see all users. Expected {all_user_count}, got {queryset.count()}."
+    users = response.context_data['object_list']
+    print(f"!! {users}")
+    
+    assert(users.count() > ah_users.count())

--- a/project/npda/tests/utils.py
+++ b/project/npda/tests/utils.py
@@ -22,28 +22,12 @@ def twofactor_signin(client, test_user) -> None:
     session.save()
 
 
-def set_session_attributes_for_signedin_user(client, user):
+def login_and_verify_user(client, user):
     """Helper function to set session attributes for a signed-in user, as done during login."""
     # Log in the user
     client.login(username=user.email, password="pw")
 
-    # Create a request to initiate the session
-    request = RequestFactory().get("/")
-
-    # Add the session middleware to process the request
-    middleware = SessionMiddleware(lambda request: None)
-    middleware.process_request(request)
-    request.session.save()
-
-    # Update session data
-    session_data = create_session_object(user)
-    request.session.update(session_data)
-    request.session.save()
-
-    # Update the client cookies to use the new session
-    client.cookies["sessionid"] = request.session.session_key
-
-    # OTP Log in (assumed to be a custom function)
+    # # OTP Log in (assumed to be a custom function)
     twofactor_signin(client, user)
 
     return client

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -489,11 +489,6 @@ class RCPCHLoginView(TwoFactorLoginView):
                 login(self.request, user)
                 # successful login, get PDU and organisation details from user and store in session
 
-                new_session_object = create_session_object(user)
-
-                # Update the session with the new session object
-                self.request.session.update(new_session_object)
-
                 # Override normal auth flow behaviour, redirect straight to home page
                 return redirect("home")
 
@@ -513,9 +508,6 @@ class RCPCHLoginView(TwoFactorLoginView):
         # Successful 2FA and login
         if response_url == login_redirect_url:
             user = self.get_user()
-
-            new_session_object = create_session_object(user.organisation_employers)
-            self.request.session.update(new_session_object)
 
             # time since last set password
             delta = timezone.now() - user.password_last_set


### PR DESCRIPTION
The previous method of swapping the sessionid in client cookies didn't seem to work so before this PR the tests weren't actually logged in.

We worked around that with a check for either a 200 **or** a 302 code and inspecting the querysets directly but that won't work in future tests that send POST requests (eg tests for #189).

I've changed the session data to be added in the user_logged_in signal. That way we don't need the session swapping test code at all. I've tested tht the signal is not fired until two factor authentication is complete. It has the nice side benefit of also fixing https://github.com/rcpch/national-paediatric-diabetes-audit/issues/180

I've also changed the tests to check the actual QuerySet passed through to the template via context. This is closer in spirit to an end-to-end test and doesn't require any manual setup or calls to get_queryset.