### PR TITLE
Remove all dark mode tailwind references

### DIFF
--- a/documentation/docs/developer/branding.md
+++ b/documentation/docs/developer/branding.md
@@ -16,16 +16,3 @@ The RCPCH full brand guidance can be found [here](https://github.com/rcpch/rcpch
 ## Use of TailwindCSS
 
 Note that the NPDA audit uses [TailwindCSS](https://tailwindcss.com/) with custom variables to conform to RCPCH branding.
-
-!!! info "Tailwind CSS CLI - Using watch to speed up development"
-    Tailwind is a large package, so "tree-shakes" unused CSS classes on build. Because of this, it is necessary to rebuild the styles.css file (i.e., "rerun treeshaking") when adding Tailwind classes to templates that haven't been used elsewhere. By rebuilding, Tailwind will automatically find and add classes to styles.css. 
-    
-    For one-off rebuilds:
-    ```console
-    docker compose exec -it django npm run build:css
-    ```
-    
-    To avoid multiple rebuilds, you can leverage Tailwind's CLI `watch` command using: 
-    ```console
-    docker compose exec -it django npm run watch:css
-    ```

--- a/documentation/docs/developer/docker-setup.md
+++ b/documentation/docs/developer/docker-setup.md
@@ -213,19 +213,6 @@ s/seed
 
 See the [Seeding the Database](../manual-setup/#seeding-the-database) section for more details on the usage of this script, for example setting a non-default Cohort Number.
 
-### Running with VSCode Debugger
-
-If you are using VSCode, you can run the Django server with the VScode debugger attached through:
-
-```console
-s/up-debug
-```
-
-This sets up the save development environment as `s/up` but additionally uses some overrides to enable Debugpy.
-
-Once setup, add a breakpoint in your code (little red dot in the margin next to line numbers), and use the hotkey `F5` to start the debugger. The debugger will pause at the breakpoint and you can inspect variables and step through the code.
-
-Unforunately, this doesn't work with running `manage.py` commands, nor `pytest` yet, but runs for the Django Server. For debugging those environments, use the `pdb` debugger through `breakpoint()`s.
 
 ## Tips and Tricks, Gotchas and Caveats
 

--- a/documentation/docs/developer/useful-scripts.md
+++ b/documentation/docs/developer/useful-scripts.md
@@ -1,0 +1,32 @@
+Easy reference for useful scripts to make development a breeze.
+
+
+## Create and run the development environment:
+
+```console
+`s/up`
+```
+
+## Create and run the development environment **with the VSCode debugger available for the Django server**:
+
+```console
+s/up-debug
+```
+
+This sets up the save development environment as `s/up` but additionally uses some overrides to enable Debugpy.
+
+Once running, add a breakpoint in your code (little red dot in the margin next to line numbers), and use the hotkey `F5` to start the debugger. The debugger will pause at the breakpoint and you can inspect variables and step through the code.
+
+Unforunately, this doesn't work with running `manage.py` commands, nor `pytest` yet, but runs for the Django Server. For debugging those environments, use the `pdb` debugger through `breakpoint()`s.
+
+
+## Auto-rebuild Tailwind CSS when adding new classes:
+
+```console
+s/watch-tailwind
+```
+
+!!! info " **Why?**"
+    Tailwind tree-shakes unused CSS classes on build. Therefore, you must rebuild the `styles.css` file when adding new Tailwind classes not previously used.
+
+    This script watches for changes and rebuilds the CSS file automatically.

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
     - 'legal/privacy.md'
     - 'legal/terms-of-service.md'
   - Developer:
+    - 'developer/useful-scripts.md'
     - 'developer/branding.md'
     - 'developer/code-style.md'
     - 'developer/database.md'

--- a/project/npda/templates/nav.html
+++ b/project/npda/templates/nav.html
@@ -79,14 +79,14 @@
       </div>
       <div class="flex md:flex-wrap justify-around">
         <a href="{% url 'home' %}"
-           class="btn btn-ghost text-xl dark:text-rcpch_lightest_grey h-auto"
+           class="btn btn-ghost text-xl  h-auto"
            style="max-width:100%">
           <img src="https://www.rcpch.ac.uk/themes/rcpch/images/logo-desktop.svg"
                class="mr-3 h-12"
                alt="RCPCH Logo" />
         </a>
         <a href="{% url 'home' %}"
-           class="btn btn-ghost text-xl dark:text-rcpch_lightest_grey h-auto"
+           class="btn btn-ghost text-xl  h-auto"
            style="max-width:100%">
           <span class="xl:hidden">NPDA</span><span class="hidden xl:block">National Paediatric
             <br>
@@ -99,37 +99,37 @@
             <li class="flex items-center hover:inner-shadow">
               <div class="tooltip tooltip-bottom" data-tip="Dashboard">
                 <a href="{% url 'dashboard' %}"
-                   class="text-xs block font-montserrat font-semibold  dark:text-rcpch_lightest_grey text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent {% active_navbar_tab request 'submissions' %}"
+                   class="text-xs block font-montserrat font-semibold   text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent {% active_navbar_tab request 'submissions' %}"
                    aria-current="page"><i class="fa-solid fa-house"></i></a>
               </div>
             </li>
             <li class="flex items-center hover:inner-shadow">
               <a href="{% url 'submissions' %}"
-                 class="text-xs block font-montserrat font-semibold dark:text-rcpch_lightest_grey text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent underline-offset-8 hover:underline {% active_navbar_tab request 'submissions' %}"
+                 class="text-xs block font-montserrat font-semibold  text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent active:bg-transparent underline-offset-8 hover:underline {% active_navbar_tab request 'submissions' %}"
                  aria-current="page">Submissions</a>
             </li>
             {% if can_complete_questionnaire %}
               <li class="flex items-center hover:inner-shadow">
                 <a href="{% url 'patients' %}"
-                   class="text-xs block font-montserrat font-semibold dark:text-rcpch_lightest_grey text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 underline-offset-8 hover:underline hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'patients' %}"
+                   class="text-xs block font-montserrat font-semibold  text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 underline-offset-8 hover:underline hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'patients' %}"
                    aria-current="page">Questionnaire</a>
               </li>
             {% endif %}
             {% if can_upload_csv %}
               <li class="flex items-center hover:inner-shadow">
                 <a href="{% url 'home' %}"
-                   class="text-xs block font-montserrat font-semibold dark:text-rcpch_lightest_grey text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 underline-offset-8 hover:underline hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'home' %}"
+                   class="text-xs block font-montserrat font-semibold  text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 underline-offset-8 hover:underline hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'home' %}"
                    aria-current="page">Upload CSV</a>
               </li>
             {% endif %}
             <li class="flex items-center hover:inner-shadow">
               <a href="{% url 'npda_users' %}"
-                 class="text-xs block font-montserrat underline-offset-8 dark:text-rcpch_lightest_grey hover:underline font-semibold  text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'npda_users' %}">Users</a>
+                 class="text-xs block font-montserrat underline-offset-8  hover:underline font-semibold  text-gray-700 lg:border-0 lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent {% active_navbar_tab request 'npda_users' %}">Users</a>
             </li>
           {% endif %}
           <li>
             <a href="http://0.0.0.0:8007/"
-               class="text-xs block font-montserrat underline-offset-8 hover:underline font-semibold text-gray-700 lg:border-0 dark:text-rcpch_lightest_grey lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent">User Guide</a>
+               class="text-xs block font-montserrat underline-offset-8 hover:underline font-semibold text-gray-700 lg:border-0  lg:hover:text-primary-700 px-0 lg:px-5 py-2 lg:py-2.5 mr-2 text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent">User Guide</a>
           </li>
         </ul>
       </div>
@@ -137,7 +137,7 @@
         <ul class="menu p-0 menu-horizontal hidden lg:flex px-1 flex gap-x-2 place-items-center">
           {% if user.is_superuser %}
             <ul class="p-3">
-              <div class="-mt-2 underline dark:text-rcpch_lightest_grey underline-offset-8 p-2 w-full text-center font-semibold text-nowrap">
+              <div class="-mt-2 underline  underline-offset-8 p-2 w-full text-center font-semibold text-nowrap">
                 <i class="fa-solid fa-solar-panel"></i> Control Panel
               </div>
               <div class="flex justify-center">
@@ -159,7 +159,7 @@
             </div>
           </div>
           <ul tabindex="0"
-              class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[70] mt-3 w-60 p-2 shadow-xl dark:drop-shadow-[0_35px_35px_rgba(1,0,0,0.25)">
+              class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[70] mt-3 w-60 p-2 shadow-xl ">
             <label class="hidden flex cursor-pointer gap-2 mx-auto my-2 items-center">
               <i class="fa-solid fa-sun"></i>
               <input type="checkbox"

--- a/project/npda/templates/two_factor/_wizard_actions.html
+++ b/project/npda/templates/two_factor/_wizard_actions.html
@@ -20,7 +20,7 @@
        class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">Reset
     Password</a>
     <div class="mt-5">
-      <div class="mt-2 bg-gray-100 border border-gray-200 text-sm text-gray-800 rounded-lg p-4 dark:bg-white/10 dark:border-white/20 dark:text-white font-montserrat"
+      <div class="mt-2 bg-gray-100 border border-gray-200 text-sm text-gray-800 rounded-lg p-4  font-montserrat"
            role="alert">
         <span class="font-bold">NOTE</span> For users of the old platform, you will require a new username and password to
         access this new platform. Please contact your Coordinator or <a href="mailto:npda@rcpch.ac.uk">npda@rcpch.ac.uk</a> for assistance.


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

I have darkmode as my machine's system preference, tailwind was still detecting this and applying dark styles, but we don't have a full dark mode theme yet (still WIP) so couple places looks a bit odd.

cc @reece for visibility 


### Code changes
Just removes the few styles where `dark:` is specified

### Documentation changes (done or required as a result of this PR)

- Also refactors some docs to add `Useful scripts` page with `s/watch-tailwind` script



### Related Issues

#108
#427


### Mentions
@mentions of the person or team responsible for reviewing proposed changes.
