### PR TITLE
Fix returning error if GP details are missing

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -170,7 +170,7 @@ class PatientForm(forms.ModelForm):
                 )
 
         if gp_practice_ods_code is None and gp_practice_postcode is None:
-            self.add_error(None, ValidationError("'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty"))
+            self.add_error("gp_practice_ods_code", ValidationError("'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty"))
 
         if gp_practice_postcode:
             try:

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -158,9 +158,9 @@ def test_missing_gp_details():
     form = PatientForm({})
     
     errors = form.errors.as_data()
-    assert("__all__" in errors)
+    assert("gp_practice_ods_code" in errors)
 
-    error_message = errors["__all__"][0].messages[0]
+    error_message = errors["gp_practice_ods_code"][0].messages[0]
     assert(error_message == "'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty")
 
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -338,10 +338,9 @@ def test_missing_gp_ods_code(test_user, single_row_valid_df):
 
     patient = Patient.objects.first()
 
-    assert("__all__" in patient.errors)
-
-    # TODO MRB: should we make this error more obvious that you can only set ODS code in the spreadsheet?
-    error_message = patient.errors["__all__"][0]['message']
+    assert("gp_practice_ods_code" in patient.errors)
+    
+    error_message = patient.errors["gp_practice_ods_code"][0]['message']
     # TODO MRB: why does this have entity encoding issues?
     assert(error_message == "&#x27;GP Practice ODS code&#x27; and &#x27;GP Practice postcode&#x27; cannot both be empty")
 


### PR DESCRIPTION
By attaching it to gp_practice_ods_code it's visible for both form usage and the CSV upload.