### PR TITLE
Handle leading and trailing whitespace in CSV column headers

### DIFF
--- a/project/npda/general_functions/csv_upload.py
+++ b/project/npda/general_functions/csv_upload.py
@@ -27,9 +27,17 @@ from ..forms.external_patient_validators import validate_patient_async
 
 
 def read_csv(csv_file):
-    return pd.read_csv(
-        csv_file, parse_dates=ALL_DATES, dayfirst=True, date_format="%d/%m/%Y"
-    )
+    df = pd.read_csv(csv_file)
+
+    # Remove leading and trailing whitespace on column names
+    # The template published on the RCPCH website has trailing spaces on 'Observation Date: Thyroid Function '
+    df.columns = df.columns.str.strip()
+
+    for column in ALL_DATES:
+        df[column] = pd.to_datetime(df[column], format="%d/%m/%Y")
+
+    return df
+
 
 async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
     """


### PR DESCRIPTION
Ronseal. Problem originally found in https://github.com/rcpch/national-paediatric-diabetes-audit/pull/341 [GitHub Actions run](https://github.com/rcpch/national-paediatric-diabetes-audit/actions/runs/11627684066/job/32381466250)