### PR TITLE
Remove redundant postcode validation

### DIFF
--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -147,23 +147,15 @@ class Patient(models.Model):
         # calculate the index of multiple deprivation quintile if the postcode is present
         # Skips the calculation if the postcode is on the 'unknown' list
         if self.postcode:
-            if str(self.postcode).replace(" ", "") not in UNKNOWN_POSTCODES_NO_SPACES:
-                validated = validate_postcode(self.postcode)
-                if not validated:
-                    raise ValidationError(
-                        _("Postcode is not valid. Please enter a valid postcode.")
-                    )
-                else:
-                    try:
-                        self.index_of_multiple_deprivation_quintile = imd_for_postcode(
-                            self.postcode
-                        )
-                    except Exception as error:
-                        # Deprivation score not persisted if deprivation score server down
-                        self.index_of_multiple_deprivation_quintile = None
-                        print(
-                            f"Cannot calculate deprivation score for {self.postcode}: {error}"
-                        )
-                        pass
+            try:
+                self.index_of_multiple_deprivation_quintile = imd_for_postcode(
+                    self.postcode
+                )
+            except Exception as error:
+                # Deprivation score not persisted if deprivation score server down
+                self.index_of_multiple_deprivation_quintile = None
+                print(
+                    f"Cannot calculate deprivation score for {self.postcode}: {error}"
+                )   
 
         return super().save(*args, **kwargs)


### PR DESCRIPTION
Make some more progress fixing #147. There's no need to check the postcode value before calling the imd endpoint.

- It's already been validated at CSV upload
- It's already been validated in PatientForm
- The IMD endpoint validates postcodes anyway by looking up the associated LSOA (https://github.com/rcpch/rcpch-census-platform/blob/14a0e25692bd1d0f9123254d0be5880a6398d136/deprivation_scores/views.py#L355C27-L355C44)


Time to upload `dummy_sheet.csv`:

- *Before*: 16.91 seconds
- *After*: 12.11 seconds