### PR TITLE
Fix choices and dates in edit child form

### DIFF
--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -17,7 +17,7 @@
                 {% for choice in field.field.choices %}
                   <option
                     value="{{choice.0}}"
-                    {% if field.value == choice.0|stringformat:'s' %}
+                    {% if field.value|stringformat:'s' == choice.0|stringformat:'s' %}
                       selected="true"
                     {% endif %}
                   >

--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -36,7 +36,7 @@
                   type="text"
                 {% endif %}
                 {% if field.value %}
-                  value="{{ field.value }}"
+                  value="{{ field.value|stringformat:'s' }}"
                 {% endif %}
               >
             {% endif %}


### PR DESCRIPTION
#168 fixed retaining values for such fields if the form failed validation but inadvertently broke rendering the edit child form.

This PR fixes that by:

- Stringifying the choice value before checking if that option is selected
  - For an invalid create form it's a string whereas for an edit form it's an integer
- Stringifying the date value
  - I don't really know what was coercing it to a  format like "Jan 01 2024" for the edit form but adding a stringify in the template stops that