### PR TITLE
Anchit/kpis/implement-pdu-vs-patient-calc-methods

### DIFF
--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -14,7 +14,6 @@ class KPIResult:
 
 @dataclass
 class KPICalculationsObject:
-    pz_code: str
     calculation_datetime: datetime
     audit_start_date: date
     audit_end_date: date

--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -1,7 +1,7 @@
 # Object types
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Dict, Union
+from typing import Dict
 
 
 @dataclass
@@ -21,5 +21,5 @@ class KPICalculationsObject:
     total_patients_count: int
     calculated_kpi_values: Dict[
         str,
-        Union[KPIResult, str],
-    ] # looks like { 'kpi_name' : KPIResult OR "Not implemented"}
+        KPIResult,
+    ]

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -1,28 +1,23 @@
 # python imports
-from datetime import date
 import logging
-
-# django imports
-from django.apps import apps
-from django.core.exceptions import ValidationError
-from django import forms
-
-# third-party imports
-from dateutil.relativedelta import relativedelta
-from requests import RequestException
+from datetime import date
 
 # project imports
 import nhs_number
-from ..models import Patient
-from ...constants.styles.form_styles import *
-from ..general_functions import (
-    validate_postcode,
-    gp_ods_code_for_postcode,
-    gp_details_for_ods_code,
-    imd_for_postcode
-)
-from ..validators import not_in_the_future_validator
+# third-party imports
+from dateutil.relativedelta import relativedelta
+from django import forms
+# django imports
+from django.apps import apps
+from django.core.exceptions import ValidationError
+from requests import RequestException
 
+from ...constants.styles.form_styles import *
+from ..general_functions import (gp_details_for_ods_code,
+                                 gp_ods_code_for_postcode, imd_for_postcode,
+                                 validate_postcode)
+from ..models import Patient
+from ..validators import not_in_the_future_validator
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +29,7 @@ class DateInput(forms.DateInput):
 class NHSNumberField(forms.CharField):
     def to_python(self, value):
         number = super().to_python(value)
-        normalised = nhs_number.normalise_number(number)
+        normalised = nhs_number.standardise_format(number)
 
         # For some combinations we get back an empty string (eg '719-573 0220')
         return normalised or value
@@ -103,13 +98,13 @@ class PatientForm(forms.ModelForm):
                 )
 
         return date_of_birth
-    
+
     def clean_postcode(self):
         postcode = self.cleaned_data["postcode"]
 
         try:
             result = validate_postcode(postcode)
-            
+
             if not result:
                 self.add_error(
                     "postcode",

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -76,8 +76,6 @@ class CalculateKPIS:
         # Sets the KPI attribute names map
         self.kpis_names_map = self._get_kpi_attribute_names()
 
-
-
     def calculate_kpis_for_patients(
         self,
         patients: list[QuerySet[Patient]],
@@ -106,8 +104,8 @@ class CalculateKPIS:
             for KPI calculations and aggregations."""
 
         self.patients = Patient.objects.filter(
-                paediatric_diabetes_units__paediatric_diabetes_unit__pz_code__in=pz_codes
-            )
+            paediatric_diabetes_units__paediatric_diabetes_unit__pz_code__in=pz_codes
+        )
         self.total_patients_count = self.patients.count()
 
         return self._calculate_kpis()
@@ -155,7 +153,6 @@ class CalculateKPIS:
             )
 
         return return_obj
-
 
     def _get_audit_start_and_end_dates(self) -> tuple[date, date]:
         return get_audit_period_for_date(input_date=self.calculation_date)

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -758,7 +758,8 @@ class CalculateKPIS:
                     )
                 )
             )
-        )
+        ).distinct() # the reason for distinct is same as KPI1 (see comments).
+        # This time, was failing tests for KPI 41-42.
 
         # Count eligible patients
         total_eligible = eligible_patients.count()

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -343,7 +343,7 @@ class CalculateKPIS:
                 date_of_birth__gt=self.audit_start_date
                 - relativedelta(years=25)
             )
-        ).distinct() # When you filter on a related model field
+        ).distinct()  # When you filter on a related model field
         # (visit__visit_date__range), Django performs a join between the
         # Patient model and the Visit model. If a patient has multiple visits
         # that fall within the specified date range, the patient will appear
@@ -758,7 +758,7 @@ class CalculateKPIS:
                     )
                 )
             )
-        ).distinct() # the reason for distinct is same as KPI1 (see comments).
+        ).distinct()  # the reason for distinct is same as KPI1 (see comments).
         # This time, was failing tests for KPI 41-42.
 
         # Count eligible patients
@@ -3301,27 +3301,3 @@ def queryset_median_value(queryset: QuerySet, column_name: str):
         return values[int(round(count / 2))]
     else:
         return sum(values[count / 2 - 1 : count / 2 + 1]) / Decimal(2.0)
-
-
-# WIP simply return KPI Agg result for given PDU
-class KPIAggregationForPDU(TemplateView):
-
-    template_name = "kpi_aggregations.html"
-
-    def get(self, request, *args, **kwargs):
-
-        pz_code = kwargs.get("pz_code", None)
-
-        start_time = time.time()  # Record the start time for calc
-        aggregated_data = CalculateKPIS(
-            pz_codes=[pz_code]
-        ).calculate_kpis_for_patients()
-        end_time = time.time()  # Record the end time
-        calculation_time = round(
-            (end_time - start_time) * 1000, 2
-        )  # Calculate the time taken in milliseconds, rounded to 2dp
-
-        # Add to context
-        aggregated_data["calculation_time"] = calculation_time
-
-        return render(request, self.template_name, context=aggregated_data)

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -342,7 +342,11 @@ class CalculateKPIS:
                 date_of_birth__gt=self.audit_start_date
                 - relativedelta(years=25)
             )
-        )
+        ).distinct() # When you filter on a related model field
+        # (visit__visit_date__range), Django performs a join between the
+        # Patient model and the Visit model. If a patient has multiple visits
+        # that fall within the specified date range, the patient will appear
+        # multiple times in the filtered queryset—once for each matching visit.
 
         # Count eligible patients and set as attribute
         # to be used in subsequent KPI calculations

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -78,13 +78,13 @@ class CalculateKPIS:
 
     def calculate_kpis_for_patients(
         self,
-        patients: list[QuerySet[Patient]],
+        patients: QuerySet[Patient],
     ) -> KPICalculationsObject:
         """Calculate KPIs 1 - 49 for given patients and cohort range
         (self.audit_start_date and self.audit_end_date).
 
         Params:
-            * patients (list[QuerySet[Patient]]) - List of patients
+            * patients (QuerySet[Patient]) - Queryset of patients
             for KPI calculations and aggregations."""
 
         self.patients = patients

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -51,7 +51,7 @@ class CalculateKPIS:
             audit period
 
         Exposes 2 methods:
-            1) calculate_kpis_for_patients (list[QuerySet[Patient]])
+            1) calculate_kpis_for_patients (QuerySet[Patient])
                 - Calculate KPIs for given patients.
             2) calculate_kpis_for_pdus (list[str])
                 - Calculate KPIs for given PZ codes.
@@ -60,7 +60,8 @@ class CalculateKPIS:
             `self.total_patients_count` attributes used throughout all
             calculations.
 
-            Both methods return a KPICalculationsObject dataclass instance.
+            Both methods return a KPICalculationsObject dataclass instance,
+            containing all KPIAggregation results.
         """
 
         # Set various attributes used in calculations

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -46,7 +46,7 @@ class CalculateKPIS:
     ):
         """Calculates KPIs for given pz_code
 
-        Params:
+        Initialise with:
             * calculation_date (date) - used to define start and end date of
             audit period
 

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from pytest_factoryboy import register
 
 # rcpch imports
+from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.tests.factories import (NPDAUserFactory,
                                           OrganisationEmployerFactory,
                                           PaediatricsDiabetesUnitFactory,
@@ -32,19 +33,30 @@ register(OrganisationEmployerFactory)  # => npdauser_factory
 register(PaediatricsDiabetesUnitFactory)  # => npdauser_factory
 register(TransferFactory)  # => npdauser_factory
 
+
 @pytest.fixture(autouse=True)
 def patch_imd_for_postcode():
     """Automatically patch `imd_for_postcode` for all tests."""
-    with patch('project.npda.models.patient.imd_for_postcode', return_value=4) as mocked_imd_for_postcode:
+    with patch(
+        "project.npda.models.patient.imd_for_postcode", return_value=4
+    ) as mocked_imd_for_postcode:
         logger.debug("Patching imd_for_postcode")
         yield
+
 
 @pytest.fixture
 def AUDIT_START_DATE():
     """AUDIT_START_DATE is Day 2 of the first audit period"""
     return date(year=2024, month=4, day=1)
 
+
 @pytest.fixture
 def AUDIT_END_DATE():
     """AUDIT_END_DATE"""
     return date(year=2025, month=3, day=31)
+
+
+@pytest.fixture
+def CALCULATE_KPIS_OBJECT_AUDIT_START(AUDIT_START_DATE):
+    """Calculate KPIS object initialised with the audit start date"""
+    return CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -13,7 +13,6 @@ import pytest
 from pytest_factoryboy import register
 
 # rcpch imports
-from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.tests.factories import (NPDAUserFactory,
                                           OrganisationEmployerFactory,
                                           PaediatricsDiabetesUnitFactory,
@@ -33,30 +32,19 @@ register(OrganisationEmployerFactory)  # => npdauser_factory
 register(PaediatricsDiabetesUnitFactory)  # => npdauser_factory
 register(TransferFactory)  # => npdauser_factory
 
-
 @pytest.fixture(autouse=True)
 def patch_imd_for_postcode():
     """Automatically patch `imd_for_postcode` for all tests."""
-    with patch(
-        "project.npda.models.patient.imd_for_postcode", return_value=4
-    ) as mocked_imd_for_postcode:
+    with patch('project.npda.models.patient.imd_for_postcode', return_value=4) as mocked_imd_for_postcode:
         logger.debug("Patching imd_for_postcode")
         yield
-
 
 @pytest.fixture
 def AUDIT_START_DATE():
     """AUDIT_START_DATE is Day 2 of the first audit period"""
     return date(year=2024, month=4, day=1)
 
-
 @pytest.fixture
 def AUDIT_END_DATE():
     """AUDIT_END_DATE"""
     return date(year=2025, month=3, day=31)
-
-
-@pytest.fixture
-def CALCULATE_KPIS_OBJECT_AUDIT_START(AUDIT_START_DATE):
-    """Calculate KPIS object initialised with the audit start date"""
-    return CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)

--- a/project/npda/tests/kpi_calculations/test_kpis_13_20.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_13_20.py
@@ -7,9 +7,8 @@ from project.constants.diabetes_treatment import TREATMENT_TYPES
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 # Set up test params for kpis 13-20, as they all have the same denominator
 # and the only thing being changed is value for visit__treatment
@@ -79,7 +78,10 @@ def test_kpi_calculations_13_to_20(
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     # Dynamically get the kpi calc method based on treatment type
     #   `treatment` is an int between 1-8

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -10,9 +10,8 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 
 @pytest.mark.django_db
@@ -45,7 +44,10 @@ def test_kpi_calculation_1(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -100,7 +102,10 @@ def test_kpi_calculation_2(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -156,7 +161,10 @@ def test_kpi_calculation_3(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -220,7 +228,10 @@ def test_kpi_calculation_4(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=N_PATIENTS_ELIGIBLE,
@@ -319,7 +330,10 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -441,7 +455,10 @@ def test_kpi_calculation_6(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = len(observation_field_names) + 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -522,7 +539,10 @@ def test_kpi_calculation_7(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = len(observation_field_names)
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -584,7 +604,10 @@ def test_kpi_calculation_8(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -654,7 +677,10 @@ def test_kpi_calculation_9(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 4
@@ -717,7 +743,10 @@ def test_kpi_calculation_10(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -789,7 +818,10 @@ def test_kpi_calculation_11(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 2
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -852,7 +884,10 @@ def test_kpi_calculation_12(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 1
     EXPECTED_TOTAL_INELIGIBLE = 3

--- a/project/npda/tests/kpi_calculations/test_kpis_21_23.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_21_23.py
@@ -6,9 +6,8 @@ from dateutil.relativedelta import relativedelta
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 
 @pytest.mark.django_db
@@ -64,7 +63,10 @@ def test_kpi_calculation_21(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -131,7 +133,10 @@ def test_kpi_calculation_22(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -200,7 +205,10 @@ def test_kpi_calculation_23(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 6
     EXPECTED_TOTAL_INELIGIBLE = 2

--- a/project/npda/tests/kpi_calculations/test_kpis_24.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_24.py
@@ -6,9 +6,8 @@ from dateutil.relativedelta import relativedelta
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 
 @pytest.mark.django_db
@@ -105,7 +104,10 @@ def test_kpi_calculation_24(AUDIT_START_DATE):
         )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 8
     EXPECTED_TOTAL_INELIGIBLE = 8

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -1025,7 +1025,6 @@ def test_kpi_calculation_32_1(AUDIT_START_DATE):
     )
 
     # Create Patients and Visits that should be ineligble
-    # Create Patients and Visits that should be ineligble
     # Visit date before audit period
     ineligible_patient_visit_date = PatientFactory(
         postcode="ineligible_patient_visit_date",
@@ -1069,6 +1068,7 @@ def test_kpi_calculation_32_1(AUDIT_START_DATE):
     # Need to be mocked as not using public `calculate_kpis_for_*` methods
     calc_kpis.patients = Patient.objects.all()
     calc_kpis.total_patients_count = Patient.objects.count()
+
 
     EXPECTED_TOTAL_ELIGIBLE = 18  # (2*3) + (2*6)
     EXPECTED_TOTAL_INELIGIBLE = 5

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -5,14 +5,14 @@ from dateutil.relativedelta import relativedelta
 
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.constants.hba1c_format import HBA1C_FORMATS
-from project.constants.retinal_screening_results import RETINAL_SCREENING_RESULTS
+from project.constants.retinal_screening_results import \
+    RETINAL_SCREENING_RESULTS
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 
 @pytest.mark.django_db
@@ -116,7 +116,10 @@ def test_kpi_calculation_25(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -245,7 +248,10 @@ def test_kpi_calculation_26(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -366,7 +372,10 @@ def test_kpi_calculation_27(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -486,7 +495,10 @@ def test_kpi_calculation_28(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -604,7 +616,10 @@ def test_kpi_calculation_29(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -734,7 +749,10 @@ def test_kpi_calculation_30(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -851,7 +869,10 @@ def test_kpi_calculation_31(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -1044,7 +1065,10 @@ def test_kpi_calculation_32_1(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 18  # (2*3) + (2*6)
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -1208,7 +1232,10 @@ def test_kpi_calculation_32_2(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -1408,7 +1435,10 @@ def test_kpi_calculation_32_3(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -11,9 +11,8 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 
 @pytest.mark.django_db
@@ -151,10 +150,11 @@ def test_kpi_calculation_33(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -284,10 +284,11 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -412,10 +413,11 @@ def test_kpi_calculation_35(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -527,10 +529,11 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -649,10 +652,11 @@ def test_kpi_calculation_37(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -772,10 +776,11 @@ def test_kpi_calculation_38(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -895,10 +900,11 @@ def test_kpi_calculation_39(AUDIT_START_DATE):
         death_date=AUDIT_START_DATE + relativedelta(days=2),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 5
@@ -980,10 +986,11 @@ def test_kpi_calculation_40(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 26),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
     EXPECTED_TOTAL_INELIGIBLE = 2

--- a/project/npda/tests/kpi_calculations/test_kpis_41_43.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_41_43.py
@@ -12,9 +12,8 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -126,10 +125,11 @@ def test_kpi_calculation_41(AUDIT_START_DATE, AUDIT_END_DATE):
         visit__coeliac_screen_date=AUDIT_END_DATE - relativedelta(days=90),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -254,10 +254,11 @@ def test_kpi_calculation_42(AUDIT_START_DATE, AUDIT_END_DATE):
         visit__thyroid_function_date=AUDIT_END_DATE - relativedelta(days=90),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3
@@ -390,10 +391,11 @@ def test_kpi_calculation_43(AUDIT_START_DATE, AUDIT_END_DATE):
         - relativedelta(days=14),
     )
 
-    calc_kpis = CalculateKPIS(
-        pz_codes=["PZ130"],
-        calculation_date=AUDIT_START_DATE,
-    )
+    # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 3

--- a/project/npda/tests/kpi_calculations/test_kpis_44_49.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_44_49.py
@@ -8,16 +8,16 @@ from dateutil.relativedelta import relativedelta
 
 from project.constants.albuminuria_stage import ALBUMINURIA_STAGES
 from project.constants.diabetes_types import DIABETES_TYPES
-from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REASONS
+from project.constants.hospital_admission_reasons import \
+    HOSPITAL_ADMISSION_REASONS
 from project.constants.smoking_status import SMOKING_STATUS
 from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
-    assert_kpi_result_equal,
-)
+from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+    assert_kpi_result_equal
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -119,7 +119,10 @@ def test_kpi_calculation_44(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     medians = list(map(calculate_median, [pt_1_hba1cs, pt_2_hba1cs]))
     EXPECTED_MEAN = sum(medians) / len(medians)
@@ -239,7 +242,10 @@ def test_kpi_calculation_45(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     medians = list(map(calculate_median, [pt_1_hba1cs, pt_2_hba1cs]))
     EXPECTED_MEDIAN = calculate_median(medians)
@@ -335,7 +341,10 @@ def test_kpi_calculation_46(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -428,7 +437,10 @@ def test_kpi_calculation_47(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 4
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -526,7 +538,10 @@ def test_kpi_calculation_48(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 2
@@ -624,7 +639,10 @@ def test_kpi_calculation_49(AUDIT_START_DATE):
     )
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
-    calc_kpis = CalculateKPIS(pz_codes=["PZ130"], calculation_date=AUDIT_START_DATE)
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    # Need to be mocked as not using public `calculate_kpis_for_*` methods
+    calc_kpis.patients = Patient.objects.all()
+    calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 5
     EXPECTED_TOTAL_INELIGIBLE = 2

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -14,21 +14,18 @@ Tests for NPDAUser model actions.
 - NPDAUser can be reactivated.
 """
 
-# Python imports
-import pytest
 import logging
 from http import HTTPStatus
 
+# Python imports
+import pytest
 # 3rd party imports
 from django.urls import reverse
-from django.test import Client
 
+from project.constants.user import RCPCH_AUDIT_TEAM
 # E12 imports
 from project.npda.models import NPDAUser
 from project.npda.tests.utils import login_and_verify_user
-from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
-from project.npda.views.npda_users import NPDAUserListView
-from project.constants.user import RCPCH_AUDIT_TEAM
 
 logger = logging.getLogger(__name__)
 

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -1,17 +1,11 @@
-from django.urls import path, include
-from django.contrib.auth.views import PasswordResetConfirmView
 from django.contrib.auth import urls as auth_urls
-from project.npda.kpi_class.kpis import KPIAggregationForPDU
-from project.npda.views import (
-    VisitCreateView,
-    VisitDeleteView,
-    VisitUpdateView,
-    PatientListView,
-    PatientVisitsListView,
-    SubmissionsListView,
-)
+from django.contrib.auth.views import PasswordResetConfirmView
+from django.urls import include, path
+
 from project.npda.forms.npda_user_form import NPDAUpdatePasswordForm
-from project.npda.general_functions.csv_download import download_csv
+from project.npda.views import (PatientListView, PatientVisitsListView,
+                                SubmissionsListView, VisitCreateView,
+                                VisitDeleteView, VisitUpdateView)
 
 from .views import *
 
@@ -102,10 +96,5 @@ urlpatterns = [
         "dashboard",
         view=dashboard,
         name="dashboard",
-    ),
-    path(
-        "kpis/aggregation/pdu/<str:pz_code>",
-        view=KPIAggregationForPDU.as_view(),
-        name="aggregation-pdu",
     ),
 ]

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -9,16 +9,18 @@ from django.forms import BaseModelForm
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
 from django.views.generic import ListView
-from django.views.generic.edit import CreateView, UpdateView, DeleteView
-
-# Third party imports
+from django.views.generic.edit import CreateView, DeleteView, UpdateView
 
 # RCPCH imports
 from ..forms.visit_form import VisitForm
 from ..general_functions import get_visit_categories
 from ..kpi_class.kpis import CalculateKPIS
-from .mixins import CheckPDUListMixin, LoginAndOTPRequiredMixin, CheckPDUInstanceMixin
-from ..models import Visit, Patient, Transfer
+from ..models import Patient, Transfer, Visit
+from .mixins import (CheckPDUInstanceMixin, CheckPDUListMixin,
+                     LoginAndOTPRequiredMixin)
+
+# Third party imports
+
 
 
 class PatientVisitsListView(
@@ -52,14 +54,15 @@ class PatientVisitsListView(
         # get the PDU for this patient - this is the PDU that the patient is currently under.
         # If the patient has left the PDU, the date_leaving_service will be set and it will be possible to view KPIs for the PDU up until transfer,
         # if this happened during the audit period. This is TODO
-        kpi_results = CalculateKPIS(
-            pz_codes=[pdu.pz_code],  # this is a list of one PZ code
-            calculation_date=datetime.date.today(),
-            patients=Patient.objects.filter(
-                pk=patient_id
-            ),  # this is a queryset of one patient
-        ).calculate_kpis_for_patients()
-        context["kpi_results"] = kpi_results
+
+        calculate_kpis = CalculateKPIS(calculation_date=datetime.date.today())
+        # calculate_kpis_for_patients expects a queryset of patients, so
+        # convert patient object to a queryset
+        patient_as_queryset = Patient.objects.filter(pk=patient.pk)
+        kpi_calculations_object = calculate_kpis.calculate_kpis_for_patients(
+            patients=patient_as_queryset
+        )
+        context["kpi_results"] = kpi_calculations_object
 
         return context
 


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview
Refactors the `CalculateKPIS` class to expose 2 separate methods for calculating kpis.

1. `calculate_kpis_for_patients` which takes in a queryset of patients
2. `calculate_kpis_for_pdus` which takes in a list of str (pz_codes)

The both work to set the `self.patients` attribute in different ways, and then run the same calculation method. Both return the same resulting calculations object

### Code changes
- refactors `CalculateKPIS` to expose 2 methods
- updates views using the class appropriately
- fix all tests which broke due to new interface
- removes old KPI view just used for debugging calcs

### Documentation changes (done or required as a result of this PR)
nil

### Related Issues
#308 
#287 

### Mentions
@mentions of the person or team responsible for reviewing proposed changes.
