### PR TITLE
fix-local-authority-district-radius

### DIFF
--- a/documentation/docs/developer/organisations.md
+++ b/documentation/docs/developer/organisations.md
@@ -9,7 +9,7 @@ The organisational structure of health care in England and Wales influences repo
 
 ### Organisations and Trusts
 
-This is the lowest level of abstraction and represents either an acute or a community hospital/organisation responsible for epilepsy care of children and young people. There are often several organisations in a Trust. Each organisation, like each Trust, has its own ODS code, and from year to year there is movement between trusts as organisations change their allegiances between trusts when mergers are carried out. The organisation model therefore has more than once instance for some organisations, as their parent status or other details such as name change.
+This is the lowest level of abstraction and represents either an acute or a community hospital/organisation responsible for the care of children and young people. There are often several organisations in a Trust. Each organisation, like each Trust, has its own ODS code, and from year to year there is movement between trusts as organisations change their allegiances between trusts when mergers are carried out. The organisation model therefore has more than once instance for some organisations, as their parent status or other details such as name change.
 
 Organisations are not actively tracked in NPDA as they are in Epilepsy12 and parent RCPCH NHS Organisations API, but the PaediatricDiabetesUnit model stores the lead organisation name and ODS code as well as the diabetes network name and code.
 

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -16,6 +16,6 @@
     </figure>
   </div>
   <div id="loading-spinner"
-       class="loading loading-spinner text-rcpch_dark_blue flex-grow-1 w-1/5 mx-auto">
+       class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center w-1/5 mx-auto bg-center">
   </div>
 {% endblock %}

--- a/project/npda/tests/permissions_tests/test_mixins_against_session.py
+++ b/project/npda/tests/permissions_tests/test_mixins_against_session.py
@@ -95,11 +95,15 @@ class TestQuestionnaireView:
         """
         # Create a patient
         form = PatientForm(VALID_FIELDS)
-
+        print(audit_dates)
         # Modify the session
         session = self.client.session
-        session["selected_audit_year"] = audit_dates[0].year + 1
+        session["selected_audit_year"] = (
+            audit_dates[0].year + 2
+        )  # 2 years in the future will always be a different audit year
         session.save()
+
+        print(self.client.session["selected_audit_year"])
 
         # url
         url = reverse("patient-add")

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -18,7 +18,9 @@ from project.npda.general_functions.map import (
     generate_distance_from_organisation_scatterplot_figure,
     generate_dataframe_and_aggregated_distance_data_from_cases,
 )
-from project.npda.general_functions.rcpch_nhs_organisations import fetch_organisation_by_ods_code
+from project.npda.general_functions.rcpch_nhs_organisations import (
+    fetch_organisation_by_ods_code,
+)
 
 # RCPCH imports
 from project.npda.views.decorators import login_and_otp_required
@@ -65,7 +67,9 @@ def get_waffle_chart_partial(request):
 
         # Handle empty data (eg. if no eligible pts)
         if not data:
-            return render(request, "dashboard/waffle_chart_partial.html", {"chart_html": None})
+            return render(
+                request, "dashboard/waffle_chart_partial.html", {"chart_html": None}
+            )
 
         # Ensure percentages sum to 100
         total = sum(data.values())
@@ -102,7 +106,10 @@ def get_waffle_chart_partial(request):
 
         # Create Plotly waffle chart
         GRID_SIZE = 10  # 10x10 grid
-        Y, X = GRID_SIZE - 1, 0  # We start top left and move left to right, top to bottom
+        Y, X = (
+            GRID_SIZE - 1,
+            0,
+        )  # We start top left and move left to right, top to bottom
 
         chart_data = []
         # For each label, add the appropriate number of squares to the chart data
@@ -176,11 +183,15 @@ def get_waffle_chart_partial(request):
                 "displayModeBar": False,
             },
         )
-        return render(request, "dashboard/waffle_chart_partial.html", {"chart_html": chart_html})
+        return render(
+            request, "dashboard/waffle_chart_partial.html", {"chart_html": chart_html}
+        )
 
     except Exception as e:
         return render(
-            request, "dashboard/waffle_chart_partial.html", {"error": "Something went wrong!"}
+            request,
+            "dashboard/waffle_chart_partial.html",
+            {"error": "Something went wrong!"},
         )
 
 
@@ -200,7 +211,7 @@ def get_map_chart_partial(request):
     try:
         pdu_lead_organisation = fetch_organisation_by_ods_code(
             ods_code=paediatric_diabetes_unit.lead_organisation_ods_code
-        )["properties"]
+        )
     except:
         raise ValueError(
             f"Lead organisation for PDU {paediatric_diabetes_unit.lead_organisation_ods_code=} not found"
@@ -215,7 +226,9 @@ def get_map_chart_partial(request):
 
     # # aggregated distances (mean, median, max, min) that patients have travelled to the selected organisation
     aggregated_distances, patient_distances_dataframe = (
-        generate_dataframe_and_aggregated_distance_data_from_cases(filtered_cases=patients_to_plot)
+        generate_dataframe_and_aggregated_distance_data_from_cases(
+            filtered_cases=patients_to_plot
+        )
     )
 
     # generate scatterplot of patients by distance from the selected organisation
@@ -494,4 +507,6 @@ def get_hcl_scatter_plot(request):
         },
     )
 
-    return render(request, "dashboard/hcl_scatter_plot_partial.html", {"chart_html": chart_html})
+    return render(
+        request, "dashboard/hcl_scatter_plot_partial.html", {"chart_html": chart_html}
+    )


### PR DESCRIPTION
### Overview
In development work in the RCPCH NHS Organisations API the local authority district endpoint was inadvertently not added to `urls.py`, so the endpoint was not present to return a list of LADs for the lead organisation to filter LSOAs against in the map.

This endpoint now is actually two endpoints, one which returns geojson and the other which does not. Since we are storing the LAD and LSOA boundary geojson data within NPDA, we do not need to request it from the API, so the `properties` element has been removed from the API call. 

fixes #450