### PR TITLE
Fix superuser view preference

### DIFF
--- a/project/npda/management/commands/create_npda_superuser.py
+++ b/project/npda/management/commands/create_npda_superuser.py
@@ -3,7 +3,6 @@ import os
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 
-
 class Command(BaseCommand):
     help = "Create a default NPDA superuser, pulling in values set in environment variables: LOCAL_DEV_ADMIN_EMAIL and LOCAL_DEV_ADMIN_PASSWORD."
 
@@ -33,11 +32,7 @@ class Command(BaseCommand):
                 first_name="SuperuserAda",
                 last_name="Lovelace",
                 email=LOCAL_DEV_ADMIN_EMAIL,
-                password=LOCAL_DEV_ADMIN_PASSWORD,
-                is_active=True,
-                is_staff=True,
-                is_superuser=True,
-                role=4,  # also sets is_rcpch_staff=True
+                password=LOCAL_DEV_ADMIN_PASSWORD
             )
             self.stdout.write(self.style.SUCCESS("Successfully created the superuser."))
         else:

--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -76,6 +76,8 @@ class NPDAUserManager(BaseUserManager):
         logged_in_user = self.create_user(
             email=email.lower(),
             password=password,
+            first_name=first_name,
+            last_name=last_name,
             role=RCPCH_AUDIT_TEAM,
             is_superuser=True,
             is_active=True,

--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -44,7 +44,8 @@ class NPDAUserManager(BaseUserManager):
         )
 
         user.set_password(password)
-        user.view_preference = 0  # organisation level view preference
+        if not extra_fields.get("view_preference"):
+            user.view_preference = 1  # PDU level view preference
         if not extra_fields.get("is_superuser"):
             user.is_superuser = False
         if not extra_fields.get("is_active"):


### PR DESCRIPTION
Fix the default view preference for newly created superusers. It now is correctly set to national where before it ended up being the obselete organisation level (`0`).

This means that you now see the data quality report after uploading in a brand new fresh instance. Before you had to juggle the switcher to get it to show up.

I've refactored the create_superuser function on the user manager to take no additional arguments, which means we can then simplify the calling code to no longer use `**extrafields` and hopefully make bugs like this less likely in the future 