### PR TITLE
Faster CSV uploads

### DIFF
--- a/project/npda/general_functions/csv_upload.py
+++ b/project/npda/general_functions/csv_upload.py
@@ -38,6 +38,7 @@ from ...constants import (
 from .validate_postcode import validate_postcode
 from .nhs_ods_requests import gp_details_for_ods_code
 from .quarter_for_date import retrieve_quarter_for_date
+from .index_multiple_deprivation import imd_for_postcode
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -820,12 +821,19 @@ def csv_upload(user, csv_file=None, organisation_ods_code=None, pdu_pz_code=None
 
         nhs_number = row["NHS Number"].replace(" ", "")
 
+        postcode = row["Postcode of usual address"]
+        
+        index_of_multiple_deprivation_quintile = None
+        if postcode:
+            index_of_multiple_deprivation_quintile = imd_for_postcode(postcode)
+
         try:
             patient = Patient.objects.create(
                 nhs_number=nhs_number,
                 site=site,
                 date_of_birth=row["Date of Birth"],
-                postcode=row["Postcode of usual address"],
+                postcode=postcode,
+                index_of_multiple_deprivation_quintile=index_of_multiple_deprivation_quintile,
                 sex=row["Stated gender"],
                 ethnicity=row["Ethnic Category"],
                 diabetes_type=row["Diabetes Type"],

--- a/project/npda/general_functions/csv_upload.py
+++ b/project/npda/general_functions/csv_upload.py
@@ -108,7 +108,6 @@ async def csv_upload(user, csv_file=None, organisation_ods_code=None, pdu_pz_cod
         """ 
         get all the data for this row
         """
-        print(f"!! validate_row: {row}")
 
         # Patient fields
         row_number = row["NHS Number"].replace(" ", "")

--- a/project/npda/general_functions/csv_upload.py
+++ b/project/npda/general_functions/csv_upload.py
@@ -1090,16 +1090,17 @@ async def csv_upload(user, csv_file=None, organisation_ods_code=None, pdu_pz_cod
     # by passing this in we can use the same timestamp for all records
     timestamp = timezone.now()
 
-    # try:
-    # TODO MRB: This will fail any pending tasks if one of them throws an exception
-    #           Is this what we want?
-    async with httpx.AsyncClient() as client:
-        async with asyncio.TaskGroup() as tg:
-                for _, row in dataframe.iterrows():
-                    tg.create_task(save_row(row, timestamp, new_cohort.pk, client))
-    # except Exception as error:
-    #     # There was an error saving one or more records - this is likely not a problem with the data passed in
-        # return {"status": 500, "errors": error}
+    try:
+        # TODO MRB: This will fail any pending tasks if one of them throws an exception
+        #           Is this what we want?
+        async with httpx.AsyncClient() as client:
+            async with asyncio.TaskGroup() as tg:
+                    for _, row in dataframe.iterrows():
+                        tg.create_task(save_row(row, timestamp, new_cohort.pk, client))
+    except Exception as error:
+        # There was an error saving one or more records - this is likely not a problem with the data passed in
+        logger.error(f"Error during csv upload {error}")
+        return {"status": 500, "errors": error}
 
     return {"status": 200, "errors": None}
 

--- a/project/npda/general_functions/index_multiple_deprivation.py
+++ b/project/npda/general_functions/index_multiple_deprivation.py
@@ -9,6 +9,8 @@ import requests
 # Third party imports
 from django.conf import settings
 
+from asgiref.sync import async_to_sync
+
 # RCPCH imports
 from ...constants import UNKNOWN_POSTCODES_NO_SPACES
 
@@ -16,7 +18,7 @@ from ...constants import UNKNOWN_POSTCODES_NO_SPACES
 logger = logging.getLogger(__name__)
 
 
-def imd_for_postcode(user_postcode: str) -> int:
+async def aimd_for_postcode(user_postcode: str) -> int:
     """
     Makes an API call to the RCPCH Census Platform with postcode and quantile_type
     Postcode - can have spaces or not - this is processed by the API
@@ -42,3 +44,6 @@ def imd_for_postcode(user_postcode: str) -> int:
             return None
 
         return response.json()["result"]["data_quantile"]
+
+
+imd_for_postcode = async_to_sync(aimd_for_postcode)

--- a/project/npda/general_functions/validate_postcode.py
+++ b/project/npda/general_functions/validate_postcode.py
@@ -3,8 +3,7 @@
 # django
 
 # third party libraries
-import requests
-from requests.exceptions import HTTPError
+import httpx
 
 # npda imports
 from django.conf import settings
@@ -12,7 +11,7 @@ from django.conf import settings
 from asgiref.sync import async_to_sync
 
 
-async def avalidate_postcode(postcode):
+async def avalidate_postcode(postcode, async_client):
     """
     Tests if postcode is valid
     Returns boolean
@@ -21,16 +20,20 @@ async def avalidate_postcode(postcode):
     request_url = f"{settings.POSTCODE_API_BASE_URL}/postcodes/{postcode}.json"
 
     try:
-        response = requests.get(
+        response = await async_client.get(
             url=request_url,
             timeout=10,  # times out after 10 seconds
         )
         response.raise_for_status()
-    except HTTPError as e:
+    except httpx.HTTPError as e:
         print(e.response.text)
         return False
 
     return True
 
-
-validate_postcode = async_to_sync(avalidate_postcode)
+def validate_postcode(postcode):
+    async def wrapper():
+        async with httpx.AsyncClient() as client:
+            return avalidate_postcode(postcode, client)
+    
+    return async_to_sync(wrapper)()

--- a/project/npda/general_functions/validate_postcode.py
+++ b/project/npda/general_functions/validate_postcode.py
@@ -9,8 +9,10 @@ from requests.exceptions import HTTPError
 # npda imports
 from django.conf import settings
 
+from asgiref.sync import async_to_sync
 
-def validate_postcode(postcode):
+
+async def avalidate_postcode(postcode):
     """
     Tests if postcode is valid
     Returns boolean
@@ -29,3 +31,6 @@ def validate_postcode(postcode):
         return False
 
     return True
+
+
+validate_postcode = async_to_sync(avalidate_postcode)

--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -16,7 +16,6 @@ from ...constants import (
     ETHNICITIES,
     DIABETES_TYPES,
     SEX_TYPE,
-    UNKNOWN_POSTCODES_NO_SPACES,
     CAN_LOCK_CHILD_PATIENT_DATA_FROM_EDITING,
     CAN_UNLOCK_CHILD_PATIENT_DATA_FROM_EDITING,
     CAN_OPT_OUT_CHILD_FROM_INCLUSION_IN_AUDIT,
@@ -145,17 +144,7 @@ class Patient(models.Model):
 
     def save(self, *args, **kwargs) -> None:
         # calculate the index of multiple deprivation quintile if the postcode is present
-        # Skips the calculation if the postcode is on the 'unknown' list
         if self.postcode:
-            try:
-                self.index_of_multiple_deprivation_quintile = imd_for_postcode(
-                    self.postcode
-                )
-            except Exception as error:
-                # Deprivation score not persisted if deprivation score server down
-                self.index_of_multiple_deprivation_quintile = None
-                print(
-                    f"Cannot calculate deprivation score for {self.postcode}: {error}"
-                )   
+            self.index_of_multiple_deprivation_quintile = imd_for_postcode(self.postcode) 
 
         return super().save(*args, **kwargs)

--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -141,10 +141,3 @@ class Patient(models.Model):
         Today's date is optional and defaults to date.today()
         """
         return stringify_time_elapsed(self.date_of_birth, today_date)
-
-    def save(self, *args, **kwargs) -> None:
-        # calculate the index of multiple deprivation quintile if the postcode is present
-        if self.postcode:
-            self.index_of_multiple_deprivation_quintile = imd_for_postcode(self.postcode) 
-
-        return super().save(*args, **kwargs)

--- a/project/npda/serializers/patient_serializer.py
+++ b/project/npda/serializers/patient_serializer.py
@@ -69,6 +69,7 @@ class PatientSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError("Invalid NHS Number")
 
     def validate_postcode(self, value):
+        print(f"!! patient_serializer.validate_postcode {value}")
         if validate_postcode(value):
             return value
         raise serializers.ValidationError("Invalid postcode.")

--- a/project/npda/serializers/patient_serializer.py
+++ b/project/npda/serializers/patient_serializer.py
@@ -69,7 +69,6 @@ class PatientSerializer(serializers.HyperlinkedModelSerializer):
             raise serializers.ValidationError("Invalid NHS Number")
 
     def validate_postcode(self, value):
-        print(f"!! patient_serializer.validate_postcode {value}")
         if validate_postcode(value):
             return value
         raise serializers.ValidationError("Invalid postcode.")

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -1,10 +1,13 @@
 # python imports
 import logging
+import asyncio
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
+
+from asgiref.sync import sync_to_async
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -14,40 +17,52 @@ def login_and_otp_required():
     """
     Must have verified via 2FA
     """
+    def check_otp(view, request):
+        # Then, ensure 2fa verified
+        user = request.user
+        # Bypass 2fa if local dev, with warning message
+        if settings.DEBUG and user.is_authenticated:
+            logger.warning(
+                "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
+                user,
+                view,
+                settings.DEBUG,
+            )
+
+        # Prevent unverified users
+        if not user.is_verified():
+            user_list = user.__dict__
+            npda_user = user_list["_wrapped"]
+            logger.info(
+                "User %s is unverified. Tried accessing %s",
+                npda_user,
+                view.__qualname__,
+            )
+            return False
+
+        return True
 
     def decorator(view):
-        # First use login_required on decorator
-        login_required(view)
-
-        def wrapper(request, *args, **kwargs):
-            # Then, ensure 2fa verified
-            user = request.user
-            # Bypass 2fa if local dev, with warning message
-            if settings.DEBUG and user.is_authenticated:
-                logger.warning(
-                    "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
-                    user,
-                    view,
-                    settings.DEBUG,
-                )
-                return view(request, *args, **kwargs)
-
-            # Prevent unverified users
-            if not user.is_verified():
-                user_list = user.__dict__
-                npda_user = user_list["_wrapped"]
-                logger.info(
-                    "User %s is unverified. Tried accessing %s",
-                    npda_user,
-                    # TODO MRB: work out how to put this back since view is the async wrapper decorator
-                    "TODO MRB: fix"
-                    # view['__qualname__'],
-                )
-                # raise PermissionDenied("Unverified user")
+        async def async_login_and_otp_required(request, *args, **kwargs):
+            async_check_otp = sync_to_async(check_otp)
+            
+            if await async_check_otp(view, request):
+                response = await view(request, *args, **kwargs)
+                return response
+            else:
                 return redirect("two_factor:setup")
 
-            return view(request, *args, **kwargs)
+        def sync_login_and_otp_required(request, *args, **kwargs):
+            if check_otp(view, request):
+                return redirect("two_factor:setup")
+            else:
+                return view(request, *args, **kwargs)
 
-        return wrapper
+        login_required(view)
 
+        if asyncio.iscoroutinefunction(view):
+            return async_login_and_otp_required
+        else:
+            return sync_login_and_otp_required
+    
     return decorator

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -39,7 +39,9 @@ def login_and_otp_required():
                 logger.info(
                     "User %s is unverified. Tried accessing %s",
                     npda_user,
-                    view.__qualname__,
+                    # TODO MRB: work out how to put this back since view is the async wrapper decorator
+                    "TODO MRB: fix"
+                    # view['__qualname__'],
                 )
                 # raise PermissionDenied("Unverified user")
                 return redirect("two_factor:setup")

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -11,6 +11,8 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.generic import ListView
 
+from asgiref.sync import async_to_sync, sync_to_async
+
 # RCPCH imports
 from ..general_functions import csv_upload, csv_summarise
 from ..forms.upload import UploadFileForm
@@ -20,26 +22,29 @@ from .decorators import login_and_otp_required
 # Logging
 logger = logging.getLogger(__name__)
 
+
+@sync_to_async
 @login_and_otp_required()
-def home(request):
+@async_to_sync
+async def home(request):
     """
     Home page view - contains the upload form.
     Only verified users can access this page.
     """
     file_uploaded = False
-    
 
     if request.method == "POST":
         form = UploadFileForm(request.POST, request.FILES)
         file = request.FILES["csv_upload"]
         pz_code = request.session.get("pz_code")
         
-        summary = csv_summarise(csv_file=file)
+        summary = await csv_summarise(csv_file=file)
 
         # You can't read the same file twice without resetting it
         file.seek(0)
         
-        file_uploaded = csv_upload(user=request.user, csv_file=file, organisation_ods_code=request.user.organisation_employers.first().ods_code, pdu_pz_code=pz_code)
+        organisation = await request.user.organisation_employers.afirst()
+        file_uploaded = await csv_upload(user=request.user, csv_file=file, organisation_ods_code=organisation.ods_code, pdu_pz_code=pz_code)
 
         if file_uploaded["status"]==422 or file_uploaded["status"]==500:
             messages.error(request=request,message=f"{file_uploaded["errors"]}")

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -23,9 +23,7 @@ from .decorators import login_and_otp_required
 logger = logging.getLogger(__name__)
 
 
-@sync_to_async
 @login_and_otp_required()
-@async_to_sync
 async def home(request):
     """
     Home page view - contains the upload form.

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -18,7 +18,7 @@ from django.http import HttpResponse
 # Third party imports
 from django_htmx.http import trigger_client_event
 
-from project.npda.general_functions import organisations_adapter
+from project.npda.general_functions import organisations_adapter, imd_for_postcode
 from project.npda.models import NPDAUser, AuditCohort
 
 # RCPCH imports
@@ -206,6 +206,10 @@ class PatientCreateView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, Succe
         )
         patient.site = site
         patient.is_valid = True
+
+        if patient.postcode:
+            patient.index_of_multiple_deprivation_quintile = imd_for_postcode(patient.postcode)
+
         patient.save()
         # add patient to the latest audit cohort
         if AuditCohort.objects.count() > 0:
@@ -240,6 +244,12 @@ class PatientUpdateView(LoginAndOTPRequiredMixin, CheckPDUInstanceMixin, Permiss
     def form_valid(self, form: BaseForm) -> HttpResponse:
         patient = form.save(commit=False)
         patient.is_valid = True
+
+        if patient.postcode:
+            imd = imd_for_postcode(patient.postcode)
+            if imd:
+                patient.index_of_multiple_deprivation_quintile = imd
+
         patient.save()
         return super().form_valid(form)
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,6 +19,7 @@ psycopg2-binary==2.9.9
 whitenoise==6.6.0
 python-dotenv==1.0.1
 azure-identity==1.17.1
+httpx==0.27.0
 
 # We don't use this but django-two-factor-auth requires it
 # They are working to make it optional https://github.com/jazzband/django-two-factor-auth/issues/469


### PR DESCRIPTION
Fixes #148
Fixes #147

Make processing CSV uploads an order of magnitude faster by making all the external API requests in parallel across all rows.

I've done this by making the parent view async along with all the csv_upload functions and the `validate_postcode` and `imd_for_postcode` third party API lookups. The CSV upload code then creates a Python TaskGroup and submits a task to process each row.

The tasks share an [httpx](https://www.python-httpx.org/) [AsyncClient](https://www.python-httpx.org/async/) so they can co-operatively submit and wait for the responses. For the existing sync calling code on patient create and update I've added wrappers to create a client on demand for the duration of the requests.

I got the approach from this blog post: https://fly.io/django-beats/running-tasks-concurrently-in-django-asynchronous-views/. It's my first time with async Python though so it's very possible I've done something wrong or inefficiently. In particular this approach is naive in proportion to the number of rows in the file. Submitting a CSV with thousands of rows will launch thousands of requests simulataneously which is almost certainly not the behaviour we want. That said, this speeds up our current demo with `dummy_sheet.csv` so much I think it's probably worth merging as is and iterating on. Async code is fiddly by nature so we should not adopt this approach across the board, only where we deem it necessary.

Time to upload `dummy_sheet.csv`:

- *Before*: 11.91 seconds
- *After*: 3.01 seconds! 🚀 