### PR TITLE
Don't add PRs to project board automatically, just issues

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yml
+++ b/.github/workflows/auto-add-issues-to-project.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Keeps the board cleaner at the expense of requiring us to make issues to track our work