### PR TITLE
Make alerts dismissible and fixed to bottom of page (toasts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 build_info.json
 
 media/submissions/csv/*
+*.crt

--- a/project/npda/templates/base.html
+++ b/project/npda/templates/base.html
@@ -153,41 +153,14 @@
 <body id="root" class="bg-white">
 
   {% csrf_token %}
+  
   {% block nav %}
   {% include 'nav.html' %}
   {% endblock %}
-  {% if messages %}
-  <div class="toast toast-bottom toast-start w-full max-h-screen overflow-y-auto overscroll-contain">
-    {% for message in messages %}
-    {% if message.tags %}{% endif %}
-    <div id="alert-{{forloop.counter}}"
-      class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md"
-      role="alert">
-      <div class="flex">
-        <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4"
-            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-            <path
-              d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
-          </svg></div>
-        <div class="text-pretty">
-          <p class="font-bold break-normal">{% if message.tags %}{% endif %}</p>
-          <p class="text-sm break-normal">{{ message }}</p>
-        </div>
-        <button type="button"
-          onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
-          class="ms-auto -mx-1.5 -my-1.5 rcpch_light_blue bg-slate-100 text-rcpch_light_blue rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-rcpch_strong_blue hover:text-white inline-flex items-center justify-center h-8 w-8 has-tooltip"
-          aria-label="Close">
-          <span class="sr-only">Close</span>
-          <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
-          </svg>
-        </button>
-      </div>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
+
+  {% block toasts %}
+  {% include 'toasts.html' %}
+  {% endblock %}
   <div>
     {% block content %}{% endblock %}
   </div>

--- a/project/npda/templates/base.html
+++ b/project/npda/templates/base.html
@@ -12,14 +12,17 @@
   <meta name="theme-color" content="#ffffff" />
   <meta name="latest_git_commit" content="{{latest_git_commit}}" />
   <title>National Paediatric Diabetes Audit Platform | RCPCH</title>
-  <link rel="icon" href="/favicon.ico"/>
+  <link rel="icon" href="/favicon.ico" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet">
   <link href="{% static 'tailwind.css' %}" rel="stylesheet">
   <link href="https://fonts.cdnfonts.com/css/arial-2" rel="stylesheet">
-  <script src="https://unpkg.com/htmx.org@1.9.11/dist/htmx.js" integrity="sha384-l9bYT9SL4CAW0Hl7pAOpfRc18mys1b0wK4U8UtGnWOxPVbVMgrOdB+jyz/WY8Jue" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.11/dist/htmx.js"
+    integrity="sha384-l9bYT9SL4CAW0Hl7pAOpfRc18mys1b0wK4U8UtGnWOxPVbVMgrOdB+jyz/WY8Jue"
+    crossorigin="anonymous"></script>
   <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
   <!-- not for production -->
   <link href="https://cdn.jsdelivr.net/npm/daisyui@4.11.1/dist/full.min.css" rel="stylesheet" type="text/css" />
@@ -40,7 +43,7 @@
     }
   </style>
   <script>
-    tailwind.config = {
+    tailwind.config={
       darkMode: 'media',
       theme: {
         backgroundColor: theme => ({
@@ -49,15 +52,15 @@
         }),
         extend: {
           fontFamily: {
-            'montserrat':['Montserrat', 'regular'],
-            'arial':['Arial', 'sans-serif']
+            'montserrat': ['Montserrat', 'regular'],
+            'arial': ['Arial', 'sans-serif']
           },
           maxWidth: {
             'custom': '33.7rem' // Replace '30rem' with the exact width you want
           },
           colors: {
             rcpch_lightest_grey: "#f3f3f3",
-            
+
             rcpch_dark_blue: "#0d0d58",
             rcpch_strong_blue: "#3366cc",
             /* 51,102,204 */
@@ -65,7 +68,7 @@
             rcpch_strong_blue_light_tint2: "#99b3e6",
             rcpch_strong_blue_light_tint3: "#ccd9f2",
             rcpch_strong_blue_dark_tint: "#405a97",
-            
+
             /* 45,49,109 */
             rcpch_light_blue: "#11a7f2",
             rcpch_light_blue_tint1: "#4dbdf5",
@@ -73,14 +76,14 @@
             rcpch_light_blue_tint3: "#cfe9fc",
             rcpch_light_blue_dark_tint: "#0082bc",
             /* 17,167,242 */
-            
+
             rcpch_pink: "#e00087",
             /* 224,0,135 */
             rcpch_pink_light_tint1: "#e840a5",
             rcpch_pink_light_tint2: "#ef80c3",
             rcpch_pink_light_tint3: "#f7bfe1",
             rcpch_pink_dark_tint: "#ab1368",
-            
+
             /* monochrome */
             rcpch_white: "#ffffff",
             rcpch_light_grey: "#d9d9d9",
@@ -93,44 +96,44 @@
             /* 77,77,77 */
             rcpch_charcoal_dark: "#191919",
             rcpch_black: "#000000",
-            
+
             /* secondary colours */
             rcpch_red: "#e60700",
             rcpch_red_light_tint1: "#ec4540",
             rcpch_red_light_tint2: "#f38380",
             rcpch_red_light_tint3: "#f9c1bf",
             rcpch_red_dark_tint: "#b11d23",
-            
+
             rcpch_orange: "#ff8000",
             rcpch_orange_light_tint1: "#ffa040",
             rcpch_orange_light_tint2: "#ffc080",
             rcpch_orange_light_tint3: "#ffdfbf",
             rcpch_orange_dark_tint: "#bf6914",
-            
+
             rcpch_yellow: "#ffd200",
             rcpch_yellow_light_tint1: "#ffdd40",
             rcpch_yellow_light_tint2: "#ffe980",
             rcpch_yellow_light_tint3: "#fff4bf",
             rcpch_yellow_dark_tint: "#c5a000",
-            
+
             rcpch_strong_green: "#66cc33",
             rcpch_strong_green_light_tint1: "#8cd966",
             rcpch_strong_green_light_tint2: "#b3e699",
             rcpch_strong_green_light_tint3: "#d9f2cc",
             rcpch_strong_green_dark_tint: "#53861b",
-            
+
             rcpch_aqua_green: "#00bdaa",
             rcpch_aqua_green_light_tint1: "#40ecbf",
             rcpch_aqua_green_light_tint2: "#80ded4",
             rcpch_aqua_green_light_tint3: "#bfeeea",
             rcpch_aqua_green_dark_tint: "#2e888d",
-            
+
             rcpch_purple: "#7159aa",
             rcpch_purple_light_tint1: "#ae4cbf",
             rcpch_purple_light_tint2: "#c987d4",
             rcpch_purple_light_tint3: "#e4c3ea",
             rcpch_purple_dark_tint: "#66296c",
-            
+
             /* old colours */
             rcpch_gold: "#c2a712",
             rcpch_vivid_green: "#c8d400",
@@ -145,39 +148,85 @@
       }
     }
   </script>
-  </script>
 </head>
 
 <body id="root" class="bg-white">
-  
+
   {% csrf_token %}
   {% block nav %}
   {% include 'nav.html' %}
   {% endblock %}
-  
+  {% if messages %}
+  <div class="toast toast-bottom toast-start w-full">
+    {% for message in messages %}
+    {% if message.tags %}{% endif %}
+    <div id="alert-{{forloop.counter}}"
+      class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md"
+      role="alert">
+      <div class="flex">
+        <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4"
+            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+            <path
+              d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
+          </svg></div>
+        <div>
+          <p class="font-bold">{% if message.tags %}{% endif %}</p>
+          <p class="text-sm">{{ message }}</p>
+        </div>
+        <button type="button"
+          onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
+          class="ms-auto -mx-1.5 -my-1.5 rcpch_light_blue bg-slate-100 text-rcpch_light_blue rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-rcpch_strong_blue hover:text-white inline-flex items-center justify-center h-8 w-8 has-tooltip"
+          aria-label="Close">
+          <span class="sr-only">Close</span>
+          <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
   {% if messages %}
   <div class="px-10">
     {% for message in messages %}
     {% if message.tags %}{% endif %}
-    <div class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md" role="alert">
+    <div id="alert-{{forloop.counter}}"
+      class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md"
+      role="alert">
       <div class="flex">
-        <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z"/></svg></div>
-            <div>
-              <p class="font-bold">{% if message.tags %}{% endif %}</p>
-              <p class="text-sm">{{ message }}</p>
-            </div>
-          </div>
+        <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4"
+            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+            <path
+              d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
+          </svg></div>
+        <div>
+          <p class="font-bold">{% if message.tags %}{% endif %}</p>
+          <p class="text-sm">{{ message }}</p>
         </div>
-        {% endfor %}
+        <button type="button"
+          onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
+          class="ms-auto -mx-1.5 -my-1.5 rcpch_light_blue bg-slate-100 text-rcpch_light_blue rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-rcpch_strong_blue hover:text-white inline-flex items-center justify-center h-8 w-8 has-tooltip"
+          aria-label="Close">
+          <span class="sr-only">Close</span>
+          <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+          </svg>
+        </button>
       </div>
-    {% endif %}
-
-    <div>
-      {% block content %}{% endblock %}
     </div>
+    {% endfor %}
+  </div>
+  {% endif %}
 
-    {% include 'footer.html' %}
-    
-  </body>
-  
+  <div>
+    {% block content %}{% endblock %}
+  </div>
+
+  {% include 'footer.html' %}
+
+</body>
+
 </html>

--- a/project/npda/templates/base.html
+++ b/project/npda/templates/base.html
@@ -157,7 +157,7 @@
   {% include 'nav.html' %}
   {% endblock %}
   {% if messages %}
-  <div class="toast toast-bottom toast-start w-full">
+  <div class="toast toast-bottom toast-start w-full max-h-screen overflow-y-auto overscroll-contain">
     {% for message in messages %}
     {% if message.tags %}{% endif %}
     <div id="alert-{{forloop.counter}}"
@@ -169,9 +169,9 @@
             <path
               d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
           </svg></div>
-        <div>
-          <p class="font-bold">{% if message.tags %}{% endif %}</p>
-          <p class="text-sm">{{ message }}</p>
+        <div class="text-pretty">
+          <p class="font-bold break-normal">{% if message.tags %}{% endif %}</p>
+          <p class="text-sm break-normal">{{ message }}</p>
         </div>
         <button type="button"
           onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
@@ -188,39 +188,6 @@
     {% endfor %}
   </div>
   {% endif %}
-  {% if messages %}
-  <div class="px-10">
-    {% for message in messages %}
-    {% if message.tags %}{% endif %}
-    <div id="alert-{{forloop.counter}}"
-      class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md"
-      role="alert">
-      <div class="flex">
-        <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4"
-            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-            <path
-              d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
-          </svg></div>
-        <div>
-          <p class="font-bold">{% if message.tags %}{% endif %}</p>
-          <p class="text-sm">{{ message }}</p>
-        </div>
-        <button type="button"
-          onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
-          class="ms-auto -mx-1.5 -my-1.5 rcpch_light_blue bg-slate-100 text-rcpch_light_blue rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-rcpch_strong_blue hover:text-white inline-flex items-center justify-center h-8 w-8 has-tooltip"
-          aria-label="Close">
-          <span class="sr-only">Close</span>
-          <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
-          </svg>
-        </button>
-      </div>
-    </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-
   <div>
     {% block content %}{% endblock %}
   </div>

--- a/project/npda/templates/toasts.html
+++ b/project/npda/templates/toasts.html
@@ -1,0 +1,32 @@
+{% if messages %}
+<div class="toast toast-bottom toast-start w-full max-h-screen overflow-y-auto overscroll-contain">
+  {% for message in messages %}
+  {% if message.tags %}{% endif %}
+  <div id="alert-{{forloop.counter}}"
+    class="bg-white border-t-4 border-rcpch_light_blue rounded-b text-rcpch_light_blue px-4 py-3 shadow-md"
+    role="alert">
+    <div class="flex">
+      <div class="py-1"><svg class="fill-current h-6 w-6 text-rcpch_light_blue mr-4" xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20">
+          <path
+            d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zm12.73-1.41A8 8 0 1 0 4.34 4.34a8 8 0 0 0 11.32 11.32zM9 11V9h2v6H9v-4zm0-6h2v2H9V5z" />
+        </svg></div>
+      <div class="text-pretty">
+        <p class="font-bold break-normal">{% if message.tags %}{% endif %}</p>
+        <p class="text-sm break-normal">{{ message }}</p>
+      </div>
+      <button type="button"
+        onclick="return document.getElementById('alert-{{forloop.counter}}').className += ' hidden';"
+        class="ms-auto -mx-1.5 -my-1.5 rcpch_light_blue bg-slate-100 text-rcpch_light_blue rounded-lg focus:ring-2 focus:ring-blue-400 p-1.5 hover:bg-rcpch_strong_blue hover:text-white inline-flex items-center justify-center h-8 w-8 has-tooltip"
+        aria-label="Close">
+        <span class="sr-only">Close</span>
+        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+        </svg>
+      </button>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}


### PR DESCRIPTION
### Overview
Following CRUD operations, a message is displayed to the user to indicate success/failure.

This PR allows these flashed messages to be dismissed (hidden) quickly and independently.

Messages are also fixed as "toasts" to the bottom of the page. This prevents disappearing messages from causing the page content to jump (potential cause of accidental clicks) 



### Code changes
- Refactored alerts from base.html into own file (toasts.html).
- Wrapped alerts into toasts, hence name.
- As per Django, messages are deleted once processed by default (https://docs.djangoproject.com/en/5.1/ref/contrib/messages/#expiration-of-messages). This PR therefore just hides the message (div class="hidden") on user click, rather than backend calls. Should later PRs use persistent messages, this may need to be revised. 


### Documentation changes (done or required as a result of this PR)
nil.

### Related Issues
#28 