### PR TITLE
Don't crash on unhandled errors saving patient and visit in CSV upload

### DIFF
--- a/project/npda/templates/base.html
+++ b/project/npda/templates/base.html
@@ -35,16 +35,15 @@
   {% include 'nav.html' %}
   {% endblock %}
 
-  {% block toasts %}
-  {% include 'toasts.html' %}
-  {% endblock %}
-
   <div>
     {% block content %}{% endblock %}
   </div>
 
   {% include 'footer.html' %}
 
+  {% block toasts %}
+  {% include 'toasts.html' %}
+  {% endblock %}
 </body>
 
 </html>

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -163,8 +163,8 @@ def test_missing_mandatory_field(test_user, valid_df, column, model_field):
 def test_error_in_single_visit(test_user, single_row_valid_df):
     single_row_valid_df.loc[0, 'Diabetes Treatment at time of Hba1c measurement'] = 45
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("treatment" in errors[0])
 
     visit = Visit.objects.first()
 
@@ -177,8 +177,8 @@ def test_error_in_multiple_visits(test_user, one_patient_two_visits):
     df = one_patient_two_visits
     df.loc[0, 'Diabetes Treatment at time of Hba1c measurement'] = 45
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
+    assert("treatment" in errors[0])
 
     assert(Visit.objects.count() == 2)
 
@@ -200,8 +200,8 @@ def test_multiple_patients_where_one_has_visit_errors_and_the_other_does_not(tes
 
     df.loc[0, 'Diabetes Treatment at time of Hba1c measurement'] = 45
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
+    assert("treatment" in errors[0])
 
     [patient_one, patient_two] = Patient.objects.all()
 
@@ -232,8 +232,8 @@ def test_invalid_nhs_number(test_user, single_row_valid_df):
     invalid_nhs_number = "123456789"
     single_row_valid_df["NHS Number"] = invalid_nhs_number
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("nhs_number" in errors[0])
 
     # Not catastrophic - error saved in model and raised back to caller
     patient = Patient.objects.first()
@@ -249,8 +249,8 @@ def test_future_date_of_birth(test_user, single_row_valid_df):
     date_of_birth = TODAY + relativedelta(days=1)
     single_row_valid_df["Date of Birth"] = pd.to_datetime(date_of_birth)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("date_of_birth" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -266,8 +266,8 @@ def test_over_25(test_user, single_row_valid_df):
     date_of_birth = TODAY + - relativedelta(years=25, days=1)
     single_row_valid_df["Date of Birth"] = pd.to_datetime(date_of_birth)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("date_of_birth" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -282,8 +282,8 @@ def test_over_25(test_user, single_row_valid_df):
 def test_invalid_diabetes_type(test_user, single_row_valid_df):
     single_row_valid_df["Diabetes Type"] = 45
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("diabetes_type" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -296,8 +296,8 @@ def test_future_diagnosis_date(test_user, single_row_valid_df):
     diagnosis_date = TODAY + relativedelta(days=1)
     single_row_valid_df["Date of Diabetes Diagnosis"] = pd.to_datetime(diagnosis_date)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("diagnosis_date" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -315,8 +315,8 @@ def test_diagnosis_date_before_date_of_birth(test_user, single_row_valid_df):
 
     single_row_valid_df["Date of Diabetes Diagnosis"] = pd.to_datetime(diagnosis_date)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("diagnosis_date" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -332,8 +332,8 @@ def test_diagnosis_date_before_date_of_birth(test_user, single_row_valid_df):
 def test_invalid_sex(test_user, single_row_valid_df):
     single_row_valid_df["Stated gender"] = 45
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("sex" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -345,8 +345,8 @@ def test_invalid_sex(test_user, single_row_valid_df):
 def test_invalid_ethnicity(test_user, single_row_valid_df):
     single_row_valid_df["Ethnic Category"] = "45"
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("ethnicity" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -358,8 +358,8 @@ def test_invalid_ethnicity(test_user, single_row_valid_df):
 def test_missing_gp_ods_code(test_user, single_row_valid_df):
     single_row_valid_df["GP Practice Code"] = None
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("gp_practice_ods_code" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -377,8 +377,8 @@ def test_future_death_date(test_user, single_row_valid_df):
 
     single_row_valid_df["Death Date"] = pd.to_datetime(death_date)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("death_date" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -396,8 +396,8 @@ def test_death_date_before_date_of_birth(test_user, single_row_valid_df):
 
     single_row_valid_df["Death Date"] = pd.to_datetime(death_date)
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("death_date" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -414,8 +414,8 @@ def test_death_date_before_date_of_birth(test_user, single_row_valid_df):
 def test_invalid_postcode(test_user, single_row_valid_df):
     single_row_valid_df["Postcode of usual address"] = "not a postcode"
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("postcode" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -428,7 +428,8 @@ def test_invalid_postcode(test_user, single_row_valid_df):
 def test_error_validating_postcode(test_user, single_row_valid_df):
     single_row_valid_df["Postcode of usual address"] = "WC1X 8SH"
 
-    csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert(len(errors) == 0)
 
     patient = Patient.objects.first()
     assert(patient.postcode == "WC1X8SH")
@@ -439,8 +440,8 @@ def test_error_validating_postcode(test_user, single_row_valid_df):
 def test_invalid_gp_ods_code(test_user, single_row_valid_df):
     single_row_valid_df["GP Practice Code"] = "not a GP code"
 
-    with pytest.raises(ValidationError) as e_info:
-        csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert("gp_practice_ods_code" in errors[0])
 
     patient = Patient.objects.first()
 
@@ -453,7 +454,8 @@ def test_invalid_gp_ods_code(test_user, single_row_valid_df):
 def test_error_validating_gp_ods_code(test_user, single_row_valid_df):
     single_row_valid_df["GP Practice Code"] = "G85023"
 
-    csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    assert(len(errors) == 0)
 
     patient = Patient.objects.first()
     assert(patient.gp_practice_ods_code == "G85023")

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -27,22 +27,6 @@ from .decorators import login_and_otp_required
 logger = logging.getLogger(__name__)
 
 
-def error_list(wrapper_error: ValidationError):
-    ret = []
-
-    for field, errors in wrapper_error.error_dict.items():
-        for error in errors:
-            ret.append(
-                {
-                    "field": field,
-                    "message": error.message,
-                    "original_row_index": getattr(error, "original_row_index", None),
-                }
-            )
-
-    return ret
-
-
 @login_and_otp_required()
 async def home(request):
     """
@@ -60,34 +44,36 @@ async def home(request):
         file.seek(0)
         errors = []
 
+        errors_by_row_index = await csv_upload(
+            user=request.user,
+            dataframe=read_csv(file),
+            csv_file=file,
+            pdu_pz_code=pz_code,
+        )
+
+        VisitActivity = apps.get_model("npda", "VisitActivity")
         try:
-            await csv_upload(
-                user=request.user,
-                dataframe=read_csv(file),
-                csv_file=file,
-                pdu_pz_code=pz_code,
-            )
+            await VisitActivity.objects.acreate(
+                activity=8,
+                ip_address=request.META.get("REMOTE_ADDR"),
+                npdauser=request.user,
+            )  # uploaded csv - activity 8
+        except Exception as e:
+            logger.error(f"Failed to log user activity: {e}")
+
+        if errors_by_row_index:
+            for row_index, errors_by_field in errors_by_row_index.items():
+                for field, errors in errors_by_field.items():
+                    for error in errors:
+                        messages.error(
+                            request=request,
+                            message=f"CSV has been uploaded, but errors have been found. These include error in row {row_index}[{field}]: {error}",
+                        )
+        else:
             messages.success(
                 request=request,
                 message="File uploaded successfully. There are no errors,",
-            )
-
-            VisitActivity = apps.get_model("npda", "VisitActivity")
-            try:
-                await VisitActivity.objects.acreate(
-                    activity=8,
-                    ip_address=request.META.get("REMOTE_ADDR"),
-                    npdauser=request.user,
-                )  # uploaded csv - activity 8
-            except Exception as e:
-                logger.error(f"Failed to log user activity: {e}")
-        except ValidationError as error:
-            errors = error_list(error)
-            for error in errors:
-                messages.error(
-                    request=request,
-                    message=f"CSV has been uploaded, but errors have been found. These include error in row {error['original_row_index']}: {error['message']}",
-                )
+            )   
 
         return redirect("submissions")
     else:


### PR DESCRIPTION
Fixes #345
Fixes #331 

Prior to this PR we just read `form.errors_as_data` to get a list of `ValidationError` instances per field for `Patient` and `Visit`. Unfortunately this strategy fell down for errors that later on cause the model to save, for example removing the year portion of the date only leaving the day and month.

This PR simplifies and extends error handling to grab all errors that occur saving patient and visit, combine them with the form validation errors and return them.

We no longer need to check if a form validation error will cause a knock on failure to save, as we'll just catch that later anyway.

For the moment we just toast each error which is quite horrible but at least gives the user ALL the information:

![Capture](https://github.com/user-attachments/assets/56315209-cd62-454d-afd7-7f5d53b16268)

I've also moved the toast to the bottom of the template so they appear over the top of the rest of the page correctly.