### PR TITLE
[Dashboard] Make charts' card height fit better into screen

### DIFF
--- a/project/npda/templates/dashboard/colored_figures_chart_partial.html
+++ b/project/npda/templates/dashboard/colored_figures_chart_partial.html
@@ -2,10 +2,11 @@
 <div class="alert alert-danger">
   <i class="fa-solid fa-person-circle-exclamation"></i> {{ error }}
 </div>
-{% elif chart_html %}
+{% else %}
 <div class="flex justify-between px-3">
   {% for should_color in is_colored %}
     <i class="fa-solid fa-child {% if should_color %} text-rcpch_light_blue {% else %} text-rcpch_dark_grey {% endif %} fa-2xl"></i>
   {% endfor %}
 </div>
 {% endif %}
+

--- a/project/npda/templates/dashboard/dashboard_base.html
+++ b/project/npda/templates/dashboard/dashboard_base.html
@@ -45,10 +45,11 @@
     </div>
 
     <div class="flex flex-col gap-3">
+      <!-- Total Eligible Patients Card -->
+      {% include 'dashboard/components/cards/total_eligible_patients_card.html' %}
       <!-- HCL CARD -->
       {% include 'dashboard/components/cards/hcl_use_card.html' %}
-      <!-- care at diagnosis CARD -->
-      {% include 'dashboard/components/cards/care_at_diagnosis_card.html' %}
+
     </div>
 
   </div>
@@ -57,8 +58,8 @@
     {% include 'dashboard/components/cards/health_checks_completion_rate_card.html' %}
     <!-- ADDITIONAL CARE PROCESSES CARD -->
     {% include 'dashboard/components/cards/additional_care_processes_card.html' %}
-    <!-- Total Eligible Patients Card -->
-    {% include 'dashboard/components/cards/total_eligible_patients_card.html' %}
+    <!-- care at diagnosis CARD -->
+    {% include 'dashboard/components/cards/care_at_diagnosis_card.html' %}
   </div>
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4 my-4">
     <!-- SEX CARD -->

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -47,6 +47,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CHART_HTML_HEIGHT = "18rem"
+
 
 @login_and_otp_required()
 def get_patient_level_report_partial(request):
@@ -203,7 +205,7 @@ def get_waffle_chart_partial(request):
                     y=[square["y"]],
                     mode="markers",
                     marker=dict(
-                        size=25,
+                        size=10,
                         color=square["colour"],
                         symbol="square",
                     ),
@@ -220,7 +222,7 @@ def get_waffle_chart_partial(request):
                     x=[None],
                     y=[None],
                     mode="markers",
-                    marker=dict(size=15, color=colours[idx], symbol="square"),
+                    marker=dict(size=10, color=colours[idx], symbol="square"),
                     name=f"{pct}% {label}",
                     # hoverinfo="skip",
                 )
@@ -230,7 +232,12 @@ def get_waffle_chart_partial(request):
             xaxis=dict(visible=False),
             yaxis=dict(visible=False),
             margin=dict(l=0, r=0, t=0, b=0),
-            legend=dict(orientation="h", y=1.1, x=0.5, xanchor="center"),
+            legend=dict(
+                orientation="h",
+                y=1.25,  # Move legend higher above the plot
+                x=0.5,
+                xanchor="center",
+            ),
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",
         )
@@ -242,6 +249,7 @@ def get_waffle_chart_partial(request):
             config={
                 "displayModeBar": False,
             },
+            default_height=DEFAULT_CHART_HTML_HEIGHT,
         )
         return render(request, "dashboard/waffle_chart_partial.html", {"chart_html": chart_html})
 
@@ -429,7 +437,11 @@ def get_simple_bar_chart_pcts_partial(request):
             title="",
             xaxis_title="",
             yaxis_title="% CYP with T1DM",
-            yaxis=dict(range=[0, 110]),  # Breathing room for percentages around 100
+            yaxis=dict(
+                range=[0, 120], # Breathing room for percentages above 100
+                tickvals = [0, 25, 50, 75, 100],
+                ticktext = ["0", "25", "50", "75", "100"],
+            ),  
             template="simple_white",  # Clean grid style
             # Wrap text
             xaxis=dict(
@@ -449,6 +461,7 @@ def get_simple_bar_chart_pcts_partial(request):
             config={
                 "displayModeBar": False,
             },
+            default_height=DEFAULT_CHART_HTML_HEIGHT,
         )
 
         return render(
@@ -544,6 +557,7 @@ def get_hcl_scatter_plot(request):
             config={
                 "displayModeBar": False,
             },
+            default_height=DEFAULT_CHART_HTML_HEIGHT,
         )
 
         return render(

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -237,6 +237,7 @@ def get_waffle_chart_partial(request):
                 y=1.25,  # Move legend higher above the plot
                 x=0.5,
                 xanchor="center",
+                font=dict(size=10),
             ),
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

Caps the height of chart cards to some arbitrary smaller height so fits better in single screen height:

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/0a994871-ee5d-440a-8de7-8acd9dc100fd" />


<img width="1385" alt="image" src="https://github.com/user-attachments/assets/e907a32f-b0b1-44aa-ab9d-7ea664f95b78" />

**NOTE: this was before:**
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/96917e66-abab-4ae6-abd3-e9d400b2e806" />


- Additionally misc aesthetic / legend tweaks related to smaller size
- Fix bug where person charts weren't rendering
