### PR TITLE
Make it easier to read NHS numbers in the patient list

### DIFF
--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -163,7 +163,7 @@
                     {% endif %}
                   </span>
                   <strong class="font-mono text-xs">
-                    {{ patient.nhs_number }}
+                    {{ patient.nhs_number|format_nhs_number }}
                   </span>
                 </a>
               </td>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -309,3 +309,10 @@ def get_item(dictionary:dict, key:str):
 @register.simple_tag
 def docs_url():
     return settings.DOCS_URL
+
+@register.filter
+def format_nhs_number(nhs_number):
+    if nhs_number and len(nhs_number) >= 10:
+        return f"{nhs_number[:3]} {nhs_number[3:6]} {nhs_number[6:]}"
+    
+    return nhs_number


### PR DESCRIPTION
We normalise down the NHS numbers so put spaces back in the patient list to make it easier to read them.

![Screenshot from 2025-01-11 20-23-06](https://github.com/user-attachments/assets/ec300cbe-50c2-40bf-bd25-ab7c66911abf)
