### PR TITLE
user-activity

### DIFF
--- a/documentation/docs/developer/users.md
+++ b/documentation/docs/developer/users.md
@@ -69,3 +69,23 @@ This has the basic django user functions but has the following extra custome fie
 - `is_patient_or_carer`: boolean - a custom field that defines the user is a patient or carer
 - `role` - user type as above
 - `organisation_employer` - this is a relational field with an Organisation. Only applies to clinicians and therefore is None for RCPCH employees.
+
+#### Passwords and Two factor authentication
+
+Password access is required to access all areas of the NPDA platform apart from the documentation/user guide. Rules for passwords are:
+Minimum of 10 characters (minimum 16 for RCPCH Audit team)
+Must contain ONE capital
+Must contain ONE number
+Must contain ONE symbol from !@£$%^&*()_-+=|~
+Must NOT be exclusively numbers
+Must NOT be same as your email, name, surname
+
+User accounts allow a maximum of 5 consecutive attempts after which the account is locked for 5 minutes.
+
+Two Factor authentication is required for all login access. This is set up only once at first login. A user can change their 2 Factor Authentication settings once logged in by clicking on the their name in the top right of the screen and navigating to Two Factor Authentication.
+
+Two Factor Authentication is either by email or Microsoft Authenticator on a mobile phone. If a user successfully logs in with their passwords, they must either check their email for a Token or generate one on their Microsoft Authenticator app.
+
+#### Captcha
+
+In addition to the above methods of authentication, a rotating image of numbers or letters is used to ensure only humans can gain access.

--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -12,14 +12,9 @@ from django.utils.translation import gettext as _
 # third party imports
 from captcha.fields import CaptchaField
 
-from project.npda.general_functions import organisations_adapter
-
 # RCPCH imports
 from ...constants.styles.form_styles import *
-from ..models import NPDAUser
-from project.npda.general_functions import (
-    organisations_adapter,
-)
+from ..models import NPDAUser, VisitActivity
 
 
 # Logging setup
@@ -126,6 +121,11 @@ class NPDAUpdatePasswordForm(SetPasswordForm):
         user.password_last_set = timezone.now()
         if commit:
             logger.debug(f"Updating password_last_set to {timezone.now()}")
+            VisitActivity.objects.create(
+                npdauser=user,
+                activity=5,
+                ip_address=None,  # cannot get ip address here as it is not a request
+            )  # password reset successful - activity 5
             user.save()
         return user
 

--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -53,7 +53,7 @@ class NPDAUserManager(BaseUserManager):
         user.email_confirmed = False
         # set time password has been updated
         user.password_last_set = timezone.now()
-        print(f"{user} password updated")
+        user.date_joined = timezone.now()
         user.save()
 
         """
@@ -122,6 +122,8 @@ class NPDAUserManager(BaseUserManager):
                     npda_user=logged_in_user,
                     defaults={"is_primary_employer": True},
                 )
+
+        logged_in_user.date_joined = timezone.now()
 
         """
         Allocate Roles

--- a/project/npda/models/visitactivity.py
+++ b/project/npda/models/visitactivity.py
@@ -9,9 +9,10 @@ class VisitActivity(models.Model):
     LOGOUT = 3
     PASSWORD_RESET_LINK_SENT = 4
     PASSWORD_RESET = 5
-    SETUP_TWO_FACTOR_AUTHENTICATION = 6
-    UPLOADED_CSV = 7
-    TOUCHED_PATIENT_RECORD = 8
+    PASSWORD_LOCKOUT = 6
+    SETUP_TWO_FACTOR_AUTHENTICATION = 7
+    UPLOADED_CSV = 8
+    TOUCHED_PATIENT_RECORD = 9
 
     ACTIVITY = (
         (SUCCESSFUL_LOGIN, "Successful login"),
@@ -19,6 +20,7 @@ class VisitActivity(models.Model):
         (LOGOUT, "Logout"),
         (PASSWORD_RESET_LINK_SENT, "Password reset link sent"),
         (PASSWORD_RESET, "Password reset successfully"),
+        (PASSWORD_LOCKOUT, "Password lockout"),
         (SETUP_TWO_FACTOR_AUTHENTICATION, "Two factor authentication set up"),
         (UPLOADED_CSV, "Uploaded CSV"),
         (TOUCHED_PATIENT_RECORD, "Touched patient record"),

--- a/project/npda/models/visitactivity.py
+++ b/project/npda/models/visitactivity.py
@@ -7,11 +7,21 @@ class VisitActivity(models.Model):
     SUCCESSFUL_LOGIN = 1
     UNSUCCESSFUL_LOGIN = 2
     LOGOUT = 3
+    PASSWORD_RESET_LINK_SENT = 4
+    PASSWORD_RESET = 5
+    SETUP_TWO_FACTOR_AUTHENTICATION = 5
+    UPLOADED_CSV = 6
+    TOUCHED_PATIENT_RECORD = 7
 
     ACTIVITY = (
-        (SUCCESSFUL_LOGIN, "SUCCESSFUL_LOGIN"),
-        (UNSUCCESSFUL_LOGIN, "UNSUCCESSFUL_LOGIN"),
-        (LOGOUT, "LOGOUT"),
+        (SUCCESSFUL_LOGIN, "Successful login"),
+        (UNSUCCESSFUL_LOGIN, "Login failed"),
+        (LOGOUT, "Logout"),
+        (PASSWORD_RESET_LINK_SENT, "Password Reset link sent"),
+        (PASSWORD_RESET, "Password reset"),
+        (SETUP_TWO_FACTOR_AUTHENTICATION, "Two factor authentication set up"),
+        (UPLOADED_CSV, "Uploaded CSV"),
+        (TOUCHED_PATIENT_RECORD, "Touched patient record"),
     )
 
     activity_datetime = models.DateTimeField(auto_created=True, default=timezone.now)

--- a/project/npda/models/visitactivity.py
+++ b/project/npda/models/visitactivity.py
@@ -9,16 +9,16 @@ class VisitActivity(models.Model):
     LOGOUT = 3
     PASSWORD_RESET_LINK_SENT = 4
     PASSWORD_RESET = 5
-    SETUP_TWO_FACTOR_AUTHENTICATION = 5
-    UPLOADED_CSV = 6
-    TOUCHED_PATIENT_RECORD = 7
+    SETUP_TWO_FACTOR_AUTHENTICATION = 6
+    UPLOADED_CSV = 7
+    TOUCHED_PATIENT_RECORD = 8
 
     ACTIVITY = (
         (SUCCESSFUL_LOGIN, "Successful login"),
         (UNSUCCESSFUL_LOGIN, "Login failed"),
         (LOGOUT, "Logout"),
-        (PASSWORD_RESET_LINK_SENT, "Password Reset link sent"),
-        (PASSWORD_RESET, "Password reset"),
+        (PASSWORD_RESET_LINK_SENT, "Password reset link sent"),
+        (PASSWORD_RESET, "Password reset successfully"),
         (SETUP_TWO_FACTOR_AUTHENTICATION, "Two factor authentication set up"),
         (UPLOADED_CSV, "Uploaded CSV"),
         (TOUCHED_PATIENT_RECORD, "Touched patient record"),

--- a/project/npda/signals.py
+++ b/project/npda/signals.py
@@ -17,6 +17,15 @@ from .general_functions.session import create_session_object
 # Logging setup
 logger = logging.getLogger(__name__)
 
+"""
+This file contains signals that are triggered when a user logs in, logs out, or fails to log in.
+These signals are used to log user activity in the VisitActivity model.
+They are also used to track if users have touched patient records.
+"""
+
+# Custom signals
+from django.dispatch import Signal
+
 
 @receiver(user_logged_in)
 def log_user_login(sender, request, user, **kwargs):
@@ -64,6 +73,16 @@ def log_user_logout(sender, request, user, **kwargs):
     VisitActivity.objects.create(
         activity=3, ip_address=get_client_ip(request), npdauser=user
     )
+
+
+# @receiver(password_reset_sent)
+# def log_password_reset(sender, request, user, **kwargs):
+#     logger.info(
+#         f"Password reset link sent to {user} ({user.email}) from {get_client_ip(request)}."
+#     )
+#     VisitActivity.objects.create(
+#     activity=4, ip_address=get_client_ip(request), npdauser=user
+# )
 
 
 # helper functions

--- a/project/npda/templates/nav.html
+++ b/project/npda/templates/nav.html
@@ -53,8 +53,7 @@
                         <ul
                         tabindex="0"
                         class="menu dropdown-content bg-base-100 rounded-none z-[1] mt-4 w-52 p-2 hover:bg-white">
-                            <li><a href="{% url 'two_factor:profile' %}">2FA</a></li>
-                            <li><a href="{% url 'password_reset' %}">Reset Password</a></li>
+                            <li><a href="{% url 'two_factor:profile' %}">Two Factor Authentication</a></li>
                             <form method="POST" action="{% url 'logout' %}">
                                 <li >{% csrf_token%}
                                     <button type="submit">Log Out</button>

--- a/project/npda/templates/npda_user_logs.html
+++ b/project/npda/templates/npda_user_logs.html
@@ -7,7 +7,8 @@
           <div class="relative overflow-x-auto">
             <strong>NPDA Audit Access Logs for {{npdauser.get_full_name}} (NPDA User ID-{{npdauser.pk}})</strong>
             <p class="text-gray-400 font-montserrat">
-              <small>Password last set: {{npdauser.password_last_set}}</small>
+              <small>Password last set: {{npdauser.password_last_set}}</small><br/>
+              <small>Account created: {{npdauser.date_joined}}</small> 
             </p>
             {% if visitactivities %}
               <table class="lg-table-fixed table-fixed w-full text-sm text-left rtl:text-left text-gray-500 text-gray-400 mb-5 font-montserrat">

--- a/project/npda/templates/npda_user_logs.html
+++ b/project/npda/templates/npda_user_logs.html
@@ -6,6 +6,9 @@
       <div class="inline-block min-w-full py-2 sm:px-6 lg:px-8">
           <div class="relative overflow-x-auto">
             <strong>NPDA Audit Access Logs for {{npdauser.get_full_name}} (NPDA User ID-{{npdauser.pk}})</strong>
+            <p class="text-gray-400 font-montserrat">
+              <small>Password last set: {{npdauser.password_last_set}}</small>
+            </p>
             {% if visitactivities %}
               <table class="lg-table-fixed table-fixed w-full text-sm text-left rtl:text-left text-gray-500 text-gray-400 mb-5 font-montserrat">
                   <thead class="text-xs text-gray-700 uppercase bg-gray-50 bg-rcpch_dark_blue text-white">

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -1,7 +1,14 @@
 {% load static %}
 {% load npda_tags %}
 {% url 'patients' as patients_url %}
-<h1 class="text-md font-montserrat font-semibold text-rcpch_dark_blue">Patients under the care of {{pz_code}}</h1>
+{% if request.user.view_preference == 1 %}
+    <!-- PDU view   -->
+    <h1 class="text-md font-montserrat font-semibold text-rcpch_dark_blue">Patients under the care of {{pz_code}}</h1>
+{% elif request.user.view_preference == 2 %}
+    <!-- national view -->
+    <h1 class="text-md font-montserrat font-semibold text-rcpch_dark_blue">All patients nationally</h1>
+{% endif %}
+
 {% if patient_list %}
 <table class="table table-md w-full text-sm text-left rtl:text-right text-gray-500 text-gray-400 mb-5 font-montserrat">
     <thead class="text-xs text-gray-700 uppercase bg-gray-50 bg-rcpch_dark_blue text-white">

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -16,6 +16,7 @@
                             <th>Audit Year</th>
                             <th>Patient Number</th>
                             <th>Active</th>
+                            {% if request.user.view_preference == 2 %}<th>PDU</th>{% endif %}
                             <th>Download</th>
                         </tr>
                     </thead>
@@ -41,6 +42,7 @@
                                         </span>
                                     {% endif %}
                                 </td>
+                                {% if request.user.view_preference == 2 %}<td>{{ submission.paediatric_diabetes_unit.pz_code }} ({{submission.paediatric_diabetes_unit.lead_organisation_name}})</td>{% endif %}
                                 <td class="flex flex-row">
                                     <form method="post" action="{% url 'submissions' %}" class="join">
                                         {% csrf_token %}
@@ -61,7 +63,7 @@
                                             type="submit" 
                                             class="join-item bg-rcpch_red text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint btn-sm rounded-none {% if submission.submission_active %}opacity-50 cursor-not-allowed {% endif %}">Delete</button>
                                     </form>
-                                    {% if forloop.first %}
+                                    {% if submission.submission_active %}
                                         <a href="{% url 'patients' %}">
                                             <svg
                                                 class="h-8 w-8 text-rcpch_pink self-center hover:text-white"

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -48,20 +48,19 @@
                                         {% csrf_token %}
                                         <input type="hidden" name="audit_id" value="{{submission.pk}}">
                                         {% if submission.submission_active %}
-                                        <button 
-                                            name="submit-data" 
-                                            value="download-data" 
-                                            type="submit" 
-                                            class="join-item bg-rcpch_light_blue text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue btn-sm rounded-none">Download</button>
+                                            <button 
+                                                name="submit-data" 
+                                                value="download-data" 
+                                                type="submit" 
+                                                class="join-item bg-rcpch_light_blue text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue btn-sm rounded-none">Download</button>
+                                        {% else %}
+                                            <button 
+                                                name="submit-data"
+                                                disabled="true"
+                                                value="delete-data"  
+                                                type="submit" 
+                                                class="join-item bg-rcpch_red text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint btn-sm rounded-none {% if submission.submission_active %}opacity-50 cursor-not-allowed {% endif %}">Delete</button>
                                         {% endif %}
-                                        <button 
-                                            name="submit-data"
-                                            {% if submission.submission_active %}
-                                            disabled="true"
-                                            {% endif %}
-                                            value="delete-data"  
-                                            type="submit" 
-                                            class="join-item bg-rcpch_red text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint btn-sm rounded-none {% if submission.submission_active %}opacity-50 cursor-not-allowed {% endif %}">Delete</button>
                                     </form>
                                     {% if submission.submission_active %}
                                         <a href="{% url 'patients' %}">

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -65,11 +65,14 @@ def home(request):
             )
             messages.success(request=request, message="File uploaded successfully")
             VisitActivity = apps.get_model("npda", "VisitActivity")
-            VisitActivity.objects.create(
-                activity=8,
-                ip_address=request.META.get("REMOTE_ADDR"),
-                npdauser=request.user,
-            )  # uploaded csv - activity 8
+            try:
+                VisitActivity.objects.create(
+                    activity=8,
+                    ip_address=request.META.get("REMOTE_ADDR"),
+                    npdauser=request.user,
+                )  # uploaded csv - activity 8
+            except Exception as e:
+                logger.error(f"Failed to log user activity: {e}")
         except ValidationError as error:
             errors = error_list(error)
 

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -2,10 +2,11 @@
 import logging
 
 # Django imports
-from django.urls import reverse
+from django.apps import apps
 from django.contrib import messages
-from django.shortcuts import render
 from django.core.exceptions import ValidationError
+from django.shortcuts import render
+from django.urls import reverse
 
 # HTMX imports
 from django_htmx.http import trigger_client_event
@@ -63,6 +64,12 @@ def home(request):
                 pdu_pz_code=pz_code,
             )
             messages.success(request=request, message="File uploaded successfully")
+            VisitActivity = apps.get_model("npda", "VisitActivity")
+            VisitActivity.objects.create(
+                activity=8,
+                ip_address=request.META.get("REMOTE_ADDR"),
+                npdauser=request.user,
+            )  # uploaded csv - activity 8
         except ValidationError as error:
             errors = error_list(error)
 


### PR DESCRIPTION
### Overview

The PR updates the VisitActivity model with some new activities
These include:

```python
ACTIVITY = (
        (SUCCESSFUL_LOGIN, "Successful login"),
        (UNSUCCESSFUL_LOGIN, "Login failed"),
        (LOGOUT, "Logout"),
        (PASSWORD_RESET_LINK_SENT, "Password reset link sent"),
        (PASSWORD_RESET, "Password reset successfully"),
        (PASSWORD_LOCKOUT, "Password lockout"),
        (SETUP_TWO_FACTOR_AUTHENTICATION, "Two factor authentication set up"),
        (UPLOADED_CSV, "Uploaded CSV"),
        (TOUCHED_PATIENT_RECORD, "Touched patient record"),
    )
```
These have all been implemented apart from the last one.
These are all reflected in the user logs table as well as inclusion of account creation date which was an unused field in the user model
Users are now locked out for 5 minutes if they attempt to login more than 5 times in a row. This is a    feature requested in the pen testing for E12.
Also, the patient table signposts more clearly if the view is national or PDU.

### Documentation changes (done or required as a result of this PR)

The user documentation relating to passwords and account creation has been updated

### Related Issues

fixes #267