### PR TITLE
Save cleaned fields during CSV upload even if other fields are invalid

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -132,10 +132,15 @@ async def csv_upload(user, dataframe, csv_file, pdu_pz_code):
     def create_instance(model, form):
         # We want to retain fields even if they're invalid so that we can return them to the user
         # Use the field value from cleaned_data, falling back to data if it's not there
-        if form.is_valid():
-            data = form.cleaned_data
-        else:
-            data = form.data
+        data = {}
+
+        for key, value in form.cleaned_data.items():
+            data[key] = value
+        
+        for key, value in form.data.items():
+            if key not in data:
+                data[key] = value
+
         instance = model(**data)
         instance.is_valid = form.is_valid()
         instance.errors = (

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -835,29 +835,35 @@ def test_height_is_rounded_to_one_decimal(test_user, single_row_valid_df):
 
 
 @pytest.mark.django_db
+@patch(
+    "project.npda.general_functions.csv.csv_upload.validate_patient_async",
+    mock_patient_external_validation_result(
+        postcode=ValidationError("Invalid postcode")
+    ),
+)
 def test_cleaned_fields_are_stored_when_other_fields_are_invalid(test_user, single_row_valid_df):
     # PATIENT
-    # - Invalid
-    single_row_valid_df["NHS Number"] = "123"
+    # - Valid, cleaning should remove the spaces
+    single_row_valid_df["NHS Number"] = "719 573 0220"
 
-    # - Valid, cleaning should upper case the postcode
-    single_row_valid_df["Postcode of usual address"] = "wc1x 8sh"
+    # Postcode marked as invalid by the mock patched above
+    single_row_valid_df["Postcode of usual address"] = "not a real postcode"
 
     # VISIT
-    # - Invalid - cannot be less than 40
-    single_row_valid_df["Patient Height (cm)"] = 38
-
     # - Valid, cleaning should retain only one decimal place
     single_row_valid_df["Patient Weight (kg)"] = 7.89
+
+    # - Invalid - cannot be less than 40
+    single_row_valid_df["Patient Height (cm)"] = 38
 
     csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
 
     patient = Patient.objects.first()
     visit = Visit.objects.first()
 
-    assert(patient.nhs_number == "123") # saved but invalid
-    assert(patient.postcode == "WC1X8SH")
+    assert(patient.nhs_number == "7195730220") # cleaned version saved
+    assert(patient.postcode == "not a real postcode") # saved but invalid
 
+    assert(visit.weight == round(Decimal("7.89"), 1)) # cleaned version saved
     assert(visit.height == 38) # saved but invalid
-    assert(visit.weight == 7.9)
     


### PR DESCRIPTION
I noticed testing #473 with `dummy_sheet.csv` that the NHS number had spaces in it if the CSV row had an error in one of the patient columns but otherwise it didn't.

CSV upload is implemented by filling in the same Django forms as manual input using the questionnaire. This was a bug where we only saved the cleaned data if the entire form were valid. So if you had a validation error in one of the columns that maps to the patient form, none of the other cleaned values would be saved (and the same for visit form).

This has real world implications as the normalised NHS number would not be saved, potentially meaning duplicates would not be detected during upload.

The fix was simply to take all the fields from cleaned data and then fill in any extra ones from data.