### PR TITLE
Improve patient table on smaller screens

### DIFF
--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -61,7 +61,7 @@
     <table class="font-montserrat table-md table mt-2 mb-5 text-sm text-left rtl:text-right">
       <thead class="bg-rcpch_dark_blue text-xs text-white uppercase">
         <tr class="snap-x">
-          <th scope="col" class="nhs-number-column px-2 py-3 text-center">
+          <th scope="col" class="px-2 py-3 text-center">
             <span class="flex flex-row">
               <div id="nhs_num_sort_label"  hx-preserve  class="swap swap-rotate">
                 <button hx-preserve
@@ -89,7 +89,7 @@
           <th scope="col" class="px-2 py-3 text-center">Sex</th>
           <th scope="col" class="px-2 py-3 text-center">Date of Birth</th>
           <th scope="col" class="px-2 py-3 text-center">Postcode</th>
-          <th scope="col" class="nhs-number-column px-2 py-3 text-center">
+          <th scope="col" class="px-2 py-3 text-center">
             <span class="flex flex-row">
               <div id="deprivation_sort_label"  hx-preserve  class="swap swap-rotate">
                 <button hx-preserve
@@ -148,25 +148,48 @@
           {% endif %}
           <tr class="{% if forloop.counter|divisibleby:2 %} bg-gray-100 {% endif %} hover:bg-gray-200">
             {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
-              <td class="nhs-number-column">
-                <a class="btn hover:text-rcpch_pink {% if nhs_number_error or gp_error %} text-rcpch_red {% endif %}"
-                   target="_blank"
-                   href="{% url 'patient-update' patient.pk %}">
-                    <span class="tooltip tooltip-right"
-                          data-tip="{% if nhs_number_error or gp_error %} {{ nhs_number_error }} {{gp_error}} {% else %} View patient details (opens new tab) {% endif %}">
-                      {% if nhs_number_error or gp_error %}
-                        <span class="fa-stack">
-                          <i class="fa-circle fa-stack-1x fas"></i>
-                          <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                        </span>
-                      {% else %}
-                        <i class="fa-hospital-user fas"></i>
-                      {% endif %}
-                    </span>
-                  {{ patient.nhs_number }}
+              <td class="whitespace-nowrap">
+                <a
+                  class="btn flex p-1 h-full tooltip tooltip-right {% if nhs_number_error or gp_error %} text-rcpch_red {% else %} hover:text-rcpch_pink {% endif %}"
+                  target="_blank"
+                  href="{% url 'patient-update' patient.pk %}"
+                  data-tip="{% if nhs_number_error or gp_error %} {{ nhs_number_error }} {{gp_error}} {% else %} View patient details (opens new tab) {% endif %}">
+                  <span class="fa-stack">
+                    {% if nhs_number_error or gp_error %}
+                      <i class="fa-circle fa-stack-1x fas"></i>
+                      <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                    {% else %}
+                      <i class="fa-hospital-user fa-stack-1x fas"></i>
+                    {% endif %}
+                  </span>
+                  <strong class="font-mono text-xs">
+                    {{ patient.nhs_number }}
+                  </span>
                 </a>
               </td>
             {% endwith %}
+            <!-- {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
+              <td class="whitespace-nowrap">
+                <a class="btn flex flex-col tooltip tooltip-right {% if nhs_number_error or gp_error %} text-rcpch_red {% else %} hover:text-rcpch_pink {% endif %}"
+                   target="_blank"
+                   href="{% url 'patient-update' patient.pk %}"
+                   data-tip="{% if nhs_number_error or gp_error %} {{ nhs_number_error }} {{gp_error}} {% else %} View patient details (opens new tab) {% endif %}">
+                  {% if nhs_number_error or gp_error %}
+                    <div class="fa-stack">
+                      <i class="fa-circle fa-stack-1x fas"></i>
+                      <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                    </div>
+                  {% else %}
+                    <div>
+                      <i class="fa-hospital-user fas"></i>
+                    </div>
+                  {% endif %}
+                  <div class="font-mono text-xs">
+                    {{ patient.nhs_number }}
+                  </div>
+                </a>
+              </td>
+            {% endwith %} -->
             <td class="px-6 py-4 text-center items-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"sex" %}
                 <div class="tooltip tooltip-right"

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -269,37 +269,20 @@
             <td class="px-6 py-4 text-center">{{ patient.latest_quarter|default:'-' }}</td>
             <td class="text-right whitespace-nowrap">
               <a href="{% url 'patient_visits' patient.pk %}"
-                 {% if patient.is_valid and patient.visit_error_count < 1 %} class="align-center text-rcpch_pink flex justify-end px-2 hover:text-white" {% else %} class="text-rcpch_red flex justify-end hover:text-white" {% endif %}>
+                class="align-center flex tooltip tooltip-left {% if patient.visit_error_count < 1 %} text-rcpch_pink {% else %} text-rcpch_red {% endif %}"
+                data-tip="{% if patient.visit_error_count > 0 %} {{ patient.visit_error_count }} visit{{ patient.visit_error_count|pluralize }} {{ patient.visit_error_count|pluralize:'has, have' }} errors that need addressing. Items have been saved but will not be included until rectified. {% else %} View patient visits {% endif %}"
+                >
                 {% if patient.visit_error_count > 0 %}
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                   <strong class="text-rcpch_red self-center px-2">Visits ({{ patient.visit_set.all.count }})</strong>
-                  <svg class="text-rcpch_red self-center"
-                       height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" fill="currentColor" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
-                  <div class="-mt-20 font-montserrat tooltip-content absolute hidden px-2 py-2 text-left text-white bg-gray-800 rounded shadow-lg group-hover:block">
-                    {{ patient.visit_error_count }} visit{{ patient.visit_error_count|pluralize }} {{ patient.visit_error_count|pluralize:'has, have' }} errors that need addressing.
-                    <br>
-                    Items have been saved but will not be included until rectified.
-                  </div>
                 {% else %}
                   <strong class="text-rcpch_pink self-center">Visits ({{ patient.visit_set.all.count }})</strong>
                 {% endif %}
                 <!-- caret -->
-                <svg class="{% if patient.is_valid and patient.visit_error_count < 1 %} text-rcpch_pink w-8 h-8 self-center" {% else %} text-rcpch_red w-8 h-8 self-center {% endif %}"
+                <svg class="w-8 h-8 self-center"
                   width="24"
                   height="24"
                   viewBox="0 0 24 24"

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -163,9 +163,7 @@
                         <i class="fa-hospital-user fas"></i>
                       {% endif %}
                     </span>
-                  <div class="badge">
-                    {{ patient.nhs_number }}
-                  </div>
+                  {{ patient.nhs_number }}
                 </a>
               </td>
             {% endwith %}
@@ -261,7 +259,7 @@
               {{ patient.diagnosis_date }}
             </td>
             <td class="px-6 py-4 text-center">{{ patient.latest_quarter|default:'-' }}</td>
-            <td class="relative text-right whitespace-nowrap">
+            <td class="text-right whitespace-nowrap">
               <a href="{% url 'patient_visits' patient.pk %}"
                  {% if patient.is_valid and patient.visit_error_count < 1 %} class="align-center text-rcpch_pink flex justify-end px-2 hover:text-white" {% else %} class="text-rcpch_red flex justify-end hover:text-white" {% endif %}>
                 {% if patient.visit_error_count > 0 %}
@@ -312,7 +310,7 @@
       </tbody>
       <tfoot>
         <tr class="bg-rcpch_dark_blue py-5 text-xs text-white text-gray-700 uppercase bg-gray-50">
-          <th colspan="11" class="px-2">
+          <th colspan="8" class="px-2">
             <strong>Total: {{ patient_list.count }} patients</strong>
           </th>
           <th colspan="2">

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -136,7 +136,7 @@
                   <i class="fa-arrow-down-1-9 fa-solid mr-2"></i>
                 </button>
               </div>
-              Deprivation Decile
+              Deprivation Quintile
             </span>
           </th>
           <th scope="col" class="px-2 py-3 text-center">Ethnicity</th>

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -61,31 +61,6 @@
     <table class="font-montserrat table-md table mt-2 mb-5 text-sm text-left rtl:text-right">
       <thead class="bg-rcpch_dark_blue text-xs text-white uppercase">
         <tr class="snap-x">
-          <th scope="col" class="px-2 py-3 text-center">
-            <span class="flex flex-row">
-              <div id="npda_id_sort_label"  hx-preserve  class="swap swap-rotate">
-                <button hx-preserve
-                        hx-get="{{ asc_url }}?sort_by=pk&page={{ current_page }}&sort=asc"
-                        hx-on:htmx:after-request="document.getElementById('npda_id_sort_label').classList.toggle('swap-active');"
-                        hx-trigger="click throttle:1s"
-                        hx-target="#patient_table"
-                        hx-swap="innerHTML swap:100ms"
-                        class="swap-on">
-                  <i class="fa-arrow-up-9-1 fa-solid mr-2"> </i>
-                </button>
-                <button hx-preserve
-                        hx-get="{{ desc_url }}?sort_by=pk&page={{ current_page }}&sort=desc"
-                        hx-on:htmx:after-request="document.getElementById('npda_id_sort_label').classList.toggle('swap-active');"
-                        hx-trigger="click throttle:1s"
-                        hx-target="#patient_table"
-                        hx-swap="innerHTML swap:100ms"
-                        class="swap-off">
-                  <i class="fa-arrow-down-1-9 fa-solid mr-2"></i>
-                </button>
-              </div>
-              NPDA Patient ID
-            </span>
-          </th>
           <th scope="col" class="nhs-number-column px-2 py-3 text-center">
             <span class="flex flex-row">
               <div id="nhs_num_sort_label"  hx-preserve  class="swap swap-rotate">
@@ -172,31 +147,26 @@
             {% endif %}
           {% endif %}
           <tr class="{% if forloop.counter|divisibleby:2 %} bg-gray-100 {% endif %} hover:bg-gray-200">
-            <td>
-              <span class="tooltip tooltip-right"
-                    data-tip="View patient details (opens new tab)">
-                <a class="btn hover:text-rcpch_pink"
+            {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
+              <td class="nhs-number-column">
+                <a class="btn hover:text-rcpch_pink {% if nhs_number_error or gp_error %} text-rcpch_red {% endif %}"
                    target="_blank"
                    href="{% url 'patient-update' patient.pk %}">
-                  <i class="fa-hospital-user fas"></i>
+                    <span class="tooltip tooltip-right"
+                          data-tip="{% if nhs_number_error or gp_error %} {{ nhs_number_error }} {{gp_error}} {% else %} View patient details (opens new tab) {% endif %}">
+                      {% if nhs_number_error or gp_error %}
+                        <span class="fa-stack">
+                          <i class="fa-circle fa-stack-1x fas"></i>
+                          <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                        </span>
+                      {% else %}
+                        <i class="fa-hospital-user fas"></i>
+                      {% endif %}
+                    </span>
                   <div class="badge">
-                    <span class="font-mono text-xs">{{ patient.pk }}</span>
+                    {{ patient.nhs_number }}
                   </div>
                 </a>
-              </span>
-            </td>
-            {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
-              <td class="nhs-number-column {% if nhs_number_error or gp_error %} text-rcpch_red {% endif %}">
-                {% if nhs_number_error or gp_error %}
-                  <span class="tooltip tooltip-right"
-                        data-tip="{{ nhs_number_error }} {{gp_error}}">
-                    <span class="fa-stack">
-                      <i class="fa-circle fa-stack-1x fas"></i>
-                      <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                    </span>
-                  </span>
-                {% endif %}
-                {{ patient.nhs_number }}
               </td>
             {% endwith %}
             <td class="px-6 py-4 text-center items-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
@@ -291,7 +261,7 @@
               {{ patient.diagnosis_date }}
             </td>
             <td class="px-6 py-4 text-center">{{ patient.latest_quarter|default:'-' }}</td>
-            <td class="w-60 relative px-2 text-right group">
+            <td class="relative text-right whitespace-nowrap">
               <a href="{% url 'patient_visits' patient.pk %}"
                  {% if patient.is_valid and patient.visit_error_count < 1 %} class="align-center text-rcpch_pink flex justify-end px-2 hover:text-white" {% else %} class="text-rcpch_red flex justify-end hover:text-white" {% endif %}>
                 {% if patient.visit_error_count > 0 %}

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -205,23 +205,10 @@
               {% if patient.errors|error_for_field:"sex" %}
                 <div class="tooltip tooltip-right"
                      data-tip="{{ patient.errors|error_for_field:'sex' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
@@ -231,23 +218,10 @@
               {% if patient.errors|error_for_field:"date_of_birth" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'date_of_birth' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
@@ -257,49 +231,23 @@
               {% if patient.errors|error_for_field:"postcode" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'postcode' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
               {{ patient.postcode }}
             </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'postcode' %}text-rcpch_red{% endif %}">
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"index_of_multiple_deprivation_quintile" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                    <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
@@ -309,23 +257,10 @@
               {% if patient.errors|error_for_field:"ethnicity" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'ethnicity' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
@@ -335,23 +270,10 @@
               {% if patient.errors|error_for_field:"diabetes_type" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'diabetes_type' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}
@@ -361,23 +283,10 @@
               {% if patient.errors|error_for_field:"diagnosis_date" %}
                 <div class="tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'diagnosis_date' }}">
-                  <svg height="16"
-                       style="overflow:visible;
-                              enable-background:new 0 0 32 32"
-                       viewBox="0 0 32 32"
-                       width="16"
-                       xml:space="preserve"
-                       xmlns="http://www.w3.org/2000/svg"
-                       xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <g>
-                    <g id="Error_1_">
-                    <g id="Error">
-                    <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                    <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                    </g>
-                    </g>
-                    </g>
-                  </svg>
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
                 </div>
                 &nbsp;
               {% endif %}

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -58,7 +58,7 @@
 {% endif %}
 {% if patient_list %}
   <div class="w-full overflow-x-scroll">
-    <table class="font-montserrat table-md table mt-2 mb-5 text-sm text-left text-gray-400 rtl:text-right">
+    <table class="font-montserrat table-md table mt-2 mb-5 text-sm text-left rtl:text-right">
       <thead class="bg-rcpch_dark_blue text-xs text-white uppercase">
         <tr class="snap-x">
           <th scope="col" class="px-2 py-3 text-center">

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -168,118 +168,103 @@
                 </a>
               </td>
             {% endwith %}
-            <!-- {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
-              <td class="whitespace-nowrap">
-                <a class="btn flex flex-col tooltip tooltip-right {% if nhs_number_error or gp_error %} text-rcpch_red {% else %} hover:text-rcpch_pink {% endif %}"
-                   target="_blank"
-                   href="{% url 'patient-update' patient.pk %}"
-                   data-tip="{% if nhs_number_error or gp_error %} {{ nhs_number_error }} {{gp_error}} {% else %} View patient details (opens new tab) {% endif %}">
-                  {% if nhs_number_error or gp_error %}
-                    <div class="fa-stack">
-                      <i class="fa-circle fa-stack-1x fas"></i>
-                      <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                    </div>
-                  {% else %}
-                    <div>
-                      <i class="fa-hospital-user fas"></i>
-                    </div>
-                  {% endif %}
-                  <div class="font-mono text-xs">
-                    {{ patient.nhs_number }}
-                  </div>
-                </a>
-              </td>
-            {% endwith %} -->
-            <td class="px-6 py-4 text-center items-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"sex" %}
-                <div class="tooltip tooltip-right"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'sex' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.get_sex_display }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.get_sex_display }}
               {% endif %}
-              {{ patient.get_sex_display }}
             </td>
-            <td class="px-6 py-4 items-center {% if patient.errors|error_for_field:'date_of_birth' %} text-rcpch_red {% endif %}">
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'date_of_birth' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"date_of_birth" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'date_of_birth' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.date_of_birth }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.date_of_birth }}
               {% endif %}
-              {{ patient.date_of_birth }}
             </td>
             <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'postcode' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"postcode" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'postcode' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.postcode }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.postcode }}
               {% endif %}
-              {{ patient.postcode }}
             </td>
             <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"index_of_multiple_deprivation_quintile" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' }}">
-                    <span class="fa-stack">
+                  <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.index_of_multiple_deprivation_quintile }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.index_of_multiple_deprivation_quintile }}
               {% endif %}
-              {{ patient.index_of_multiple_deprivation_quintile }}
             </td>
             <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'ethnicity' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"ethnicity" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'ethnicity' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.get_ethnicity_display }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.get_ethnicity_display }}
               {% endif %}
-              {{ patient.get_ethnicity_display }}
             </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'diabetes_type' %} text-rcpch_red {% endif %}">
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'diabetes_type' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"diabetes_type" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'diabetes_type' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.get_diabetes_type_display }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.get_diabetes_type_display }}
               {% endif %}
-              {{ patient.get_diabetes_type_display }}
             </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'diagnosis_date' %} text-rcpch_red {% endif %}">
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'diagnosis_date' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"diagnosis_date" %}
-                <div class="tooltip tooltip-top"
+                <div class="inline-flex tooltip tooltip-top"
                      data-tip="{{ patient.errors|error_for_field:'diagnosis_date' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
+                  {{ patient.diagnosis_date }}
                 </div>
-                &nbsp;
+              {% else %}
+                {{ patient.diagnosis_date }}
               {% endif %}
-              {{ patient.diagnosis_date }}
             </td>
             <td class="px-6 py-4 text-center">{{ patient.latest_quarter|default:'-' }}</td>
             <td class="text-right whitespace-nowrap">

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -142,8 +142,6 @@
           <th scope="col" class="px-2 py-3 text-center">Ethnicity</th>
           <th scope="col" class="px-2 py-3 text-center">Diabetes Type</th>
           <th scope="col" class="px-2 py-3 text-center">Diagnosis Date</th>
-          <th scope="col" class="px-2 py-3 text-center">Date Uploaded</th>
-          <th scope="col" class="px-2 py-3 text-center">Audit Year</th>
           <th scope="col"
               class="px-2 py-3 text-center tooltip tooltip-bottom"
               data-tip="The most recent quarter for which data has been uploaded.">
@@ -292,10 +290,6 @@
               {% endif %}
               {{ patient.diagnosis_date }}
             </td>
-            <td class="px-6 py-4 text-center">
-              {{ patient.last_upload_date|date:"d/m/Y H:m:s" }}
-            </td>
-            <td class="px-6 py-4 text-center">{{ patient.audit_year }}</td>
             <td class="px-6 py-4 text-center">{{ patient.latest_quarter|default:'-' }}</td>
             <td class="w-60 relative px-2 text-right group">
               <a href="{% url 'patient_visits' patient.pk %}"

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -187,57 +187,20 @@
                 </a>
               </span>
             </td>
-            <td class="nhs-number-column {% if patient.errors|error_for_field:'nhs_number' or patient.errors|error_for_field:'gp_practice_ods_code' %} text-rcpch_red {% endif %}">
-              {% if patient.errors|error_for_field:"nhs_number" or patient.errors|error_for_field:"gp_practice_ods_code" %}
-                {% if patient.errors|error_for_field:"gp_practice_ods_code" %}
+            {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
+              <td class="nhs-number-column {% if nhs_number_error or gp_error %} text-rcpch_red {% endif %}">
+                {% if nhs_number_error or gp_error %}
                   <span class="tooltip tooltip-right"
-                        data-tip="{{ patient.errors|error_for_field:'gp_practice_ods_code' }}">
-                    <svg class="mr-2"
-                         height="16"
-                         style="overflow:visible;
-                                enable-background:new 0 0 32 32"
-                         viewBox="0 0 32 32"
-                         width="16"
-                         xml:space="preserve"
-                         xmlns="http://www.w3.org/2000/svg"
-                         xmlns:xlink="http://www.w3.org/1999/xlink">
-                      <g>
-                      <g id="Error_1_">
-                      <g id="Error">
-                      <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                      <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                      </g>
-                      </g>
-                      </g>
-                    </svg>
+                        data-tip="{{ nhs_number_error }} {{gp_error}}">
+                    <span class="fa-stack">
+                      <i class="fa-circle fa-stack-1x fas"></i>
+                      <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                    </span>
                   </span>
                 {% endif %}
-                {% if patient.errors|error_for_field:"nhs_number" %}
-                  <span class="tooltip tooltip-right"
-                        data-tip="{{ patient.errors|error_for_field:'nhs_number' }}">
-                    <svg class="mr-2"
-                         height="16"
-                         style="overflow:visible;
-                                enable-background:new 0 0 32 32"
-                         viewBox="0 0 32 32"
-                         width="16"
-                         xml:space="preserve"
-                         xmlns="http://www.w3.org/2000/svg"
-                         xmlns:xlink="http://www.w3.org/1999/xlink">
-                      <g>
-                      <g id="Error_1_">
-                      <g id="Error">
-                      <circle cx="16" cy="16" id="BG" r="16" style="fill:#D72828;" />
-                      <path d="M14.5,25h3v-3h-3V25z M14.5,6v13h3V6H14.5z" id="Exclamatory_x5F_Sign" style="fill:#E6E6E6;" />
-                      </g>
-                      </g>
-                      </g>
-                    </svg>
-                  </span>
-                {% endif %}
-              {% endif %}
-              {{ patient.nhs_number }}
-            </td>
+                {{ patient.nhs_number }}
+              </td>
+            {% endwith %}
             <td class="px-6 py-4 text-center items-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"sex" %}
                 <div class="tooltip tooltip-right"

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -42,14 +42,3 @@ input[type="radio"]:checked {
   opacity: 1;
   transition: opacity 500ms ease-out;
 }
-
-.nhs-number-column {
-  white-space: nowrap;
-  width: auto;
-}
-
-.nhs-number-column .flex {
-  display: flex;
-  align-items: center;
-  justify-content: center; /* Optional: Center horizontally as well */
-}


### PR DESCRIPTION
## Small screen

### Before

![Screenshot from 2025-01-11 16-24-11](https://github.com/user-attachments/assets/e21d4f7d-99ae-489a-88dd-cc5a809b0cbd)


### After

![Screenshot from 2025-01-11 16-23-57](https://github.com/user-attachments/assets/eb268b42-5bb8-4f78-bf41-ff37d4a38f79)


## Big screen

### Before
![Screenshot from 2025-01-11 16-22-59](https://github.com/user-attachments/assets/777957b7-b0ae-4ffe-94db-6b9c16afb354)

### After
![Screenshot from 2025-01-11 16-22-36](https://github.com/user-attachments/assets/90def108-ba8d-453f-98e4-a39d5817428a)

- Remove some columns to make space
  - NPDA patient ID
  - Date uploaded
  - Audit year
- Correctly call the IMD column quintile not decile
- Change the text to black not grey to improve readability
- Replace all SVG icons with font awesome to reduce the amount of code in the template
- Fix the visit tooltip on error

Fixes #468, although the link still goes off screen at lower sizes.
