### PR TITLE
Run external validators in parallel

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -14,9 +14,6 @@ from django.core.exceptions import ValidationError
 from httpx import HTTPError
 
 from ...constants.styles.form_styles import *
-from ..general_functions import (gp_details_for_ods_code,
-                                 gp_ods_code_for_postcode,
-                                 validate_postcode)
 from ..models import Patient
 from ..validators import not_in_the_future_validator
 from .external_patient_validators import validate_patient_sync

--- a/project/npda/tests/form_tests/test_external_patient_validators.py
+++ b/project/npda/tests/form_tests/test_external_patient_validators.py
@@ -15,11 +15,19 @@ from project.npda.forms.external_patient_validators import validate_patient_asyn
 
 async_client = AsyncMock()
 
+MOCK_GP_DETAILS_FOR_ODS_CODE = {
+    "GeoLoc": {
+        "Location": {
+            "PostCode": VALID_FIELDS_WITH_GP_POSTCODE["gp_practice_postcode"]
+        }
+    }
+}
+
 # We don't want to call remote services in unit tests
 @pytest.fixture(autouse=True)
 def mock_remote_calls():
     with patch("project.npda.forms.external_patient_validators.validate_postcode", AsyncMock(return_value={"normalised_postcode": VALID_FIELDS["postcode"]})):
-        with patch("project.npda.forms.external_patient_validators.gp_details_for_ods_code", AsyncMock(return_value=True)):
+        with patch("project.npda.forms.external_patient_validators.gp_details_for_ods_code", AsyncMock(return_value=MOCK_GP_DETAILS_FOR_ODS_CODE)):
             with patch("project.npda.forms.external_patient_validators.gp_ods_code_for_postcode", AsyncMock(return_value=VALID_FIELDS["gp_practice_ods_code"])):
                 with patch("project.npda.forms.external_patient_validators.imd_for_postcode", AsyncMock(return_value=INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE)):
                     yield None
@@ -35,7 +43,7 @@ async def test_validate_patient():
 
     assert(result.postcode == VALID_FIELDS["postcode"])
     assert(result.gp_practice_ods_code == VALID_FIELDS["gp_practice_ods_code"])
-    assert(result.gp_practice_postcode == None)
+    assert(result.gp_practice_postcode == VALID_FIELDS_WITH_GP_POSTCODE["gp_practice_postcode"])
     assert(result.index_of_multiple_deprivation_quintile == INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE)
 
 
@@ -95,7 +103,7 @@ async def test_validate_patient_with_gp_practice_ods_code():
     )
 
     assert(result.gp_practice_ods_code == VALID_FIELDS["gp_practice_ods_code"])
-    assert(result.gp_practice_postcode == None)
+    assert(result.gp_practice_postcode == VALID_FIELDS_WITH_GP_POSTCODE["gp_practice_postcode"])
 
 
 async def test_invalid_gp_practice_ods_code():


### PR DESCRIPTION
Speeds up both CSV uploads and creating/updating patients in the UI by issuing all external validation requests (postcode, imd, gp details) in parallel.

Also fixes #330 - gp_practice_postcode is now set for CSV uploads as well as form submissions.

Brings the time taken for CSV upload of `dummy_sheet.csv` down to 1.62 seconds :rocket: 