### PR TITLE
Deploy documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - live
+      # TODO MRB: remove this once we test the GitHub pages deploy
+      - mbarton/docs-in-deploy
 
 permissions:
   id-token: write
   contents: read
+  pages: write
 
 jobs:
   build-and-deploy:
@@ -31,3 +34,15 @@ jobs:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
         run: s/ci
+      
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+      
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'staticdocs'
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - live
-      # TODO MRB: remove this once we test the GitHub pages deploy
-      - mbarton/docs-in-deploy
 
 permissions:
   id-token: write

--- a/project/npda/templates/nav.html
+++ b/project/npda/templates/nav.html
@@ -41,7 +41,7 @@
                     </li>
                 {% endif %}
                 <li>
-                    <a href="http://0.0.0.0:8007/"
+                    <a href="{% docs_url %}"
                         class="text-xs block font-montserrat font-semibold py-2 pr-4 pl-3 text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent">
                         User Guide</a>
                 </li>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -225,3 +225,7 @@ def extract_digits(value, underscore_index=0):
     if len(matches) > 0:
         return int(matches[underscore_index])
     return 0
+
+@register.simple_tag
+def docs_url():
+    return settings.DOCS_URL

--- a/project/settings.py
+++ b/project/settings.py
@@ -68,6 +68,8 @@ POSTCODE_API_BASE_URL = os.getenv("POSTCODE_API_BASE_URL")
 POSTCODES_IO_API_URL = os.getenv("POSTCODES_IO_API_URL")
 POSTCODES_IO_API_KEY = os.getenv("POSTCODES_IO_API_KEY")
 
+DOCS_URL = os.getenv("DOCS_URL", "/docs/index.html")
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 if DEBUG is True:

--- a/s/ci
+++ b/s/ci
@@ -21,14 +21,18 @@ docker compose up -d
 s/test
 docker compose down
 
+# TODO MRB: uncomment these once we test the GitHub pages deploy
+
 # Push to Azure
-azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
-docker tag npda-django:built ${azure_tag}
-docker push ${azure_tag}
+# azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
+# docker tag npda-django:built ${azure_tag}
+# docker push ${azure_tag}
 
 # Deploy to Azure Container Apps
-az containerapp revision copy \
-    --name ${AZURE_STAGING_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --image ${azure_tag} \
-    --query 'properties.provisioningState'
+# az containerapp revision copy \
+#     --name ${AZURE_STAGING_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --image ${azure_tag} \
+#     --query 'properties.provisioningState'
+
+# Deploy to the docs is handled in the GitHub workflow itself

--- a/s/ci
+++ b/s/ci
@@ -21,18 +21,16 @@ docker compose up -d
 s/test
 docker compose down
 
-# TODO MRB: uncomment these once we test the GitHub pages deploy
-
 # Push to Azure
-# azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
-# docker tag npda-django:built ${azure_tag}
-# docker push ${azure_tag}
+azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
+docker tag npda-django:built ${azure_tag}
+docker push ${azure_tag}
 
 # Deploy to Azure Container Apps
-# az containerapp revision copy \
-#     --name ${AZURE_STAGING_APP_NAME} \
-#     --resource-group ${AZURE_RESOURCE_GROUP} \
-#     --image ${azure_tag} \
-#     --query 'properties.provisioningState'
+az containerapp revision copy \
+    --name ${AZURE_STAGING_APP_NAME} \
+    --resource-group ${AZURE_RESOURCE_GROUP} \
+    --image ${azure_tag} \
+    --query 'properties.provisioningState'
 
 # Deploy to the docs is handled in the GitHub workflow itself


### PR DESCRIPTION
Fixes #323 

Currently just to GitHub pages: https://rcpch.github.io/national-paediatric-diabetes-audit/. I've set `DOCS_URL` in staging to point to it.

We'll use a custom domain in production but first we need to decide what the domain will be!