### PR TITLE
[KPIS] Fix test for KPI45 sporadically failing

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -3571,17 +3571,3 @@ class Median(Func):
     function = "percentile_cont"
     template = "%(function)s(0.5) WITHIN GROUP (ORDER BY %(expressions)s)"
 
-
-def queryset_median_value(queryset: QuerySet, column_name: str):
-    """Calculates the median value of a given column_name:str in a queryset
-
-    Median is not a SQL aggregate function so we have to calculate it manually
-
-    Thanks https://stackoverflow.com/questions/942620/missing-median-aggregate-function-in-django.
-    """
-    count = queryset.count()
-    values = queryset.values_list(column_name, flat=True).order_by(column_name)
-    if count % 2 == 1:
-        return values[int(round(count / 2))]
-    else:
-        return sum(values[count / 2 - 1 : count / 2 + 1]) / Decimal(2.0)

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -611,7 +611,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_6_total_t1dm_complete_year_gte_12yo(self) -> dict:
+    def calculate_kpi_6_total_t1dm_complete_year_gte_12yo(self) -> KPIResult:
         """
         Calculates KPI 6: Total number of patients with T1DM who have completed a year of care and are aged 12 or older
         Total number of patients with:
@@ -729,7 +729,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_7_total_new_diagnoses_t1dm(self) -> dict:
+    def calculate_kpi_7_total_new_diagnoses_t1dm(self) -> KPIResult:
         """
         Calculates KPI 7: Total number of new diagnoses of T1DM
         Total number of patients with:
@@ -822,7 +822,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_8_total_deaths(self) -> dict:
+    def calculate_kpi_8_total_deaths(self) -> KPIResult:
         """
         Calculates KPI 8: Number of patients who died within audit period
         Number of eligible patients (measure 1) with:
@@ -868,7 +868,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_9_total_service_transitions(self) -> dict:
+    def calculate_kpi_9_total_service_transitions(self) -> KPIResult:
         """
         Calculates KPI 9: Number of patients who transitioned/left service within audit period
 
@@ -919,7 +919,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_10_total_coeliacs(self) -> dict:
+    def calculate_kpi_10_total_coeliacs(self) -> KPIResult:
         """
         Calculates KPI 10: Total number of coeliacs
         Number of eligible patients (measure 1) who:
@@ -977,7 +977,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_11_total_thyroids(self) -> dict:
+    def calculate_kpi_11_total_thyroids(self) -> KPIResult:
         """
         Calculates KPI 11: Number of patients with thyroid  disease
         Number of eligible patients (measure 1)
@@ -1037,7 +1037,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_12_total_ketone_test_equipment(self) -> dict:
+    def calculate_kpi_12_total_ketone_test_equipment(self) -> KPIResult:
         """
         Calculates KPI 12: Number of patients using (or trained to use) blood ketone testing equipment
 
@@ -1095,7 +1095,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_13_one_to_three_injections_per_day(self) -> dict:
+    def calculate_kpi_13_one_to_three_injections_per_day(self) -> KPIResult:
         """
         Calculates KPI 13: One - three injections/day
 
@@ -1141,7 +1141,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_14_four_or_more_injections_per_day(self) -> dict:
+    def calculate_kpi_14_four_or_more_injections_per_day(self) -> KPIResult:
         """
         Calculates KPI 14: Four or more injections/day
 
@@ -1187,7 +1187,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_15_insulin_pump(self) -> dict:
+    def calculate_kpi_15_insulin_pump(self) -> KPIResult:
         """
         Calculates KPI 15: Insulin pump (including those using a pump as part of a hybrid closed loop)
 
@@ -1235,7 +1235,7 @@ class CalculateKPIS:
 
     def calculate_kpi_16_one_to_three_injections_plus_other_medication(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 16: One - three injections/day plus other blood glucose lowering medication
 
@@ -1282,7 +1282,7 @@ class CalculateKPIS:
 
     def calculate_kpi_17_four_or_more_injections_plus_other_medication(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 17: Four or more injections/day plus other blood glucose lowering medication
 
@@ -1328,7 +1328,7 @@ class CalculateKPIS:
 
     def calculate_kpi_18_insulin_pump_plus_other_medication(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 18: Insulin pump therapy plus other blood glucose lowering medication
 
@@ -1374,7 +1374,7 @@ class CalculateKPIS:
 
     def calculate_kpi_19_dietary_management_alone(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 19: Dietary management alone (no insulin or other diabetes related medication)
 
@@ -1420,7 +1420,7 @@ class CalculateKPIS:
 
     def calculate_kpi_20_dietary_management_plus_other_medication(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 20: Dietary management plus other blood glucose lowering medication (non Type-1 diabetes)
 
@@ -1466,7 +1466,7 @@ class CalculateKPIS:
 
     def calculate_kpi_21_flash_glucose_monitor(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 21: Number of patients using a flash glucose monitor
 
@@ -1512,7 +1512,7 @@ class CalculateKPIS:
 
     def calculate_kpi_22_real_time_cgm_with_alarms(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 22: Number of patients using a real time continuous glucose monitor (CGM) with alarms
 
@@ -1558,7 +1558,7 @@ class CalculateKPIS:
 
     def calculate_kpi_23_type1_real_time_cgm_with_alarms(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 23: Number of patients with Type 1 diabetes using a real time continuous glucose monitor (CGM) with alarms
 
@@ -1605,7 +1605,7 @@ class CalculateKPIS:
 
     def calculate_kpi_24_hybrid_closed_loop_system(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 24: Hybrid closed loop system (HCL)
 
@@ -1691,7 +1691,7 @@ class CalculateKPIS:
 
     def calculate_kpi_25_hba1c(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 25: HbA1c (%)
 
@@ -1733,7 +1733,7 @@ class CalculateKPIS:
 
     def calculate_kpi_26_bmi(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 26: BMI (%)
 
@@ -1776,7 +1776,7 @@ class CalculateKPIS:
 
     def calculate_kpi_27_thyroid_screen(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 27: Thyroid Screen (%)
 
@@ -1817,7 +1817,7 @@ class CalculateKPIS:
 
     def calculate_kpi_28_blood_pressure(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 28: Blood Pressure (%)
 
@@ -1861,7 +1861,7 @@ class CalculateKPIS:
 
     def calculate_kpi_29_urinary_albumin(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 29: Urinary Albumin (%)
 
@@ -1904,7 +1904,7 @@ class CalculateKPIS:
 
     def calculate_kpi_30_retinal_screening(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 30: Retinal Screening (%)
 
@@ -1951,7 +1951,7 @@ class CalculateKPIS:
 
     def calculate_kpi_31_foot_examination(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 31: Foot Examination (%)
 
@@ -1993,7 +1993,7 @@ class CalculateKPIS:
     # TODO: get actual querysets for patients who passed and failed
     def calculate_kpi_32_1_health_check_completion_rate(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 32.1: Health check completion rate (%)
         Number of actual health checks over number of expected health checks.
@@ -2199,7 +2199,7 @@ class CalculateKPIS:
         )
 
     # TODO: get actual querysets for patients who passed and failed
-    def calculate_kpi_32_2_health_check_lt_12yo(self) -> dict:
+    def calculate_kpi_32_2_health_check_lt_12yo(self) -> KPIResult:
         """
         Calculates KPI 32.2: Health Checks (Less than 12 years)
 
@@ -2281,7 +2281,7 @@ class CalculateKPIS:
         )
 
     # TODO: get actual querysets for patients who passed and failed
-    def calculate_kpi_32_3_health_check_gte_12yo(self) -> dict:
+    def calculate_kpi_32_3_health_check_gte_12yo(self) -> KPIResult:
         """
         Calculates KPI 32.3: Health Checks (12 years and over)
 
@@ -2433,7 +2433,7 @@ class CalculateKPIS:
 
     def calculate_kpi_33_hba1c_4plus(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 33: HbA1c 4+ (%)
 
@@ -2485,7 +2485,7 @@ class CalculateKPIS:
 
     def calculate_kpi_34_psychological_assessment(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 34: Psychological assessment (%)
 
@@ -2536,7 +2536,7 @@ class CalculateKPIS:
 
     def calculate_kpi_35_smoking_status_screened(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 35: Smoking status screened (%)
 
@@ -2593,7 +2593,7 @@ class CalculateKPIS:
 
     def calculate_kpi_36_referral_to_smoking_cessation_service(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 36: Referral to smoking cessation service (%)
 
@@ -2643,7 +2643,7 @@ class CalculateKPIS:
 
     def calculate_kpi_37_additional_dietetic_appointment_offered(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 37: Additional dietetic appointment offered (%)
 
@@ -2692,7 +2692,7 @@ class CalculateKPIS:
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 38: Patients attending additional dietetic appointment (%)
 
@@ -2744,7 +2744,7 @@ class CalculateKPIS:
 
     def calculate_kpi_39_influenza_immunisation_recommended(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 39: Influenza immunisation recommended (%)
 
@@ -2796,7 +2796,7 @@ class CalculateKPIS:
 
     def calculate_kpi_40_sick_day_rules_advice(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 40: Sick day rules advice (%)
 
@@ -2847,7 +2847,7 @@ class CalculateKPIS:
 
     def calculate_kpi_41_coeliac_disease_screening(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 41: Coeliac diasease screening (%)
 
@@ -2901,7 +2901,7 @@ class CalculateKPIS:
 
     def calculate_kpi_42_thyroid_disease_screening(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 42: Thyroid disaese screening (%)
 
@@ -2953,7 +2953,7 @@ class CalculateKPIS:
 
     def calculate_kpi_43_carbohydrate_counting_education(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 43: Carbohydrate counting education (%)
 
@@ -3022,7 +3022,7 @@ class CalculateKPIS:
 
     def calculate_kpi_44_mean_hba1c(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 44: Mean HbA1c
 
@@ -3097,7 +3097,7 @@ class CalculateKPIS:
 
     def calculate_kpi_45_median_hba1c(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 43: Median HbA1c
 
@@ -3170,7 +3170,7 @@ class CalculateKPIS:
 
     def calculate_kpi_46_number_of_admissions(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 46: Number of admissions
 
@@ -3233,7 +3233,7 @@ class CalculateKPIS:
 
     def calculate_kpi_47_number_of_dka_admissions(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 47: Number of DKA admissions
 
@@ -3294,7 +3294,7 @@ class CalculateKPIS:
 
     def calculate_kpi_48_required_additional_psychological_support(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 48: Required additional psychological support
 
@@ -3347,7 +3347,7 @@ class CalculateKPIS:
 
     def calculate_kpi_49_albuminuria_present(
         self,
-    ) -> dict:
+    ) -> KPIResult:
         """
         Calculates KPI 49: Albuminuria present
 

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -1,6 +1,7 @@
 """Views for KPIs calculations
 """
 
+from collections import defaultdict
 import logging
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timedelta
@@ -3153,7 +3154,7 @@ class CalculateKPIS:
             total_eligible=total_eligible,
             total_ineligible=total_ineligible,
             # Use passed for storing the value
-            total_passed=mean_of_median_hba1cs,
+            total_passed=median_of_median_hba1cs,
             # Failed is not used
             total_failed=-1,
             patient_querysets=patient_querysets,
@@ -3555,6 +3556,35 @@ class CalculateKPIS:
             self.t1dm_pts_diagnosed_90D_before_end_base_query_set,
             self.t1dm_pts_diagnosed_90D_before_end_total_eligible,
         )
+
+    def calculate_median(self, values: list[Decimal]) -> float:
+        """Calculates the median of a list of values
+
+        Args:
+            values (list[Decimal]): List of values to calculate the median for.
+            assuming used with hba1c values which come in as Decimals. Convert
+            these to floats for convenience.
+
+        Returns:
+            float: Median of the list of values. Returns -1 if no values
+        """
+        if not values:
+            return float(-1)
+
+        # Ensure they're sorted
+        values.sort()
+
+        length = len(values)
+        if length % 2 == 0:
+
+            # even number, take mean
+            middle_1 = values[(length // 2) - 1]
+            middle_2 = values[length // 2]
+            return float((middle_1 + middle_2) / 2)
+
+        # odd number
+        middle = values[length // 2]
+        return float(middle)
 
 
 # Custom Median function for PostgreSQL

--- a/project/npda/tests/kpi_calculations/test_kpis_44_49.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_44_49.py
@@ -1,5 +1,6 @@
 """Tests for the Outcomes KPIs."""
 
+from decimal import Decimal
 import logging
 from typing import List
 

--- a/project/npda/tests/kpi_calculations/test_kpis_44_49.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_44_49.py
@@ -162,68 +162,79 @@ def test_kpi_calculation_45(AUDIT_START_DATE):
     Patient.objects.all().delete()
 
     # Create  Patients and Visits that should be eligible (KPI1)
-    DIAGNOSIS_DATE = AUDIT_START_DATE - relativedelta(days=90)
+    DIAGNOSIS_DATE = AUDIT_START_DATE - relativedelta(days=91)
     eligible_criteria = {
-        "visit__visit_date": AUDIT_START_DATE + relativedelta(days=2),
         "date_of_birth": AUDIT_START_DATE - relativedelta(days=365 * 10),
     }
 
     # Create passing pts
-    pt_1_hba1cs = [45, 46, 47]
+    pt_1_hba1cs = [Decimal(n) for n in [45, 46, 47]]
+    # Diagnosis date is 91 days before AUDIT_START_DATE so valid hba1c dates are
+    # all from AUDIT_START_DATE+1day onwards
+    # 91 so we can test for 90 days after diagnosis whilst still being in audit period
+    pt_1_hba1c_date_1 = AUDIT_START_DATE+relativedelta(days=1)
     passing_pt_1_median_46 = PatientFactory(
         # KPI1 eligible
         **eligible_criteria,
         postcode="passing_pt_1_median_46",
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        visit__hba1c_date=DIAGNOSIS_DATE + relativedelta(days=91),
+        visit__visit_date=pt_1_hba1c_date_1,
+        visit__hba1c_date=pt_1_hba1c_date_1,
         visit__hba1c=pt_1_hba1cs[0],
     )
     # 2 more HbA1c measurements
+    pt_1_hba1c_date_2 = AUDIT_START_DATE + relativedelta(months=3)
     VisitFactory(
         patient=passing_pt_1_median_46,
-        visit_date=AUDIT_START_DATE + relativedelta(months=3),
+        visit_date=pt_1_hba1c_date_2,
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        hba1c_date=DIAGNOSIS_DATE + relativedelta(months=3),
+        hba1c_date=pt_1_hba1c_date_2,
         hba1c=pt_1_hba1cs[1],
     )
+    pt_1_hba1c_date_3 = AUDIT_START_DATE + relativedelta(months=6)
     VisitFactory(
         patient=passing_pt_1_median_46,
-        visit_date=AUDIT_START_DATE + relativedelta(months=6),
+        visit_date=pt_1_hba1c_date_3,
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        hba1c_date=DIAGNOSIS_DATE + relativedelta(days=6),
+        hba1c_date=pt_1_hba1c_date_3,
         hba1c=pt_1_hba1cs[2],
     )
 
-    pt_2_hba1cs = [47, 48, 49]
+    pt_2_hba1cs = [Decimal(n) for n in [47, 48, 49]]
+    pt_2_hba1c_date_1 = AUDIT_START_DATE+relativedelta(days=1)
     passing_pt_2_median_48 = PatientFactory(
         # KPI1 eligible
         **eligible_criteria,
         postcode="passing_pt_2_median_48",
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        visit__hba1c_date=DIAGNOSIS_DATE + relativedelta(days=91),
+        visit__visit_date=pt_2_hba1c_date_1,
+        visit__hba1c_date=pt_2_hba1c_date_1,
         visit__hba1c=pt_2_hba1cs[0],
     )
     # 2 more HbA1c measurements
+    pt_2_hba1c_date_2 = AUDIT_START_DATE + relativedelta(months=3)
     VisitFactory(
         patient=passing_pt_2_median_48,
-        visit_date=AUDIT_START_DATE + relativedelta(months=3),
+        visit_date=pt_2_hba1c_date_2,
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        hba1c_date=DIAGNOSIS_DATE + relativedelta(months=3),
+        hba1c_date=pt_2_hba1c_date_2,
         hba1c=pt_2_hba1cs[1],
     )
+    pt_2_hba1c_date_3 = AUDIT_START_DATE + relativedelta(months=6)
     VisitFactory(
         patient=passing_pt_2_median_48,
-        visit_date=AUDIT_START_DATE + relativedelta(months=6),
+        visit_date=pt_2_hba1c_date_3,
         # HbA1c measurements within the audit period and after 90 days of diagnosis
-        hba1c_date=DIAGNOSIS_DATE + relativedelta(months=6),
+        hba1c_date=pt_2_hba1c_date_3,
         hba1c=pt_2_hba1cs[2],
     )
-    # This measurement should NOT be counted
+    # This measurement should NOT be counted as it's within 90 days of diagnosis
+    pt_2_invalid_hba1c_date_wihtin_90_days_diagnosis = AUDIT_START_DATE
     VisitFactory(
         patient=passing_pt_2_median_48,
-        visit_date=DIAGNOSIS_DATE + relativedelta(days=89),
+        visit_date=pt_2_invalid_hba1c_date_wihtin_90_days_diagnosis,
         # HbA1c measurement is within 90 days of diagnosis
-        hba1c_date=DIAGNOSIS_DATE + relativedelta(days=89),
+        hba1c_date=pt_2_invalid_hba1c_date_wihtin_90_days_diagnosis,
         hba1c=1,  # ridiculously low to skew numbers if counted
     )
 


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

A few things were going on here, and was a fun rabbit hole!

TL/DR : main things contributing to the *random* failing were:

1. Floating point precision
2. SQL median is weird
3. Accidentally using random values for `Patient.diagnosis_date`

All have been fixed. Run the test many times as it should now be fine (importantly, no random values are being used now, so one pass = deterministic!).

# Fun details on above: 

## 1. Floating point precision

We have our `Visit.hba1c` field defined as a `DecimalField`. The actual kpi calculation method querying this outputs a python `Decimal( )` object.  My test was just using `float( )` objects. Good article on difference: <https://www.laac.dev/blog/float-vs-decimal-python/> but *generally*:

- `float`s are good for speed & convenience, use the classic `IEEE 754` binary representation, can lead to rounding precision errors
- `Decimal`, somehow uses `base-10` representation`, but means it can accurately represent decimal numbers without the traditional floating point errors

This was partly leading to errors as tests are comparing different types of values. Fixed by converting expected values into `Decimal`. The output of the `calculate_kpi_45_median_hba1c` still returns a `float` though for convenience

## 2. SQL median is weird

There is no standard implementation of median in Django's ORM because it's more complicated to calculate. I created a custom SQL class for it but that ended up being harder to reason with. Instead, did a simpler approach of just using ORM to retrieve a list of hba1c values, and then calculate the median in Python. Much more straightforward.

## 3. Accidentally using random values for `Patient.diagnosis_date`

Rookie error! In the tests, just forgot to set `PatientFactory.diagnosis_date`. Expected behavior of the `PatientFactory` is to generate random valid values for any not given (to make it easier to create `Patient` objects). 

Fixed by just defining.


### Code changes

- tests updated to use `Decimal()` values for hba1c instead of `float`
- tests updated to specify `diagnosis_date`, thus not relying on the `PatientFactory()` generating a random `diagnosis_date`
- tests updated to be a little more clear for the invalid case
- `calculate_median` implementation moved into Python instead of SQL, simplifying and circumventing harder-to-reason precision errors
- `calculate_kpi_45_median_hba1c` method more straightforward because of using a Python way of calculating median
- also update type annotations of returns from `calculate_kpi_` methods to `KPIResult`



### Related Issues

https://github.com/orgs/rcpch/projects/13?pane=issue&itemId=85211949&issue=rcpch%7Cnational-paediatric-diabetes-audit%7C338

### Mentions
@mentions of the person or team responsible for reviewing proposed changes.
