### PR TITLE
Fix CSV parse crash

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -51,23 +51,12 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
         if pd.isnull(value):
             return None
 
-        # # Pandas is returning 0 for empty cells in integer columns
-        # if value == 0:
-        #     return None
-
-        # Pandas will convert an integer column to float if it contains missing values
-        # http://pandas.pydata.org/pandas-docs/stable/user_guide/gotchas.html#missing-value-representation-for-numpy-types
-        # if pd.api.types.is_float(value) and model_field.choices:
-        #     return int(value)
-
         if isinstance(value, pd.Timestamp):
             return value.to_pydatetime().date()
 
-        # if model_field.choices:
-        #     # If the model field has choices, we need to convert the value to the correct type otherwise 1, 2 will be saved as booleans
-        #     return model_field.to_python(value)
-
-        return value
+        # Pass Django forms native Python values not numpy ones
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/425
+        return value.item() if isinstance(value, np.generic) else value
 
     def row_to_dict(row, model):
         ret = {}


### PR DESCRIPTION
Fixes #425 

Numpy v2.2.0 (which we get transitively) made truth comparisons against the empty array an error. This interacted badly with Django forms which tests for empty values that way.

This crashed CSV uploading:

```
+---------------- 10 ----------------
    | Traceback (most recent call last):
    |   File "/app/project/npda/general_functions/csv/csv_upload.py", line 132, in validate_rows
    |     patient_form.is_valid()
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/forms.py", line 197, in is_valid
    |     return self.is_bound and not self.errors
    |                                  ^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/forms.py", line 192, in errors
    |     self.full_clean()
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/forms.py", line 325, in full_clean
    |     self._clean_fields()
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/forms.py", line 333, in _clean_fields
    |     self.cleaned_data[name] = field._clean_bound_field(bf)
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/fields.py", line 266, in _clean_bound_field
    |     return self.clean(value)
    |            ^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/fields.py", line 959, in clean
    |     value = super().clean(value)
    |             ^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/fields.py", line 204, in clean
    |     value = self.to_python(value)
    |             ^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/django/forms/fields.py", line 907, in to_python
    |     if value in self.empty_values:
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    | ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.
```

The fix is simple: don't pass numpy types (eg int8) to Django forms.