### PR TITLE
dont-lose-your-head

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -3,6 +3,9 @@ from dataclasses import dataclass
 import logging
 import re
 
+# Django imports
+from django.core.exceptions import ValidationError
+
 # Third-party imports
 import pandas as pd
 import numpy as np
@@ -18,6 +21,7 @@ from project.constants import (
 # Logging setup
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class ParsedCSVFile:
     df: pd.DataFrame
@@ -25,6 +29,7 @@ class ParsedCSVFile:
     additional_columns: list[str]
     duplicate_columns: list[str]
     parse_type_error_columns: list[str]
+
 
 def csv_parse(csv_file):
     """
@@ -37,6 +42,7 @@ def csv_parse(csv_file):
     # We will check if the first row of the csv file matches the predefined column names
     # If it does not, we will use the predefined column names
     # If it does, we will use the column names in the csv file
+    # The exception is if the first row of the csv file does not match any of the predefined column names, in which case we will reject the csv
 
     # Convert the predefined column names to lowercase
     lowercase_headings_list = [heading.lower() for heading in HEADINGS_LIST]
@@ -50,9 +56,10 @@ def csv_parse(csv_file):
         pass
     else:
         # The first row of the csv file does not match the predefined column names
-        # We will use the predefined column names
-        csv_file.seek(0)
-        df = pd.read_csv(csv_file, header=None, names=HEADINGS_LIST)
+        # We will reject this csv (#391)
+        raise ValueError(
+            "The first row of the csv file does not match any of the predefined column names. Please include these and upload the file again."
+        )
 
     # Remove leading and trailing whitespace on column names
     # The template published on the RCPCH website has trailing spaces on 'Observation Date: Thyroid Function '

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -773,12 +773,17 @@ def test_upload_without_headers(test_user, one_patient_two_visits):
 
     csv = "\n".join(lines)
 
-    df = read_csv_from_str(csv).df
+    # The first row of the csv file does not match any of the predefined column names - this is a fatal error and the csv should be rejected and the user notified
+    with pytest.raises(
+        ValueError,
+        match="The first row of the csv file does not match any of the predefined column names. Please include these and upload the file again.",
+    ):
+        df = read_csv_from_str(csv).df
+        csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
 
-    csv_upload_sync(test_user, df, None, ALDER_HEY_PZ_CODE)
-
-    assert Patient.objects.count() == 1
-    assert Visit.objects.count() == 2
+    # No patients or associated visits should be saved
+    assert Patient.objects.count() == 0
+    assert Visit.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -51,8 +51,16 @@ async def home(request):
         user_csv = request.FILES["csv_upload"]
         pz_code = request.session.get("pz_code")
         if request.session.get("can_upload_csv") is True:
-            # check to see if the CSV is valid
-            parsed_csv = csv_parse(user_csv)
+            # check to see if the CSV is valid - cannot accept CSVs with no header. All other header errors are non-lethal but are reported back to the user
+            try:
+                parsed_csv = csv_parse(user_csv)
+            except ValueError as e:
+                messages.error(
+                    request=request,
+                    message=f"Invalid CSV format: {e}",
+                )
+                return redirect("home")
+
             if (
                 parsed_csv.missing_columns
                 or parsed_csv.additional_columns


### PR DESCRIPTION
Fixes #391

### Overview
Uploading a CSV without a header is now seen as a fatal error (as it could be the doctor rota which they have uploaded, not the audit data) and the file is rejected. 

Now  a `ValueError` is raised and this is trapped in the home page and passed back to the user in an error message and a redirect. 

The test for this (reassuringly failed after the revert was made) now captures the error and checks not records have been saved

### Related Issues
Closes #391