### PR TITLE
[KPIs] Adds `calculate_kpis_for_single_patient` method, `calculate_kpis_for_single_patient`, and documentation for usage

### DIFF
--- a/documentation/docs/developer/kpis/kpi_class.md
+++ b/documentation/docs/developer/kpis/kpi_class.md
@@ -1,0 +1,180 @@
+# KPI Class
+
+## `CalculateKPIS`
+The entrypoint for everything relevant to KPIs _should_ be the `CalculateKPIS`
+class. Missing functionality should be added to this class.
+
+This class is responsible for calculating all KPIs for a given subset of of patients, set through its `self.patients` attribute. There are various methods used to calculate KPIs for different abstractions (e.g. `calculate_kpis_for_single_patient` vs `calculate_kpis_for_pdus`), but each method is a wrapper that works to set the `self.patients` attribute, and then they all call the `_calculate_kpis` method.
+
+### Initialisation
+
+To initialise an instance of the `CalculateKPIS` class, you can pass in optional parameters to define the audit period and whether to return patient querysets as part of the KPI calculations.
+
+**Parameters**
+
+- `calculation_date` (`date`, optional):
+   The date used to define the start and end dates of the audit period, used throughout calculations. If no date is provided, the current date is used as the default.
+
+- `return_pt_querysets` (`bool`, optional):
+   If set to `True`, the calculated KPIs will include patient querysets used during the KPI calculation. The default is `False`.
+
+```python
+from datetime import date
+from project.npda.kpi_class.kpis import CalculateKPIS
+
+# Initialise with default parameters
+kpi_calculator = CalculateKPIS()
+
+# Example 2: Initialise with a specific audit date
+calculation_date = date(2023, 1, 1)
+kpi_calculator_SPECIFIC_DATE = CalculateKPIS(calculation_date=calculation_date)
+```
+
+### Calculation methods
+
+We can then use one of the `calculate_kpis_for_` methods to calculate KPIs:
+
+1) `calculate_kpis_for_patients` (QuerySet[Patient])
+    - Calculate KPIs for given patients.
+2) `calculate_kpis_for_pdus` (list[str])
+    - Calculate KPIs for given PZ codes.
+3) `calculate_kpis_for_single_patient` (Patient)
+    - Calculate KPIs for a single patient. Runs all calculations (required as KPIs 1-12 are used as denominators for subsequent KPIs) but returns a subset relevant to a single patient.
+
+All `calculate_` methods return a `KPICalculationsObject`. This is used to represent the results of  calculations across the specified audit period. It contains information about the audit dates, the total number of patients involved, and the calculated KPI results. It looks like:
+
+```python
+@dataclass
+class KPICalculationsObject:
+    calculation_datetime: datetime
+    audit_start_date: date
+    audit_end_date: date
+    total_patients_count: int
+    calculated_kpi_values: Dict[
+        str,
+        KPIResult,
+    ]
+```
+
+Actual calculation results can be retrieved using the `calculated_kpi_values` key.
+
+This is a dictionary where the key is the KPI name and the value is a `KPIResult` object. This object contains the calculated KPI value and the patient querysets used during the calculation (if `return_pt_querysets` was set to `True` during `CalculateKPIS` initialisation).
+
+The KPI name for keys comes from [`kpi_name_registry`](#kpi_name_registry) (described later). The values are `KPIResult` objects that look like:
+
+```python
+@dataclass
+class KPIResult:
+    """
+    Example would be:
+
+    `return_patient_querysets` == False
+    {
+        'total_eligible': 100,
+        'total_ineligible': 50,
+        'total_passed': 75,
+        'total_failed': 25,
+        'patient_querysets': None
+    }
+
+    `return_patient_querysets` == True
+    {
+        'total_eligible': 100,
+        'total_ineligible': 50,
+        'total_passed': 75,
+        'total_failed': 25,
+        'patient_querysets': {
+            'eligible': <QuerySet[Patient]>,
+            'ineligible': <QuerySet[Patient]>,
+            'passed': <QuerySet[Patient]>,
+            'failed': <QuerySet[Patient]>,
+        }
+    }
+    """
+
+    total_eligible: int
+    total_ineligible: int
+    total_passed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
+    total_failed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
+    kpi_label: str = "KPI Name not found"
+    patient_querysets: Union[Dict[str, QuerySet[Patient]], None] = None
+```
+
+### Example usage
+
+```python
+class PatientVisitsListView(
+    ...
+):
+    ...
+
+    def get_context_data(self, **kwargs):
+        patient_id = self.kwargs.get("patient_id")
+        context = super(PatientVisitsListView, self).get_context_data(**kwargs)
+        patient = Patient.objects.get(pk=patient_id)
+
+        ...
+
+        calculate_kpis = CalculateKPIS(
+            calculation_date=datetime.date.today(), return_pt_querysets=False
+        )
+
+        # Calculate the KPIs for this patient, returning only subset relevant
+        # for a single patient's calculation
+        kpi_calculations_object = calculate_kpis.calculate_kpis_for_single_patient(patient)
+
+        context["kpi_results"] = kpi_calculations_object
+
+        return context
+```
+
+## `kpi_name_registry`
+
+The `CalculateKPIS` object has a `.kpi_name_registry` attribute that can be used to access both attribute names and rendered label names for each KPI.
+
+The benefit of using this registry is that it allows for a single source of truth for KPI names, which can be used throughout the application. This is particularly useful when needing to access KPI names in multiple places, such as in the frontend and backend.
+
+It exposes the following methods:
+
+- `get_kpi(self, number: int) -> KPINames` which returns a `KPINames` object for the given KPI number:
+
+```python
+@dataclass
+class KPINames:
+    attribute_name: str  # e.g. kpi_32_1_health_check_completion_rate
+    rendered_label: str  # e.g. Care Processes Completion Rate
+```
+
+- `get_attribute_name(self, number: int) -> str` which returns the attribute name for the given KPI number
+
+
+- `get_rendered_label(self, number: int) -> str` which returns the rendered label name for the given KPI number
+
+### Example usage
+
+```python
+@pytest.mark.django_db
+def test_ensure_calculate_kpis_for_patient_returns_correct_kpi_subset(AUDIT_START_DATE):
+    """Tests that the `calculate_kpis_for_single_patient()` method
+    returns the correct subset of KPIs for a single patient.
+    """
+    kpi_calculator = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+
+    kpi_calc_obj = kpi_calculator.calculate_kpis_for_single_patient(
+        PatientFactory(),
+    )
+
+    kpi_results_obj = kpi_calc_obj["calculated_kpi_values"].keys()
+
+    # Check that the KPIs are a subset of the full KPI list
+    EXPECTED_KPIS_SUBSET = list(range(13, 32)) + [321, 322, 323] + (list(range(33, 50)))
+    EXPECTED_KPI_KEYS = [
+        kpi_calculator.kpi_name_registry.get_attribute_name(i)
+        for i in EXPECTED_KPIS_SUBSET
+    ]
+
+    for expected_kpi_key in EXPECTED_KPI_KEYS:
+        assert (
+            expected_kpi_key in kpi_results_obj
+        ), f"Expected KPI {expected_kpi_key} in single patient subset, but not present in results"
+```

--- a/documentation/docs/developer/kpis/kpi_definitions.md
+++ b/documentation/docs/developer/kpis/kpi_definitions.md
@@ -1,0 +1,1 @@
+# Need to add definitions

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -147,3 +147,7 @@ nav:
     - 'developer/organisations.md'
     - 'developer/users.md'
     - 'developer/testing.md'
+    - KPIs:
+      # - KPI Definitions: 'developer/kpis/kpi_definitions.md'
+      - KPI Class: 'developer/kpis/kpi_class.md'
+      # - Tests: 'developer/kpis/tests.md'

--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -41,7 +41,7 @@ class KPIResult:
     total_ineligible: int
     total_passed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
     total_failed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
-    kpi_label: str
+    kpi_label: str = "KPI Name not found"
     patient_querysets: Union[Dict[str, QuerySet[Patient]], None] = None
 
 

--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -54,3 +54,279 @@ class KPICalculationsObject:
         str,
         KPIResult,
     ]
+
+
+"""
+Hard coding these for simplicty and readability
+
+KPIS
+1-12
+    - used as denominators for subsequent
+13-20
+    - treatment regimen
+21-23
+    - glucose monitoring
+24
+    - Hybrid closed loop system (HCL)
+25-32
+    - 7 key processes
+33-40
+    - additional processes
+41-43
+    - care at diagnosis
+44-49
+    - outcomes
+"""
+KPI_ATTRIBUTE_LABEL_MAP = {
+    1: {
+        "attribute_name": "kpi_1_total_eligible",
+        "rendered_label": "Total number of eligible patients",
+    },
+    2: {
+        "attribute_name": "kpi_2_total_new_diagnoses",
+        "rendered_label": "Total number of new diagnoses within the audit period",
+    },
+    3: {
+        "attribute_name": "kpi_3_total_t1dm",
+        "rendered_label": "Total number of eligible patients with Type 1 diabetes",
+    },
+    4: {
+        "attribute_name": "kpi_4_total_t1dm_gte_12yo",
+        "rendered_label": "Number of patients aged 12+ with Type 1 diabetes",
+    },
+    5: {
+        "attribute_name": "kpi_5_total_t1dm_complete_year",
+        "rendered_label": "Total number of patients with T1DM who have completed a year of care",
+    },
+    6: {
+        "attribute_name": "kpi_6_total_t1dm_complete_year_gte_12yo",
+        "rendered_label": "Total number of patients with T1DM who have completed a year of care and are aged 12 or older",
+    },
+    7: {
+        "attribute_name": "kpi_7_total_new_diagnoses_t1dm",
+        "rendered_label": "Total number of new diagnoses of T1DM",
+    },
+    8: {
+        "attribute_name": "kpi_8_total_deaths",
+        "rendered_label": "Number of patients who died within audit period",
+    },
+    9: {
+        "attribute_name": "kpi_9_total_service_transitions",
+        "rendered_label": "Number of patients who transitioned/left service within audit period",
+    },
+    10: {
+        "attribute_name": "kpi_10_total_coeliacs",
+        "rendered_label": "Total number of coeliacs",
+    },
+    11: {
+        "attribute_name": "kpi_11_total_thyroids",
+        "rendered_label": "Number of patients with thyroid disease",
+    },
+    12: {
+        "attribute_name": "kpi_12_total_ketone_test_equipment",
+        "rendered_label": "Number of patients with ketone test equipment",
+    },
+    13: {
+        "attribute_name": "kpi_13_one_to_three_injections_per_day",
+        "rendered_label": "Number of patients on one to three injections per day",
+    },
+    14: {
+        "attribute_name": "kpi_14_four_or_more_injections_per_day",
+        "rendered_label": "Number of patients on four or more injections per day",
+    },
+    15: {
+        "attribute_name": "kpi_15_insulin_pump",
+        "rendered_label": "Number of patients on insulin pump",
+    },
+    16: {
+        "attribute_name": "kpi_16_one_to_three_injections_plus_other_medication",
+        "rendered_label": "Number of patients on one to three injections plus other medication",
+    },
+    17: {
+        "attribute_name": "kpi_17_four_or_more_injections_plus_other_medication",
+        "rendered_label": "Number of patients on four or more injections plus other medication",
+    },
+    18: {
+        "attribute_name": "kpi_18_insulin_pump_plus_other_medication",
+        "rendered_label": "Number of patients on insulin pump plus other medication",
+    },
+    19: {
+        "attribute_name": "kpi_19_dietary_management_alone",
+        "rendered_label": "Number of patients on dietary management alone",
+    },
+    20: {
+        "attribute_name": "kpi_20_dietary_management_plus_other_medication",
+        "rendered_label": "Number of patients on dietary management plus other medication",
+    },
+    21: {
+        "attribute_name": "kpi_21_flash_glucose_monitor",
+        "rendered_label": "Number of patients on flash glucose monitor",
+    },
+    22: {
+        "attribute_name": "kpi_22_real_time_cgm_with_alarms",
+        "rendered_label": "Number of patients on real-time CGM with alarms",
+    },
+    23: {
+        "attribute_name": "kpi_23_type1_real_time_cgm_with_alarms",
+        "rendered_label": "Number of patients on Type 1 real-time CGM with alarms",
+    },
+    24: {
+        "attribute_name": "kpi_24_hybrid_closed_loop_system",
+        "rendered_label": "Number of patients on hybrid closed loop system",
+    },
+    25: {
+        "attribute_name": "kpi_25_hba1c",
+        "rendered_label": "Number of patients with HbA1c",
+    },
+    26: {
+        "attribute_name": "kpi_26_bmi",
+        "rendered_label": "Number of patients with BMI",
+    },
+    27: {
+        "attribute_name": "kpi_27_thyroid_screen",
+        "rendered_label": "Number of patients with thyroid screen",
+    },
+    28: {
+        "attribute_name": "kpi_28_blood_pressure",
+        "rendered_label": "Number of patients with blood pressure",
+    },
+    29: {
+        "attribute_name": "kpi_29_urinary_albumin",
+        "rendered_label": "Number of patients with urinary albumin",
+    },
+    30: {
+        "attribute_name": "kpi_30_retinal_screening",
+        "rendered_label": "Number of patients with retinal screening",
+    },
+    31: {
+        "attribute_name": "kpi_31_foot_examination",
+        "rendered_label": "Number of patients with foot examination",
+    },
+    321: {
+        "attribute_name": "kpi_32_1_health_check_completion_rate",
+        "rendered_label": "Care processes completion rate",
+    },
+    322: {
+        "attribute_name": "kpi_32_2_health_check_lt_12yo",
+        "rendered_label": "Care processes in patients < 12 years old",
+    },
+    323: {
+        "attribute_name": "kpi_32_3_health_check_gte_12yo",
+        "rendered_label": "Care processes in patients ≥ 12 years old",
+    },
+    33: {
+        "attribute_name": "kpi_33_hba1c_4plus",
+        "rendered_label": "Number of patients with 4 or more HbA1c measurements",
+    },
+    34: {
+        "attribute_name": "kpi_34_psychological_assessment",
+        "rendered_label": "Number of patients offered a psychological assessment",
+    },
+    35: {
+        "attribute_name": "kpi_35_smoking_status_screened",
+        "rendered_label": "Number of patients asked about smoking status",
+    },
+    36: {
+        "attribute_name": "kpi_36_referral_to_smoking_cessation_service",
+        "rendered_label": "Number of patients referred to a smoking cessation service",
+    },
+    37: {
+        "attribute_name": "kpi_37_additional_dietetic_appointment_offered",
+        "rendered_label": "Number of patients offered an additional dietetic appointment",
+    },
+    38: {
+        "attribute_name": "kpi_38_patients_attending_additional_dietetic_appointment",
+        "rendered_label": "Number of patients attending an additional dietetic appointment",
+    },
+    39: {
+        "attribute_name": "kpi_39_influenza_immunisation_recommended",
+        "rendered_label": "Number of patients recommended influenza immunisation",
+    },
+    40: {
+        "attribute_name": "kpi_40_sick_day_rules_advice",
+        "rendered_label": "Number of patients given sick day rules advice",
+    },
+    41: {
+        "attribute_name": "kpi_41_coeliac_disease_screening",
+        "rendered_label": "Number of patients with coeliac disease screening",
+    },
+    42: {
+        "attribute_name": "kpi_42_thyroid_disease_screening",
+        "rendered_label": "Number of patients with thyroid disease screening",
+    },
+    43: {
+        "attribute_name": "kpi_43_carbohydrate_counting_education",
+        "rendered_label": "Number of patients with carbohydrate counting education",
+    },
+    44: {
+        "attribute_name": "kpi_44_mean_hba1c",
+        "rendered_label": "Mean HbA1c",
+    },
+    45: {
+        "attribute_name": "kpi_45_median_hba1c",
+        "rendered_label": "Median HbA1c",
+    },
+    46: {
+        "attribute_name": "kpi_46_number_of_admissions",
+        "rendered_label": "Number of admissions",
+    },
+    47: {
+        "attribute_name": "kpi_47_number_of_dka_admissions",
+        "rendered_label": "Number of DKA admissions",
+    },
+    48: {
+        "attribute_name": "kpi_48_required_additional_psychological_support",
+        "rendered_label": "Number of patients requiring additional psychological support",
+    },
+    49: {
+        "attribute_name": "kpi_49_albuminuria_present",
+        "rendered_label": "Number of patients with albuminuria",
+    },
+}
+
+
+@dataclass
+class KPINames:
+    attribute_name: str  # e.g. kpi_32_1_health_check_completion_rate
+    rendered_label: str  # e.g. Care Processes Completion Rate
+
+
+class KPIRegistry:
+    """Makes it easier to get attribute names and rendered labels for KPIs,
+    hardcoded above.
+
+    Usage:
+
+    kpi_registry.get_kpi(323)
+        -> KPINames(
+            attribute_name='kpi_32_3_health_check_gte_12yo',
+            rendered_label='Care processes in patients ≥ 12 years old'
+        )
+
+    kpi_registry.get_attribute_name(323)
+        -> 'kpi_32_3_health_check_gte_12yo'
+
+    kpi_registry.get_rendered_label(323)
+        -> 'Care processes in patients ≥ 12 years old'
+    """
+
+    def __init__(self, kpi_data: Dict[int, Dict[str, str]]):
+        self.kpi_map = {
+            number: KPINames(data["attribute_name"], data["rendered_label"])
+            for number, data in kpi_data.items()
+        }
+
+    def get_kpi(self, number: int) -> KPINames:
+        return self.kpi_map.get(number)
+
+    def get_attribute_name(self, number: int) -> str:
+        kpi = self.get_kpi(number)
+        return kpi.attribute_name if kpi else None
+
+    def get_rendered_label(self, number: int) -> str:
+        kpi = self.get_kpi(number)
+        return kpi.rendered_label if kpi else None
+
+
+# Initialise registry
+kpi_registry = KPIRegistry(KPI_ATTRIBUTE_LABEL_MAP)

--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -39,9 +39,10 @@ class KPIResult:
 
     total_eligible: int
     total_ineligible: int
-    total_passed: int
-    total_failed: int
-    patient_querysets: Optional[Dict[str, QuerySet[Patient]]] = None
+    total_passed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
+    total_failed: Union[int | None]  # E.g. KPIs 1-12 would be None as counts
+    kpi_label: str
+    patient_querysets: Union[Dict[str, QuerySet[Patient]], None] = None
 
 
 @dataclass
@@ -52,7 +53,7 @@ class KPICalculationsObject:
     total_patients_count: int
     calculated_kpi_values: Dict[
         str,
-        Union[KPIResult | None],
+        KPIResult,
     ]
 
 

--- a/project/constants/types/kpi_types.py
+++ b/project/constants/types/kpi_types.py
@@ -1,7 +1,7 @@
 # Object types
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from django.db.models import QuerySet
 
@@ -52,7 +52,7 @@ class KPICalculationsObject:
     total_patients_count: int
     calculated_kpi_values: Dict[
         str,
-        KPIResult,
+        Union[KPIResult | None],
     ]
 
 

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -71,18 +71,22 @@ class CalculateKPIS:
             * return_pt_querysets (bool) - if True, will return the querysets
             of patients for each kpi calculation
 
-        Exposes 2 methods:
+        Exposes methods:
             1) calculate_kpis_for_patients (QuerySet[Patient])
                 - Calculate KPIs for given patients.
             2) calculate_kpis_for_pdus (list[str])
                 - Calculate KPIs for given PZ codes.
 
-            Each method works to set the `self.patients` and
+            Each calculation method works to set the `self.patients` and
             `self.total_patients_count` attributes used throughout all
             calculations.
 
             Both methods return a KPICalculationsObject dataclass instance,
             containing all KPIAggregation results.
+
+        Exposes attributes:
+            * kpi_name_registry (KPINameRegistry) - used to get the kpi method name / label from
+            the kpi number
         """
 
         # Set various attributes used in calculations

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -76,6 +76,8 @@ class CalculateKPIS:
                 - Calculate KPIs for given patients.
             2) calculate_kpis_for_pdus (list[str])
                 - Calculate KPIs for given PZ codes.
+            3) calculate_kpis_for_single_patient (Patient)
+                - Calculate KPIs for a single patient.
 
             Each calculation method works to set the `self.patients` and
             `self.total_patients_count` attributes used throughout all

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 
 class CalculateKPIS:
     """
-    Calculates KPIs for a given PZ code
+    Calculates KPIs
     """
 
     def __init__(

--- a/project/npda/tests/kpi_calculations/test_calculate_kpis.py
+++ b/project/npda/tests/kpi_calculations/test_calculate_kpis.py
@@ -1,4 +1,5 @@
 """Tests for the CalculateKPIS class.
+
 Also contains utils / helper functions for testing the CalculateKPIS class.
 """
 
@@ -181,3 +182,4 @@ def test_calculate_kpis_return_obj_has_correct_kpi_labels(AUDIT_START_DATE):
         assert (
             actual_kpi_label == EXPECTED_KPI_NAMES.rendered_label
         ), f"KPI {actual_kpi_attribute_name} has incorrect label: {actual_kpi_label}"
+

--- a/project/npda/tests/kpi_calculations/test_kpi_calculations.py
+++ b/project/npda/tests/kpi_calculations/test_kpi_calculations.py
@@ -7,7 +7,7 @@ from datetime import date
 
 import pytest
 
-from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
+from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult, kpi_registry
 from project.npda.models.patient import Patient
 
 # Logging
@@ -143,3 +143,41 @@ def test_kpi_calculations_dont_break_when_no_patients(
                 if value is not None
             ]
         ), f"KPI {kpi} has non-integer values: {results}"
+
+
+@pytest.mark.django_db
+def test_calculate_kpis_return_obj_has_correct_kpi_labels(AUDIT_START_DATE):
+    """Tests that the CalculateKPIS object has the correct KPI label for each
+    KPI.
+
+    Do this by taking the kpi_registry and comparing it to the result object.
+
+    The CalculateKPIS is a pretty thin wrapper around the kpi_registry anyway but this is to ensure
+    that the KPI labels are correctly set.
+    """
+    kpi_calculator = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+
+    kpi_calc_obj = kpi_calculator.calculate_kpis_for_patients(Patient.objects.all())
+
+    kpi_results_obj = kpi_calc_obj["calculated_kpi_values"]
+
+    for actual_kpi_attribute_name, result_obj in kpi_results_obj.items():
+        actual_kpi_label = result_obj["kpi_label"]
+
+        # Get the expected KPI label from the registry
+        kpi_names_split = actual_kpi_attribute_name.split("_")
+
+        kpi_number = int(kpi_names_split[1])
+        if kpi_number == 32:
+            kpi_number = 320 + int(kpi_names_split[2])  # offset for subkpis
+
+        EXPECTED_KPI_NAMES = kpi_registry.get_kpi(kpi_number)
+
+        assert (
+            actual_kpi_attribute_name == EXPECTED_KPI_NAMES.attribute_name
+        ), f"KPI {actual_kpi_attribute_name} has incorrect attribute name: "
+        "{actual_kpi_attribute_name}"
+
+        assert (
+            actual_kpi_label == EXPECTED_KPI_NAMES.rendered_label
+        ), f"KPI {actual_kpi_attribute_name} has incorrect label: {actual_kpi_label}"

--- a/project/npda/tests/kpi_calculations/test_kpis_13_20.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_13_20.py
@@ -7,8 +7,9 @@ from project.constants.diabetes_treatment import TREATMENT_TYPES
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
-    assert_kpi_result_equal
+from project.npda.tests.kpi_calculations.test_kpi_calculations import (
+    assert_kpi_result_equal,
+)
 
 # Set up test params for kpis 13-20, as they all have the same denominator
 # and the only thing being changed is value for visit__treatment
@@ -88,7 +89,7 @@ def test_kpi_calculations_13_to_20(
     #   these kpi calulations start at 13
     #   so just offset by 12 to get kpi number
     kpi_number = treatment + 12
-    kpi_method_name = calc_kpis.kpis_names_map[kpi_number]
+    kpi_method_name = calc_kpis.kpi_name_registry.get_attribute_name(kpi_number)
     kpi_calc_method = getattr(calc_kpis, f"calculate_{kpi_method_name}")
     assert_kpi_result_equal(
         expected=expected_result,

--- a/project/npda/tests/kpi_calculations/test_kpis_13_20.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_13_20.py
@@ -7,7 +7,7 @@ from project.constants.diabetes_treatment import TREATMENT_TYPES
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
+from project.npda.tests.kpi_calculations.test_calculate_kpis import (
     assert_kpi_result_equal,
 )
 

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -10,7 +10,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import (
+from project.npda.tests.kpi_calculations.test_calculate_kpis import (
     assert_kpi_result_equal,
 )
 

--- a/project/npda/tests/kpi_calculations/test_kpis_21_23.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_21_23.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 

--- a/project/npda/tests/kpi_calculations/test_kpis_24.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_24.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -11,7 +11,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -11,7 +11,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 

--- a/project/npda/tests/kpi_calculations/test_kpis_41_43.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_41_43.py
@@ -12,7 +12,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 # Logging

--- a/project/npda/tests/kpi_calculations/test_kpis_44_49.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_44_49.py
@@ -16,7 +16,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_kpi_calculations import \
+from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
 # Logging

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -56,12 +56,9 @@ class PatientVisitsListView(
         calculate_kpis = CalculateKPIS(
             calculation_date=datetime.date.today(), return_pt_querysets=False
         )
-        # calculate_kpis_for_patients expects a queryset of patients, so
-        # convert patient object to a queryset
-        patient_as_queryset = Patient.objects.filter(pk=patient.pk)
-        kpi_calculations_object = calculate_kpis.calculate_kpis_for_patients(
-            patients=patient_as_queryset, exclude_one_to_twelve=True
-        )
+        # Calculate the KPIs for this patient, returning only subset relevant
+        # for a single patient's calculation
+        kpi_calculations_object = calculate_kpis.calculate_kpis_for_single_patient(patient)
 
         context["kpi_results"] = kpi_calculations_object
 


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

Documentation for all KPI-related usage has been added. pls see for details including usage.

Extends `CalculateKPIS` with `.calculate_kpis_for_single_patient()` method that takes in a single `Patient`, runs all calculations (subsequent calculations use KPIs 1-12 for denominators so still need), and returns the relevant subset excluding 1-12. Refactors `PatientVisitsListView` to use new method. @eatyourpeas note unsure if this has downstream effects on template?

Extends `CalculateKPIS` with `.kpi_name_registry` attribute to help with kpi name / labels etc and also have single source of truth for them.

### Code changes

- `CalculateKPI` updates, including updates to type definitions
- `kpi_name_regsitry`
- tests for labels rendering and the `single_patient` kpi calculation returns correct subset of kpis

### Documentation changes (done or required as a result of this PR)

KPI calculation section

### Related Issues

https://github.com/orgs/rcpch/projects/13/views/1?pane=issue&itemId=82710195&issue=rcpch%7Cnational-paediatric-diabetes-audit%7C310


