### PR TITLE
Replace findthatpostcode.uk with postcodes.io

### DIFF
--- a/project/npda/general_functions/validate_postcode.py
+++ b/project/npda/general_functions/validate_postcode.py
@@ -15,8 +15,12 @@ async def validate_postcode(postcode: str, async_client: httpx.AsyncClient):
     Tests if postcode is valid
     Returns boolean
     """
+    use_postcodes_io = settings.POSTCODES_IO_API_URL and settings.POSTCODES_IO_API_KEY
 
-    request_url = f"{settings.POSTCODE_API_BASE_URL}/postcodes/{postcode}.json"
+    if use_postcodes_io:
+        request_url = f"{settings.POSTCODES_IO_API_URL}/postcodes/{postcode}"
+    else:
+        request_url = f"{settings.POSTCODE_API_BASE_URL}/postcodes/{postcode}.json"
 
     response = await async_client.get(
         url=request_url,
@@ -24,6 +28,12 @@ async def validate_postcode(postcode: str, async_client: httpx.AsyncClient):
     )
     response.raise_for_status()
 
+    if use_postcodes_io:
+        print(f"Postcodes.io response: {response.json()}")
+        normalised_postcode = response.json()["result"]["postcode"]
+    else:
+        normalised_postcode = response.json()["data"]["id"]
+
     return {
-        "normalised_postcode": response.json()["data"]["id"]
+        "normalised_postcode": normalised_postcode
     }

--- a/project/settings.py
+++ b/project/settings.py
@@ -65,6 +65,9 @@ NHS_SPINE_SERVICES_URL = os.getenv("NHS_SPINE_SERVICES_URL")
 
 POSTCODE_API_BASE_URL = os.getenv("POSTCODE_API_BASE_URL")
 
+POSTCODES_IO_API_URL = os.getenv("POSTCODES_IO_API_URL")
+POSTCODES_IO_API_KEY = os.getenv("POSTCODES_IO_API_KEY")
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 if DEBUG is True:


### PR DESCRIPTION
See https://github.com/rcpch/national-paediatric-diabetes-audit/issues/342. findthatpostcode.uk has spikes in latency, replace with something we host and control.

Part 1 of https://github.com/rcpch/rcpch-audit-engine/issues/1096