### PR TITLE
Option to add Caddy's SSL cert to trust store in WSL2 environments

### DIFF
--- a/s/trust-caddy-ca
+++ b/s/trust-caddy-ca
@@ -13,6 +13,7 @@ echo "Select your operating system:"
 echo "1. Windows"
 echo "2. Linux"
 echo "3. macOS"
+echo "4. WSL2 (run from within a WSL2 terminal)"
 
 # Read user's choice
 read -p "Enter the number of your choice: " choice
@@ -42,6 +43,15 @@ case $choice in
     /tmp/root.crt &&
     sudo security add-trusted-cert -d -r trustRoot \
       -k /Library/Keychains/System.keychain /tmp/root.crt
+  ;;
+4)
+  echo "You chose WSL2."
+  export WINTEMP=$(wslpath $(cmd.exe /C "echo %TEMP%" 2>/dev/null | tr -d '\r'))
+  export USERNAME=$(wslpath $(cmd.exe /C "echo %USERNAME%" 2>/dev/null | tr -d '\r'))
+  echo "Windows temp directory (automatically found): ${WINTEMP}"
+  echo "Logged in Windows user (automatically found): ${USERNAME}"
+  docker compose cp caddy:"/data/caddy/pki/authorities/local/root.crt" "${WINTEMP}/root.crt"
+  runas.exe /user:${USERNAME} "cmd.exe /C %CD%\certutil -addstore -f "ROOT" %TEMP%/root.crt %CD%"
   ;;
 *)
   echo "Invalid choice. Please select a valid option (1, 2, or 3)."


### PR DESCRIPTION
This pull request includes updates to the `s/trust-caddy-ca` script to add support for WSL2. The most important changes include adding a new option for WSL2 in the operating system selection menu and handling the WSL2-specific certificate installation process.

Support for WSL2:

* [`s/trust-caddy-ca`](diffhunk://#diff-60951a97945449aee28579b5619394d814d7e02cd43440302260c8508a83aef7R16): Added an option for WSL2 in the operating system selection menu.
* [`s/trust-caddy-ca`](diffhunk://#diff-60951a97945449aee28579b5619394d814d7e02cd43440302260c8508a83aef7R47-R55): Implemented the certificate installation process for WSL2, including finding the Windows temp directory and logged-in user, copying the certificate using Docker, and adding the certificate to the Windows certificate store.