### PR TITLE
async-patient-location-save

### DIFF
--- a/project/npda/forms/external_patient_validators.py
+++ b/project/npda/forms/external_patient_validators.py
@@ -150,7 +150,7 @@ async def validate_patient_async(
         raise postcode  # postcode has an error that is not to do with validation
     else:
         ret.postcode = postcode
-        if type(postcode) is ValidationError:
+        if type(postcode) is ValidationError or postcode is None:
             # the postcode is invalid. There is no point in running the IMD and location tasks
             # Await the tasks, even though their results won't be used
             await asyncio.gather(
@@ -181,7 +181,8 @@ async def validate_patient_async(
         if isinstance(location, Exception) and not type(location) is ValidationError:
             raise location
         else:
-            ret.location = location
+            ret.location_bng = location[0]
+            ret.location_wgs84 = location[1]
 
     # run the GP details task
     if type(gp_details) is ValidationError:

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -5,9 +5,11 @@ from datetime import date
 # project imports
 import nhs_number
 import httpx
+
 # third-party imports
 from dateutil.relativedelta import relativedelta
 from django import forms
+
 # django imports
 from django.apps import apps
 from django.core.exceptions import ValidationError
@@ -45,6 +47,7 @@ class PostcodeField(forms.CharField):
         if postcode:
             return postcode.upper().replace(" ", "").replace("-", "")
 
+
 class PatientForm(forms.ModelForm):
 
     class Meta:
@@ -64,7 +67,7 @@ class PatientForm(forms.ModelForm):
         field_classes = {
             "nhs_number": NHSNumberField,
             "postcode": PostcodeField,
-            "gp_practice_postcode": PostcodeField
+            "gp_practice_postcode": PostcodeField,
         }
         widgets = {
             "nhs_number": forms.TextInput(
@@ -93,7 +96,7 @@ class PatientForm(forms.ModelForm):
             if age >= 25:
                 raise ValidationError(
                     "NPDA patients cannot be 25+ years old. This patient is %(age)s",
-                    params={"age": age}
+                    params={"age": age},
                 )
 
         return date_of_birth
@@ -109,7 +112,7 @@ class PatientForm(forms.ModelForm):
         not_in_the_future_validator(death_date)
 
         return death_date
-    
+
     def handle_async_validation_result(self, key):
         value = getattr(self.async_validation_results, key)
 
@@ -153,22 +156,44 @@ class PatientForm(forms.ModelForm):
                 )
 
         if gp_practice_ods_code is None and gp_practice_postcode is None:
-            self.add_error("gp_practice_ods_code", ValidationError("'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty"))
-        
+            self.add_error(
+                "gp_practice_ods_code",
+                ValidationError(
+                    "'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty"
+                ),
+            )
+
         if not getattr(self, "async_validation_results", None):
             self.async_validation_results = validate_patient_sync(
                 postcode=self.cleaned_data["postcode"],
                 gp_practice_ods_code=self.cleaned_data.get("gp_practice_ods_code"),
-                gp_practice_postcode=self.cleaned_data.get("gp_practice_postcode")
+                gp_practice_postcode=self.cleaned_data.get("gp_practice_postcode"),
             )
-        
-        for key in ["postcode", "gp_practice_ods_code", "gp_practice_postcode"]:
+
+        for key in [
+            "postcode",
+            "location_bng",
+            "location_wgs84",
+            "gp_practice_ods_code",
+            "gp_practice_postcode",
+        ]:
             self.handle_async_validation_result(key)
-    
+
     def save(self, commit=True):
         instance = super().save(commit=False)
 
-        instance.index_of_multiple_deprivation_quintile = self.async_validation_results.index_of_multiple_deprivation_quintile
+        instance.index_of_multiple_deprivation_quintile = (
+            self.async_validation_results.index_of_multiple_deprivation_quintile
+        )
+
+        if getattr(self, "async_validation_results"):
+
+            for field in ["location_bng", "location_wgs84"]:
+                result = getattr(self.async_validation_results, f"{field}")
+
+                if result and not type(result) is ValidationError:
+                    setattr(instance, "location_bng", result.location_bng)
+                    setattr(instance, "location_wgs84", result.location_wgs84)
 
         if commit:
             instance.save()

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -186,14 +186,8 @@ class PatientForm(forms.ModelForm):
             self.async_validation_results.index_of_multiple_deprivation_quintile
         )
 
-        if getattr(self, "async_validation_results"):
-
-            for field in ["location_bng", "location_wgs84"]:
-                result = getattr(self.async_validation_results, f"{field}")
-
-                if result and not type(result) is ValidationError:
-                    setattr(instance, "location_bng", result.location_bng)
-                    setattr(instance, "location_wgs84", result.location_wgs84)
+        instance.location_bng = self.async_validation_results.location[1]
+        instance.location_wgs84 = self.async_validation_results.location[0]
 
         if commit:
             instance.save()

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -186,8 +186,8 @@ class PatientForm(forms.ModelForm):
             self.async_validation_results.index_of_multiple_deprivation_quintile
         )
 
-        instance.location_bng = self.async_validation_results.location[1]
-        instance.location_wgs84 = self.async_validation_results.location[0]
+        instance.location_bng = self.async_validation_results.location_bng
+        instance.location_wgs84 = self.async_validation_results.location_wgs84
 
         if commit:
             instance.save()

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -273,10 +273,12 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
                     patient_form.async_validation_results.index_of_multiple_deprivation_quintile
                 )
 
-                patient.location_bng = patient_form.async_validation_results.location[1]
-                patient.location_wgs84 = patient_form.async_validation_results.location[
-                    0
-                ]
+                patient.location_bng = (
+                    patient_form.async_validation_results.location_bng
+                )
+                patient.location_wgs84 = (
+                    patient_form.async_validation_results.location_wgs84
+                )
 
                 await patient.asave()
 

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -26,11 +26,6 @@ from project.npda.forms.visit_form import VisitForm
 from project.npda.forms.external_patient_validators import validate_patient_async
 from project.npda.forms.external_visit_validators import validate_visit_async
 
-from project.npda.general_functions.dgc_centile_calculations import (
-    calculate_bmi,
-    calculate_centiles_z_scores,
-)
-
 
 async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
     """
@@ -104,7 +99,7 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
             height=fields["height"],
             weight=fields["weight"],
             sex=patient_form.cleaned_data.get("sex"),
-            async_client=async_client
+            async_client=async_client,
         )
 
         return form
@@ -114,15 +109,17 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
         patient_row_index = first_row["row_index"]
 
         transfer_fields = validate_transfer(first_row)
-        
+
         patient_form = await validate_patient_using_form(first_row, async_client)
-        
         # Pull through cleaned_data so we can use it in the async visit validators
+
         patient_form.is_valid()
 
         visit_forms = []
         for _, row in rows.iterrows():
-            visit_form = await validate_visit_using_form(patient_form, row, async_client)
+            visit_form = await validate_visit_using_form(
+                patient_form, row, async_client
+            )
             visit_forms.append((visit_form, row["row_index"]))
 
         return (
@@ -276,6 +273,16 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
                     patient_form.async_validation_results.index_of_multiple_deprivation_quintile
                 )
 
+                patient.location_wgs = (
+                    patient_form.async_validation_results.location_wgs
+                )
+                patient.location_bng = (
+                    patient_form.async_validation_results.location_bng
+                )
+                patient.location_wgs84 = (
+                    patient_form.async_validation_results.location_wgs84
+                )
+
                 await patient.asave()
 
                 # add the patient to a new Transfer instance
@@ -288,7 +295,6 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
                 # We don't know what field caused the error so add to __all__
                 errors_to_return[patient_row_index]["__all__"].append(error)
 
-            no_errors_preventing_centile_calcuation = True
             for visit_form, visit_row_index in parsed_visits:
                 # Errors validating the Visit fields
                 for field, error in visit_form.errors.as_data().items():

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -301,9 +301,7 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
                     try:
                         await visit.asave()
                     except Exception as error:
-                        print(
-                            f"Error saving visit: {error}"  # , height: {visit.height} (centile: {visit.height_centile, visit.height_sds}) {visit.weight} ({visit.weight_centile}, {visit.weight_sds}), {visit.bmi} ({visit.bmi_centile}, {visit.bmi_sds}), visit.patient: {visit.patient}"
-                        )
+                        print(f"Error saving visit: {error}")
                 except Exception as error:
                     errors_to_return[visit_row_index]["__all__"].append(error)
 

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -273,15 +273,10 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
                     patient_form.async_validation_results.index_of_multiple_deprivation_quintile
                 )
 
-                patient.location_wgs = (
-                    patient_form.async_validation_results.location_wgs
-                )
-                patient.location_bng = (
-                    patient_form.async_validation_results.location_bng
-                )
-                patient.location_wgs84 = (
-                    patient_form.async_validation_results.location_wgs84
-                )
+                patient.location_bng = patient_form.async_validation_results.location[1]
+                patient.location_wgs84 = patient_form.async_validation_results.location[
+                    0
+                ]
 
                 await patient.asave()
 

--- a/project/npda/general_functions/map.py
+++ b/project/npda/general_functions/map.py
@@ -64,16 +64,6 @@ def get_children_by_pdu_audit_year(
             | ~Q(postcode__exact=""),  # Exclude patients with no postcode
         )
 
-        for patient in filtered_patients:
-            if patient.postcode:
-                # this currently takes a long time to run because of the API call - once we save the location data in the database on save, we can remove this
-                lon, lat, location_wgs84, location_bng = location_for_postcode(
-                    patient.postcode
-                )
-                patient.location_wgs84 = location_wgs84
-                patient.location_bng = location_bng
-                patient.save()
-
         filtered_patients = filtered_patients.annotate(
             distance_from_lead_organisation=Distance(
                 "location_wgs84",

--- a/project/npda/general_functions/validate_postcode.py
+++ b/project/npda/general_functions/validate_postcode.py
@@ -35,7 +35,7 @@ async def validate_postcode(postcode: str, async_client: httpx.AsyncClient):
     return normalised_postcode
 
 
-def location_for_postcode(postcode: str):
+async def location_for_postcode(postcode: str, async_client: httpx.AsyncClient):
     # update the longitude and latitude
     """
     The SRID (Spatial Reference System Identifier) 27700 refers to the British National Grid (BNG), a common system used for mapping in the UK. It uses Eastings and Northings, rather than longitude & latitude.
@@ -50,7 +50,9 @@ def location_for_postcode(postcode: str):
             location_bng = None
 
         # Fetch the coordinates (WGS 84)
-        lon, lat = coordinates_for_postcode(postcode=postcode)
+        lon, lat = await coordinates_for_postcode(
+            postcode=postcode, async_client=async_client
+        )
 
         # Create a Point in WGS 84
         point_wgs84 = Point(lon, lat, srid=4326)
@@ -74,13 +76,13 @@ def location_for_postcode(postcode: str):
     return lon, lat, location_wgs84, location_bng
 
 
-def coordinates_for_postcode(postcode: str) -> bool:
+async def coordinates_for_postcode(postcode: str, async_client) -> bool:
     """
     Returns longitude and latitude for a valid postcode.
     """
 
     # check against API
-    response = requests.get(
+    response = await async_client.get(
         url=f"{settings.POSTCODES_IO_API_URL}/postcodes/{postcode}",
         headers={"Ocp-Apim-Subscription-Key": settings.POSTCODES_IO_API_KEY},
         timeout=10,  # times out after 10 seconds

--- a/project/npda/tests/factories/patient_factory.py
+++ b/project/npda/tests/factories/patient_factory.py
@@ -8,6 +8,7 @@ import logging
 import random
 
 # third-party imports
+from django.contrib.gis.geos import Point
 import factory
 import nhs_number
 from dateutil.relativedelta import relativedelta
@@ -34,6 +35,12 @@ DATE_OF_BIRTH = TODAY - relativedelta(years=10)
 GP_POSTCODE_NO_SPACES = "SE135PJ"
 GP_POSTCODE_WITH_SPACES = "SE13 5PJ"
 
+# Mocked values
+location_bng = Point(x=531000, y=180000)
+location_wgs84 = Point(x=51.5074, y=0.1278)
+
+LOCATION = location_wgs84, location_bng
+
 VALID_FIELDS = {
     "nhs_number": "6239431915",
     "sex": SEX_TYPE[0][0],
@@ -43,6 +50,8 @@ VALID_FIELDS = {
     "diabetes_type": DIABETES_TYPES[0][0],
     "diagnosis_date": DATE_OF_BIRTH + relativedelta(years=8),
     "gp_practice_ods_code": "G85023",
+    "location_bng": location_bng,
+    "location_wgs84": location_wgs84,
 }
 
 VALID_FIELDS_WITH_GP_POSTCODE = VALID_FIELDS | {
@@ -116,10 +125,7 @@ class PatientFactory(factory.django.DjangoModelFactory):
 
     @factory.lazy_attribute
     def date_of_birth(self):
-        """Set date_of_birth based on the selected age_range.
-
-
-        """
+        """Set date_of_birth based on the selected age_range."""
         min_age, max_age = self.age_range.value
 
         # Has to be at least 0 years old to be in the audit

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -13,14 +13,17 @@ from httpx import HTTPError
 # NPDA Imports
 from project.npda.models.patient import Patient
 from project.npda.forms.patient_form import PatientForm
-from project.npda.forms.external_patient_validators import PatientExternalValidationResult
+from project.npda.forms.external_patient_validators import (
+    PatientExternalValidationResult,
+)
 from project.npda import general_functions
 from project.npda.tests.factories.patient_factory import (
     TODAY,
     DATE_OF_BIRTH,
     VALID_FIELDS,
     VALID_FIELDS_WITH_GP_POSTCODE,
-    INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE
+    INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
+    LOCATION,
 )
 
 # Logging
@@ -31,279 +34,319 @@ MOCK_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
     postcode=VALID_FIELDS["postcode"],
     gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
     gp_practice_postcode=VALID_FIELDS_WITH_GP_POSTCODE["gp_practice_postcode"],
-    index_of_multiple_deprivation_quintile=INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE
+    index_of_multiple_deprivation_quintile=INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
+    location_bng=LOCATION[1],
+    location_wgs84=LOCATION[0],
 )
 
+
 def mock_external_validation_result(**kwargs):
-    return Mock(return_value=dataclasses.replace(MOCK_EXTERNAL_VALIDATION_RESULT, **kwargs))
+    return Mock(
+        return_value=dataclasses.replace(MOCK_EXTERNAL_VALIDATION_RESULT, **kwargs)
+    )
+
 
 # We don't want to call remote services in unit tests
 @pytest.fixture(autouse=True)
 def mock_remote_calls():
-    with patch("project.npda.forms.patient_form.validate_patient_sync", Mock(return_value=MOCK_EXTERNAL_VALIDATION_RESULT)):
+    with patch(
+        "project.npda.forms.patient_form.validate_patient_sync",
+        Mock(return_value=MOCK_EXTERNAL_VALIDATION_RESULT),
+    ):
         yield None
 
 
 @pytest.mark.django_db
 def test_create_patient():
     form = PatientForm(VALID_FIELDS)
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
 
 @pytest.mark.django_db
 def test_create_patient_with_death_date():
-    form = PatientForm(VALID_FIELDS | {
-        "death_date": VALID_FIELDS["diagnosis_date"] + relativedelta(years=1)
-    })
+    form = PatientForm(
+        VALID_FIELDS
+        | {"death_date": VALID_FIELDS["diagnosis_date"] + relativedelta(years=1)}
+    )
 
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
 
 def test_missing_nhs_number():
     form = PatientForm({})
-    assert("nhs_number" in form.errors.as_data())
+    assert "nhs_number" in form.errors.as_data()
 
 
 def test_invalid_nhs_number():
-    form = PatientForm({
-        "nhs_number": "123456789"
-    })
+    form = PatientForm({"nhs_number": "123456789"})
 
-    assert("nhs_number" in form.errors.as_data())
+    assert "nhs_number" in form.errors.as_data()
 
 
 def test_date_of_birth_missing():
     form = PatientForm({})
-    assert("date_of_birth" in form.errors.as_data())
+    assert "date_of_birth" in form.errors.as_data()
 
 
 def test_future_date_of_birth():
-    form = PatientForm({
-        "date_of_birth": TODAY + relativedelta(days=1)
-    })
+    form = PatientForm({"date_of_birth": TODAY + relativedelta(days=1)})
 
     errors = form.errors.as_data()
-    assert("date_of_birth" in errors)
+    assert "date_of_birth" in errors
 
     error_message = errors["date_of_birth"][0].messages[0]
-    assert(error_message == "Cannot be in the future")
+    assert error_message == "Cannot be in the future"
 
 
 def test_over_25():
-    form = PatientForm({
-        "date_of_birth": TODAY - relativedelta(years=25, days=1)
-    })
+    form = PatientForm({"date_of_birth": TODAY - relativedelta(years=25, days=1)})
 
     errors = form.errors.as_data()
-    assert("date_of_birth" in errors)
+    assert "date_of_birth" in errors
 
     error_message = errors["date_of_birth"][0].messages[0]
-    assert(error_message == "NPDA patients cannot be 25+ years old. This patient is 25")
+    assert error_message == "NPDA patients cannot be 25+ years old. This patient is 25"
 
 
 def test_missing_diabetes_type():
     form = PatientForm({})
-    assert("diabetes_type" in form.errors.as_data())
+    assert "diabetes_type" in form.errors.as_data()
 
 
 def test_invalid_diabetes_type():
-    form = PatientForm({
-        "diabetes_type": 45
-    })
+    form = PatientForm({"diabetes_type": 45})
 
-    assert("diabetes_type" in form.errors.as_data())
+    assert "diabetes_type" in form.errors.as_data()
 
 
 def test_missing_diagnosis_date():
     form = PatientForm({})
-    assert("diagnosis_date" in form.errors.as_data())
+    assert "diagnosis_date" in form.errors.as_data()
 
 
 def test_future_diagnosis_date():
-    form = PatientForm({
-        "diagnosis_date": TODAY + relativedelta(days=1)
-    })
+    form = PatientForm({"diagnosis_date": TODAY + relativedelta(days=1)})
 
     errors = form.errors.as_data()
-    assert("diagnosis_date" in errors)
+    assert "diagnosis_date" in errors
 
     error_message = errors["diagnosis_date"][0].messages[0]
-    assert(error_message == "Cannot be in the future")
+    assert error_message == "Cannot be in the future"
 
 
 def test_diagnosis_date_before_date_of_birth():
-    form = PatientForm({
-        "date_of_birth": VALID_FIELDS["date_of_birth"],
-        "diagnosis_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1)
-    })
+    form = PatientForm(
+        {
+            "date_of_birth": VALID_FIELDS["date_of_birth"],
+            "diagnosis_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1),
+        }
+    )
 
     errors = form.errors.as_data()
-    assert("diagnosis_date" in errors)
+    assert "diagnosis_date" in errors
 
     error_message = errors["diagnosis_date"][0].messages[0]
-    assert(error_message == "'Date of Diabetes Diagnosis' cannot be before 'Date of Birth'")
+    assert (
+        error_message == "'Date of Diabetes Diagnosis' cannot be before 'Date of Birth'"
+    )
 
 
 def test_invalid_sex():
-    form = PatientForm({
-        "sex": 45
-    })
+    form = PatientForm({"sex": 45})
 
-    assert("sex" in form.errors.as_data())
+    assert "sex" in form.errors.as_data()
 
 
 def test_invalid_ethnicity():
-    form = PatientForm({
-        "ethnicity": 45
-    })
+    form = PatientForm({"ethnicity": 45})
 
-    assert("ethnicity" in form.errors.as_data())
+    assert "ethnicity" in form.errors.as_data()
 
 
 def test_missing_gp_details():
     form = PatientForm({})
-    
+
     errors = form.errors.as_data()
-    assert("gp_practice_ods_code" in errors)
+    assert "gp_practice_ods_code" in errors
 
     error_message = errors["gp_practice_ods_code"][0].messages[0]
-    assert(error_message == "'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty")
+    assert (
+        error_message
+        == "'GP Practice ODS code' and 'GP Practice postcode' cannot both be empty"
+    )
 
 
 def test_patient_creation_with_future_death_date():
-    form = PatientForm({
-        "death_date": TODAY + relativedelta(years=1)
-    })
+    form = PatientForm({"death_date": TODAY + relativedelta(years=1)})
 
     errors = form.errors.as_data()
-    assert("death_date" in errors)
+    assert "death_date" in errors
 
     error_message = errors["death_date"][0].messages[0]
-    assert(error_message == "Cannot be in the future")
+    assert error_message == "Cannot be in the future"
 
 
 def test_patient_creation_with_death_date_before_date_of_birth():
-    form = PatientForm({
-        "date_of_birth": VALID_FIELDS["date_of_birth"],
-        "death_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1)
-    })
+    form = PatientForm(
+        {
+            "date_of_birth": VALID_FIELDS["date_of_birth"],
+            "death_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1),
+        }
+    )
 
     errors = form.errors.as_data()
-    assert("death_date" in errors)
+    assert "death_date" in errors
 
     error_message = errors["death_date"][0].messages[0]
-    assert(error_message == "'Death Date' cannot be before 'Date of Birth'")
+    assert error_message == "'Death Date' cannot be before 'Date of Birth'"
 
 
 def test_multiple_date_validation_errors_returned():
-    form = PatientForm({
-        "date_of_birth": VALID_FIELDS["date_of_birth"],
-        "diagnosis_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1),
-        "death_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1)
-    })
+    form = PatientForm(
+        {
+            "date_of_birth": VALID_FIELDS["date_of_birth"],
+            "diagnosis_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1),
+            "death_date": VALID_FIELDS["date_of_birth"] - relativedelta(years=1),
+        }
+    )
 
     errors = form.errors.as_data()
-    
-    assert("death_date" in errors)
-    assert("diagnosis_date" in errors)
+
+    assert "death_date" in errors
+    assert "diagnosis_date" in errors
 
 
 @pytest.mark.django_db
 def test_spaces_removed_from_postcode():
-    with patch("project.npda.forms.patient_form.validate_patient_sync") as mock_validate_patient_sync:
-        form = PatientForm(VALID_FIELDS | {
-            "postcode": "WC1X 8SH",
-        })
+    with patch(
+        "project.npda.forms.patient_form.validate_patient_sync"
+    ) as mock_validate_patient_sync:
+        form = PatientForm(
+            VALID_FIELDS
+            | {
+                "postcode": "WC1X 8SH",
+            }
+        )
 
         form.is_valid()
-    
+
         mock_validate_patient_sync.assert_called_once_with(
             postcode="WC1X8SH",
             gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
-            gp_practice_postcode=None
+            gp_practice_postcode=None,
         )
 
 
 @pytest.mark.django_db
 def test_dashes_removed_from_postcode():
-    with patch("project.npda.forms.patient_form.validate_patient_sync") as mock_validate_patient_sync:
-        form = PatientForm(VALID_FIELDS | {
-            "postcode": "WC1X-8SH",
-        })
+    with patch(
+        "project.npda.forms.patient_form.validate_patient_sync"
+    ) as mock_validate_patient_sync:
+        form = PatientForm(
+            VALID_FIELDS
+            | {
+                "postcode": "WC1X-8SH",
+            }
+        )
 
         form.is_valid()
-    
+
         mock_validate_patient_sync.assert_called_once_with(
             postcode="WC1X8SH",
             gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
-            gp_practice_postcode=None
+            gp_practice_postcode=None,
         )
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(postcode="W1A 1AA"))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(postcode="W1A 1AA"),
+)
 def test_normalised_postcode_saved():
     form = PatientForm(VALID_FIELDS)
     form.is_valid()
 
-    assert(form.cleaned_data["postcode"] == "W1A 1AA")
+    assert form.cleaned_data["postcode"] == "W1A 1AA"
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(postcode=ValidationError("Invalid postcode")))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(postcode=ValidationError("Invalid postcode")),
+)
 def test_invalid_postcode():
     form = PatientForm(VALID_FIELDS)
     form.is_valid()
 
-    assert("postcode" in form.errors.as_data())
+    assert "postcode" in form.errors.as_data()
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(postcode=None))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(postcode=None),
+)
 def test_error_validating_postcode():
     # TODO MRB: report this back somehow rather than just eat it in the log? (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/334)
     form = PatientForm(VALID_FIELDS)
     form.is_valid()
 
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(gp_practice_postcode=ValidationError("Invalid postcode")))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(
+        gp_practice_postcode=ValidationError("Invalid postcode")
+    ),
+)
 def test_invalid_gp_postcode():
     form = PatientForm(VALID_FIELDS_WITH_GP_POSTCODE)
     form.is_valid()
 
-    assert("gp_practice_postcode" in form.errors.as_data())
+    assert "gp_practice_postcode" in form.errors.as_data()
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(gp_practice_postcode=None))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(gp_practice_postcode=None),
+)
 def test_error_validating_gp_postcode():
     # TODO MRB: report this back somehow rather than just eat it in the log? (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/334)
     form = PatientForm(VALID_FIELDS_WITH_GP_POSTCODE)
     form.is_valid()
 
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(gp_practice_ods_code=ValidationError("Invalid ODS code")))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(
+        gp_practice_ods_code=ValidationError("Invalid ODS code")
+    ),
+)
 def test_invalid_gp_ods_code():
     form = PatientForm(VALID_FIELDS)
     form.is_valid()
 
-    assert("gp_practice_ods_code" in form.errors.as_data())
+    assert "gp_practice_ods_code" in form.errors.as_data()
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(gp_practice_ods_code=None))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(gp_practice_ods_code=None),
+)
 def test_error_validating_gp_ods_code():
     # TODO MRB: report this back somehow rather than just eat it in the log? (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/334)
     form = PatientForm(VALID_FIELDS)
     form.is_valid()
 
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
 
 @pytest.mark.django_db
@@ -311,17 +354,23 @@ def test_lookup_index_of_multiple_deprivation():
     form = PatientForm(VALID_FIELDS)
 
     form.is_valid()
-    assert(len(form.errors.as_data()) == 0)
+    assert len(form.errors.as_data()) == 0
 
     patient = form.save()
-    assert(patient.index_of_multiple_deprivation_quintile == INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE)
+    assert (
+        patient.index_of_multiple_deprivation_quintile
+        == INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE
+    )
 
 
 @pytest.mark.django_db
-@patch("project.npda.forms.patient_form.validate_patient_sync", mock_external_validation_result(index_of_multiple_deprivation_quintile=None))
+@patch(
+    "project.npda.forms.patient_form.validate_patient_sync",
+    mock_external_validation_result(index_of_multiple_deprivation_quintile=None),
+)
 def test_error_looking_up_index_of_multiple_deprivation():
     # TODO MRB: report this back somehow rather than just eat it in the log? (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/334)
     form = PatientForm(VALID_FIELDS)
     patient = form.save()
-    
+
     patient.index_of_multiple_deprivation_quintile = None

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -364,6 +364,18 @@ def test_lookup_index_of_multiple_deprivation():
 
 
 @pytest.mark.django_db
+def test_lookup_location():
+    form = PatientForm(VALID_FIELDS)
+
+    form.is_valid()
+    assert len(form.errors.as_data()) == 0
+
+    patient = form.save()
+    assert patient.location_wgs84 == LOCATION[0]
+    assert patient.location_bng == LOCATION[1]
+
+
+@pytest.mark.django_db
 @patch(
     "project.npda.forms.patient_form.validate_patient_sync",
     mock_external_validation_result(index_of_multiple_deprivation_quintile=None),

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -20,6 +20,7 @@ from project.npda.tests.factories.patient_factory import (
     INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
     TODAY,
     VALID_FIELDS,
+    LOCATION,
 )
 from project.npda.forms.external_patient_validators import (
     PatientExternalValidationResult,
@@ -34,14 +35,20 @@ MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
     gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
     gp_practice_postcode=None,
     index_of_multiple_deprivation_quintile=INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
+    location_bng=None,
+    location_wgs84=None,
 )
 
-MOCK_VISIT_EXTERNAL_VALIDATION_RESULT = VisitExternalValidationResult(None, None, None, None)
+MOCK_VISIT_EXTERNAL_VALIDATION_RESULT = VisitExternalValidationResult(
+    None, None, None, None
+)
 
 
 def mock_patient_external_validation_result(**kwargs):
     return AsyncMock(
-        return_value=dataclasses.replace(MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT, **kwargs)
+        return_value=dataclasses.replace(
+            MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT, **kwargs
+        )
     )
 
 
@@ -521,7 +528,9 @@ def test_death_date_before_date_of_birth(test_user, single_row_valid_df):
 @pytest.mark.django_db
 @patch(
     "project.npda.general_functions.csv.csv_upload.validate_patient_async",
-    mock_patient_external_validation_result(postcode=ValidationError("Invalid postcode")),
+    mock_patient_external_validation_result(
+        postcode=ValidationError("Invalid postcode")
+    ),
 )
 def test_invalid_postcode(test_user, single_row_valid_df):
     single_row_valid_df["Postcode of usual address"] = "not a postcode"
@@ -598,7 +607,9 @@ def test_lookup_index_of_multiple_deprivation(test_user, single_row_valid_df):
 @pytest.mark.django_db
 @patch(
     "project.npda.general_functions.csv.csv_upload.validate_patient_async",
-    mock_patient_external_validation_result(index_of_multiple_deprivation_quintile=None),
+    mock_patient_external_validation_result(
+        index_of_multiple_deprivation_quintile=None
+    ),
 )
 def test_error_looking_up_index_of_multiple_deprivation(test_user, single_row_valid_df):
     csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)


### PR DESCRIPTION
### Overview
Location save is added to the async validation functions when a patient is added to NPDA, either by csv upload or through the questionnaire.

This builds on the elegant work of @mbarton. It adds a new async function that uses the postcodes.io service to get longitude and latitude against the patient postcode. It uses these to generate two geodjango Point objects (one for the bng or british national grid which uses northings and eastings, the other for wgs84 which uses the crs 4326 which is standard for mapping). A small optimisation is that the imd and location async functions are now ignored if the postcode fails validation. This limits the noise in the logs.

### Code changes
- `external_patient_validators`: adds a new `_location_for_postcode` method, and conditionally calls this or `_imd_for_postcode` if postcode is valid. Location is returned as a tuple of `location_wgs84, location_bng`
- `patient_form`: adds the new location fields and updates them on save
- adds the location fields to the `csv_upload` 
- removes the creation of location fields from `map.py` which had been there as a temporizing measure
- makes the `location_for_postcode` function async

closes #417