### PR TITLE
Dashboard

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -60,7 +60,7 @@ class CalculateKPIS:
         """Calculates KPIs for given pz_code
 
         Params:
-            * pz_code (str) - PZ code for KPIS
+            * pz_code (str) - PZ code for KPIS: accepts a list of PZ codes as this allows aggregation of KPIs across multiple PZ codes to calculate KPIs for a region or the whole country
             * calculation_date (date) - used to define start and end date of audit period
             * patients (QuerySet) - optional, used to define patients for KPI calculations: this can be used to calculate KPIs for a subset of patients or an individual patient - if not provided, all patients for the given PZ code will be used
         """

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -54,7 +54,9 @@ class CalculateKPIS:
     Calculates KPIs for a given PZ code
     """
 
-    def __init__(self, pz_code: str, calculation_date: date = None, patients=None):
+    def __init__(
+        self, pz_codes: list[str], calculation_date: date = None, patients=None
+    ):
         """Calculates KPIs for given pz_code
 
         Params:
@@ -62,10 +64,10 @@ class CalculateKPIS:
             * calculation_date (date) - used to define start and end date of audit period
             * patients (QuerySet) - optional, used to define patients for KPI calculations: this can be used to calculate KPIs for a subset of patients or an individual patient - if not provided, all patients for the given PZ code will be used
         """
-        if not pz_code:
+        if not pz_codes or len(pz_codes) == 0:
             raise AttributeError("pz_code must be provided")
         # Set various attributes used in calculations
-        self.pz_code = pz_code
+        self.pz_codes = pz_codes
         self.calculation_date = (
             calculation_date if calculation_date is not None else date.today()
         )
@@ -85,7 +87,7 @@ class CalculateKPIS:
         # TODO: should this filter out patients who have left the service?
         if patients is None:
             self.patients = Patient.objects.filter(
-                paediatric_diabetes_units__paediatric_diabetes_unit__pz_code=pz_code
+                paediatric_diabetes_units__paediatric_diabetes_unit__pz_code__in=pz_codes
             ).distinct()
             self.total_patients_count = self.patients.count()
         else:
@@ -297,7 +299,7 @@ class CalculateKPIS:
 
         # Add in used attributes for calculations
         return_obj = {}
-        return_obj["pz_code"] = self.pz_code
+        return_obj["pz_codes"] = self.pz_codes
         return_obj["calculation_datetime"] = datetime.now()
         return_obj["audit_start_date"] = self.audit_start_date
         return_obj["audit_end_date"] = self.audit_end_date

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -3149,7 +3149,9 @@ class KPIAggregationForPDU(TemplateView):
         pz_code = kwargs.get("pz_code", None)
 
         start_time = time.time()  # Record the start time for calc
-        aggregated_data = CalculateKPIS(pz_code=pz_code).calculate_kpis_for_patients()
+        aggregated_data = CalculateKPIS(
+            pz_codes=[pz_code]
+        ).calculate_kpis_for_patients()
         end_time = time.time()  # Record the end time
         calculation_time = round(
             (end_time - start_time) * 1000, 2

--- a/project/npda/templates/dashboard.html
+++ b/project/npda/templates/dashboard.html
@@ -1,7 +1,16 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<div class="">
-    <strong>Dahsboard for {{pz_code}}</strong>
+<div class="flex flex-col justify-center px-10" >
+    <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div class="inline-block min-w-full py-2 sm:px-6 lg:px-8">
+          <div class="relative overflow-x-auto">
+            <div class="py-8 px-4 mx-auto max-w-screen-xl text-center lg:py-16 lg:px-12">
+                <strong>Dashboard for {{pdu.lead_organisation_name}}({{pdu.pz_code}} - {{pdu.parent_name}}) - {{pdu.paediatric_diabetes_network_name}}({{pdu.paediatric_diabetes_network_code}}) </strong>
+            </div>
+                {% include "partials/kpi_table.html" with kpi_results=pdu_kpis pdu=pdu aggregation_level="Paediatric Diabetes Unit" %}
+          </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/project/npda/templates/dashboard.html
+++ b/project/npda/templates/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-{% url 'dashboard' pz_code=pdu.pz_code as hx_get %}
+{% url 'dashboard' as hx_get %}
 <div class="flex flex-col justify-center px-10" hx-get={{hx_get}} hx-trigger="dashboard from:body" hx-target="#dashboard">
     <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="inline-block min-w-full py-2 sm:px-6 lg:px-8">

--- a/project/npda/templates/dashboard.html
+++ b/project/npda/templates/dashboard.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<div class="">
+    <strong>Dahsboard for {{pz_code}}</strong>
+</div>
+{% endblock %}

--- a/project/npda/templates/dashboard.html
+++ b/project/npda/templates/dashboard.html
@@ -1,14 +1,17 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
-<div class="flex flex-col justify-center px-10" >
+{% url 'dashboard' pz_code=pdu.pz_code as hx_get %}
+<div class="flex flex-col justify-center px-10" hx-get={{hx_get}} hx-trigger="dashboard from:body" hx-target="#dashboard">
     <div class="overflow-x-auto sm:-mx-6 lg:-mx-8">
       <div class="inline-block min-w-full py-2 sm:px-6 lg:px-8">
           <div class="relative overflow-x-auto">
             <div class="py-8 px-4 mx-auto max-w-screen-xl text-center lg:py-16 lg:px-12">
-                <strong>Dashboard for {{pdu.lead_organisation_name}}({{pdu.pz_code}} - {{pdu.parent_name}}) - {{pdu.paediatric_diabetes_network_name}}({{pdu.paediatric_diabetes_network_code}}) </strong>
+                <strong>Dashboard</strong>
             </div>
-                {% include "partials/kpi_table.html" with kpi_results=pdu_kpis pdu=pdu aggregation_level="Paediatric Diabetes Unit" %}
+            <div id="dashboard">
+                {% include "partials/kpi_table.html" with kpi_results=kpi_results pdu=pdu aggregation_level=aggregation_level %}
+            </div>
           </div>
         </div>
     </div>

--- a/project/npda/templates/nav.html
+++ b/project/npda/templates/nav.html
@@ -14,7 +14,7 @@
             <ul class="menu menu-horizontal px-1 flex items-center active:rounded-none">
                 {% if user.is_authenticated %}
                     <li class="ml-auto mr-2 flex items-center">
-                        <a href="{% url 'dashboard' pz_code=request.session.pz_code %}"
+                        <a href="{% url 'dashboard' %}"
                             class="text-xs block font-montserrat font-semibold py-2 pr-4 pl-3 text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent {% active_navbar_tab request 'submissions' %}"
                             aria-current="page">Dashboard</a>
                     </li>

--- a/project/npda/templates/nav.html
+++ b/project/npda/templates/nav.html
@@ -14,6 +14,11 @@
             <ul class="menu menu-horizontal px-1 flex items-center active:rounded-none">
                 {% if user.is_authenticated %}
                     <li class="ml-auto mr-2 flex items-center">
+                        <a href="{% url 'dashboard' pz_code=request.session.pz_code %}"
+                            class="text-xs block font-montserrat font-semibold py-2 pr-4 pl-3 text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent {% active_navbar_tab request 'submissions' %}"
+                            aria-current="page">Dashboard</a>
+                    </li>
+                    <li class="ml-auto mr-2 flex items-center">
                         <a href="{% url 'submissions' %}"
                             class="text-xs block font-montserrat font-semibold py-2 pr-4 pl-3 text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent {% active_navbar_tab request 'submissions' %}"
                             aria-current="page">Submissions</a>

--- a/project/npda/templates/partials/kpi_table.html
+++ b/project/npda/templates/partials/kpi_table.html
@@ -1,4 +1,4 @@
-<div class="w-100"></div>
+<div class="w-100">
 <strong>
     Key Performance Indicators for {{aggregation_level}} for {{pdu.lead_organisation_name}} ({{pdu.pz_code}} - {{pdu.parent_name}}) - {{pdu.paediatric_diabetes_network_name}} ({{pdu.paediatric_diabetes_network_code}})
 </strong>

--- a/project/npda/templates/partials/kpi_table.html
+++ b/project/npda/templates/partials/kpi_table.html
@@ -1,0 +1,58 @@
+<div class="w-100"></div>
+<strong>
+    Key Performance Indicators for {{aggregation_level}} for {{pdu.lead_organisation_name}} ({{pdu.pz_code}} - {{pdu.parent_name}}) - {{pdu.paediatric_diabetes_network_name}} ({{pdu.paediatric_diabetes_network_code}})
+</strong>
+<table class="table-auto w-full text-sm text-left text-gray-500 mb-5 font-montserrat">
+    <thead class="text-xs text-gray-700 uppercase bg-gray-50 bg-rcpch_dark_blue text-white">
+        <tr>
+            <th class="px-6 py-3">KPI</th>
+            <th class="px-6 py-3">Total Eligible</th>
+            <th class="px-6 py-3">Total Passed</th>
+            <th class="px-6 py-3">Total Failed</th>
+            <th class="px-6 py-3">Total Ineligible</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for kpi_key, kpi_value in kpi_results.calculated_kpi_values.items %}
+            {% if not kpi_key|slice:":6" == "kpi_32" %}
+                <tr class="bg-white border-b">
+                    <td class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">{{ kpi_value.kpi_label }}</td>
+                    <td class="px-6 py-4">{{ kpi_value.total_eligible }}</td>
+                    <td class="px-6 py-4">{{ kpi_value.total_passed }}</td>
+                    <td class="px-6 py-4">{{ kpi_value.total_failed }}</td>
+                    <td class="px-6 py-4">{{ kpi_value.total_ineligible }}</td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        <!-- Sub-rows for KPI 32 -->
+        <tr class="bg-white border-b">
+            <td class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap">KPI 32</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_eligible }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_passed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_failed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_ineligible }}</td>
+        </tr>
+        <tr class="bg-gray-50 border-b">
+            <td class="px-6 py-4 pl-12 font-medium text-gray-900 whitespace-nowrap">Care Process Completion Rate</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_eligible }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_passed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_failed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_1_health_check_completion_rate.total_ineligible }}</td>
+        </tr>
+        <tr class="bg-gray-50 border-b">
+            <td class="px-6 py-4 pl-12 font-medium text-gray-900 whitespace-nowrap">Health Check &lt; 12yo</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_2_health_check_lt_12yo.total_eligible }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_2_health_check_lt_12yo.total_passed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_2_health_check_lt_12yo.total_failed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_2_health_check_lt_12yo.total_ineligible }}</td>
+        </tr>
+        <tr class="bg-gray-50 border-b">
+            <td class="px-6 py-4 pl-12 font-medium text-gray-900 whitespace-nowrap">Health Check &gt;= 12yo</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_3_health_check_gte_12yo.total_eligible }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_3_health_check_gte_12yo.total_passed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_3_health_check_gte_12yo.total_failed }}</td>
+            <td class="px-6 py-4">{{ kpi_results.calculated_kpi_values.kpi_32_3_health_check_gte_12yo.total_ineligible }}</td>
+        </tr>
+    </tbody>
+</table>
+</div>

--- a/project/npda/tests/kpi_calculations/test_kpi_calculations.py
+++ b/project/npda/tests/kpi_calculations/test_kpi_calculations.py
@@ -62,7 +62,7 @@ def assert_kpi_result_equal(expected: KPIResult, actual: KPIResult) -> None:
 def test_ensure_mocked_audit_date_range_is_correct(AUDIT_START_DATE):
     """Ensure that the mocked audit date range is correct."""
     calc_kpis = CalculateKPIS(
-        pz_code="mocked_pz_code", calculation_date=AUDIT_START_DATE
+        pz_codes=["mocked_pz_code"], calculation_date=AUDIT_START_DATE
     )
 
     assert calc_kpis.audit_start_date == date(
@@ -85,7 +85,7 @@ def test_kpi_calculations_dont_break_when_no_patients(AUDIT_START_DATE):
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
     kpi_calculations_object = CalculateKPIS(
-        pz_code="PZ130", calculation_date=AUDIT_START_DATE
+        pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE
     ).calculate_kpis_for_patients()
 
     for kpi, results in kpi_calculations_object["calculated_kpi_values"].items():

--- a/project/npda/tests/kpi_calculations/test_kpis_13_20.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_13_20.py
@@ -79,7 +79,7 @@ def test_kpi_calculations_13_to_20(
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     # Dynamically get the kpi calc method based on treatment type
     #   `treatment` is an int between 1-8

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -45,7 +45,7 @@ def test_kpi_calculation_1(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -100,7 +100,7 @@ def test_kpi_calculation_2(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -156,7 +156,7 @@ def test_kpi_calculation_3(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -220,7 +220,7 @@ def test_kpi_calculation_4(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -319,7 +319,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -441,7 +441,7 @@ def test_kpi_calculation_6(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = len(observation_field_names) + 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -522,7 +522,7 @@ def test_kpi_calculation_7(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = len(observation_field_names)
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -584,7 +584,7 @@ def test_kpi_calculation_8(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -654,7 +654,7 @@ def test_kpi_calculation_9(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 4
@@ -717,7 +717,7 @@ def test_kpi_calculation_10(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -789,7 +789,7 @@ def test_kpi_calculation_11(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 2
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -852,7 +852,7 @@ def test_kpi_calculation_12(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3

--- a/project/npda/tests/kpi_calculations/test_kpis_21_23.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_21_23.py
@@ -64,7 +64,7 @@ def test_kpi_calculation_21(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -131,7 +131,7 @@ def test_kpi_calculation_22(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -200,7 +200,7 @@ def test_kpi_calculation_23(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2

--- a/project/npda/tests/kpi_calculations/test_kpis_24.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_24.py
@@ -105,7 +105,7 @@ def test_kpi_calculation_24(AUDIT_START_DATE):
         )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 8
     EXPECTED_TOTAL_INELIGIBLE = 8

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -116,7 +116,7 @@ def test_kpi_calculation_25(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -245,7 +245,7 @@ def test_kpi_calculation_26(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -366,7 +366,7 @@ def test_kpi_calculation_27(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -486,7 +486,7 @@ def test_kpi_calculation_28(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -604,7 +604,7 @@ def test_kpi_calculation_29(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -734,7 +734,7 @@ def test_kpi_calculation_30(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -851,7 +851,7 @@ def test_kpi_calculation_31(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -1044,7 +1044,7 @@ def test_kpi_calculation_32_1(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 18  # (2*3) + (2*6)
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -1208,7 +1208,7 @@ def test_kpi_calculation_32_2(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -1408,7 +1408,7 @@ def test_kpi_calculation_32_3(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -152,7 +152,7 @@ def test_kpi_calculation_33(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -285,7 +285,7 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -413,7 +413,7 @@ def test_kpi_calculation_35(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -528,7 +528,7 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -650,7 +650,7 @@ def test_kpi_calculation_37(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -773,7 +773,7 @@ def test_kpi_calculation_38(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -896,7 +896,7 @@ def test_kpi_calculation_39(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -981,7 +981,7 @@ def test_kpi_calculation_40(AUDIT_START_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 

--- a/project/npda/tests/kpi_calculations/test_kpis_41_43.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_41_43.py
@@ -127,7 +127,7 @@ def test_kpi_calculation_41(AUDIT_START_DATE, AUDIT_END_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -255,7 +255,7 @@ def test_kpi_calculation_42(AUDIT_START_DATE, AUDIT_END_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 
@@ -391,7 +391,7 @@ def test_kpi_calculation_43(AUDIT_START_DATE, AUDIT_END_DATE):
     )
 
     calc_kpis = CalculateKPIS(
-        pz_code="PZ130",
+        pz_codes=["PZ130"],
         calculation_date=AUDIT_START_DATE,
     )
 

--- a/project/npda/tests/kpi_calculations/test_kpis_44_49.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_44_49.py
@@ -119,7 +119,7 @@ def test_kpi_calculation_44(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     medians = list(map(calculate_median, [pt_1_hba1cs, pt_2_hba1cs]))
     EXPECTED_MEAN = sum(medians) / len(medians)
@@ -239,7 +239,7 @@ def test_kpi_calculation_45(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     medians = list(map(calculate_median, [pt_1_hba1cs, pt_2_hba1cs]))
     EXPECTED_MEDIAN = calculate_median(medians)
@@ -335,7 +335,7 @@ def test_kpi_calculation_46(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -428,7 +428,7 @@ def test_kpi_calculation_47(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -526,7 +526,7 @@ def test_kpi_calculation_48(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -624,7 +624,7 @@ def test_kpi_calculation_49(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_code="PZ130", calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 2

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -99,6 +99,11 @@ urlpatterns = [
     ),
     # KPI views
     path(
+        "paediatric_diabetes_unit/<str:pz_code>/dashboard",
+        view=dashboard,
+        name="dashboard",
+    ),
+    path(
         "kpis/aggregation/pdu/<str:pz_code>",
         view=KPIAggregationForPDU.as_view(),
         name="aggregation-pdu",

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -99,7 +99,7 @@ urlpatterns = [
     ),
     # KPI views
     path(
-        "paediatric_diabetes_unit/<str:pz_code>/dashboard",
+        "dashboard",
         view=dashboard,
         name="dashboard",
     ),

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -169,6 +169,7 @@ def dashboard(request, pz_code):
         )
         return render(request, "dashboard.html", {"pz_code": pz_code})
 
+    # accepts a list of PZ codes
     pdu_kpis = CalculateKPIS(
         pz_codes=[pz_code], calculation_date=datetime.date.today()
     )  # accepts a list of PZ codes

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -150,3 +150,12 @@ def view_preference(request):
         params={"method": "GET", "url": patients_list_view_url},
     )  # reloads the patients table
     return response
+
+
+@login_and_otp_required()
+def dashboard(request, pz_code):
+    """
+    Dashboard view for the KPIs.
+    """
+    context = {"pz_code": pz_code}
+    return render(request, "dashboard.html", context)

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -169,7 +169,9 @@ def dashboard(request, pz_code):
         )
         return render(request, "dashboard.html", {"pz_code": pz_code})
 
-    pdu_kpis = CalculateKPIS(pz_code=pz_code, calculation_date=datetime.date.today())
+    pdu_kpis = CalculateKPIS(
+        pz_codes=[pz_code], calculation_date=datetime.date.today()
+    )  # accepts a list of PZ codes
 
     context = {"pdu": pdu, "pdu_kpis": pdu_kpis.calculate_kpis_for_patients()}
     return render(request, "dashboard.html", context)

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -53,7 +53,7 @@ class PatientVisitsListView(
         # If the patient has left the PDU, the date_leaving_service will be set and it will be possible to view KPIs for the PDU up until transfer,
         # if this happened during the audit period. This is TODO
         kpi_results = CalculateKPIS(
-            pz_code=pdu.pz_code,
+            pz_codes=[pdu.pz_code],  # this is a list of one PZ code
             calculation_date=datetime.date.today(),
             patients=Patient.objects.filter(
                 pk=patient_id


### PR DESCRIPTION
### Overview
This sets up for next step to aggregate across regions
The `CalculateKPIS` class now accepts a list of pz_codes rather than just one, and this will allow us to pass in a list of PDUs within a region and retrieve a summary of the kpis across them all.

It also creates a new page called `dashboard` which has a table of the KPIs for the selected PDU, and in future will have further levels of abstraction. This reloads on changes in the `view_progress`