### PR TITLE
Add an http access log

### DIFF
--- a/s/start-prod
+++ b/s/start-prod
@@ -4,4 +4,10 @@ python manage.py write_azure_pg_password_file
 python manage.py makemigrations
 python manage.py migrate
 python manage.py seed --mode=seed_groups_and_permissions
-gunicorn --bind=0.0.0.0:8000 --timeout 600 project.wsgi
+
+gunicorn \
+    --bind=0.0.0.0:8000 \
+    --timeout 600 \
+    --access-logfile '-' \
+    --access-logformat '%({x-forwarded-for}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"' \
+    project.wsgi


### PR DESCRIPTION
Seemed simplest to do this in gunicorn as the Django logging configuration is very complicated and it's Friday and I can't cope with that before a weekend.

The logging format is the default format but I have replaced the host IP logging with X-Forwarded-For as otherwise it will always be the same IP address of the Azure ingress machine.

Example:

```
django-1   | 172.22.0.1 - - [16/Aug/2024:14:55:41 +0100] "GET / HTTP/1.1" 302 0 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
django-1   | 172.22.0.1 - - [16/Aug/2024:14:55:41 +0100] "GET /account/two_factor/setup/ HTTP/1.1" 200 29690 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
```