### PR TITLE
Periodically get a new Azure DB token

### DIFF
--- a/project/npda/apps.py
+++ b/project/npda/apps.py
@@ -1,5 +1,22 @@
+import threading
+
 from django.apps import AppConfig
 
+from .management.commands.write_azure_pg_password_file import write_azure_pg_password_file 
+
+def periodically_update_azure_pg_password_file():
+    update_interval = 60 * 15 # 15 minutes
+
+    def _periodically_update_azure_pg_password_file():
+        write_azure_pg_password_file()
+        
+        thread = threading.Timer(update_interval, _periodically_update_azure_pg_password_file)
+        thread.daemon = True
+        thread.start()
+    
+    thread = threading.Timer(update_interval, _periodically_update_azure_pg_password_file)
+    thread.daemon = True
+    thread.start()
 
 class NpdaConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -7,5 +24,7 @@ class NpdaConfig(AppConfig):
 
     def ready(self) -> None:
         import project.npda.signals
+
+        periodically_update_azure_pg_password_file()
 
         return super().ready()

--- a/project/npda/management/commands/write_azure_pg_password_file.py
+++ b/project/npda/management/commands/write_azure_pg_password_file.py
@@ -11,19 +11,24 @@ from azure.identity import DefaultAzureCredential
 # Django specifically does not allow you to update settings at
 # runtime so we store the connection details in a separate file.
 
+def write_azure_pg_password_file():
+    password_file = os.environ.get('NPDA_POSTGRES_DB_PASSWORD_FILE')
+
+    if not password_file:
+        return
+
+    password = DefaultAzureCredential().get_token("https://ossrdbms-aad.database.windows.net").token
+
+    with open(password_file, "w") as f:
+        f.write(f"*:*:*:*:{password}")
+    
+    # libpg silently ignores the file if it's readable by anyone else
+    os.chmod(password_file, 0o600)
+
+
 class Command(BaseCommand):
     help = "Generate a Postgres password file to use an Azure managed identity to authenticate with the database."
 
     def handle(self, *args, **options):
-        password_file = os.environ.get('NPDA_POSTGRES_DB_PASSWORD_FILE')
-
-        if not password_file:
-            return
-
-        password = DefaultAzureCredential().get_token("https://ossrdbms-aad.database.windows.net").token
-
-        with open(password_file, "w") as f:
-            f.write(f"*:*:*:*:{password}")
+        write_azure_pg_password_file()
         
-        # libpg silently ignores the file if it's readable by anyone else
-        os.chmod(password_file, 0o600)


### PR DESCRIPTION
Fixes #207.

Periodically get a new Azure DB token. Do it in a background thread as we don't have a sensible cron setup within the container. Azure Container Apps does have scheduled jobs but they run as totally separate managed identities so it would get confusing when monitoring things that the main app uses a token from an identity other than it's own. This solution works regardless of how we deploy the app.

We still get a token as the first step in the `start-prod` script.

The tokens live for a day but 15 minutes seems like a reasonable amount of time to avoid doing it too much. From what I can tell the token is cached somewhere within Azure Container Apps anyway. I guess *really* we should drive this period from the expiry time on the token itself but nothing else in the app parses it yet so this seems a reasonable compromise.