### PR TITLE
Show patient NHS number in visit form

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -4,8 +4,8 @@
 {% block content %}
   <div class="flex justify-center bg-white py-8">
     <div class="max-w-full lg:max-w-[75%] px-2 bg-white font-montserrat">
-      <strong>{{ title }} - NPDA Patient {{ patient_id }}
-        {% if visit_id %}- NPDA Visit No. {{ visit_id }}{% endif %}
+      <strong>
+        {{ title }} - NHS Number {{ nhs_number }}
       </strong>
       <form id="update-form"
             method="post"

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -103,6 +103,8 @@ class VisitCreateView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["patient_id"] = self.kwargs["patient_id"]
+        patient = Patient.objects.get(pk=self.kwargs["patient_id"])
+        context["nhs_number"] = patient.nhs_number
         context["title"] = "Add New Visit"
         context["form_method"] = "create"
         context["button_title"] = "Add New Visit"
@@ -143,12 +145,15 @@ class VisitUpdateView(
     form_class = VisitForm
 
     def get_context_data(self, **kwargs):
+        print(f"!! get_context_data")
+
         context = super().get_context_data(**kwargs)
         visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
         visit_categories = get_visit_categories(visit_instance)
         context["visit_instance"] = visit_instance
         context["visit_errors"] = [visit_instance.errors]
         context["patient_id"] = self.kwargs["patient_id"]
+        context["nhs_number"] = visit_instance.patient.nhs_number
         context["visit_id"] = self.kwargs["pk"]
         context["title"] = "Edit Visit Details"
         context["button_title"] = "Edit Visit Details"
@@ -209,6 +214,8 @@ class VisitUpdateView(
         )
 
     def get_initial(self):
+        print(f"!! get_initial")
+
         initial = super().get_initial()
         patient = Patient.objects.get(pk=self.kwargs["patient_id"])
         initial["patient"] = patient

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -145,8 +145,6 @@ class VisitUpdateView(
     form_class = VisitForm
 
     def get_context_data(self, **kwargs):
-        print(f"!! get_context_data")
-
         context = super().get_context_data(**kwargs)
         visit_instance = Visit.objects.get(pk=self.kwargs["pk"])
         visit_categories = get_visit_categories(visit_instance)
@@ -214,8 +212,6 @@ class VisitUpdateView(
         )
 
     def get_initial(self):
-        print(f"!! get_initial")
-
         initial = super().get_initial()
         patient = Patient.objects.get(pk=self.kwargs["patient_id"])
         initial["patient"] = patient


### PR DESCRIPTION
We previously showed the database ID which is not useful for cross referencing with other systems. Since NPDA doesn't collect names this is the best identifier we have.

**Before**

![Screenshot from 2025-01-12 16-26-48](https://github.com/user-attachments/assets/96ff4876-e8e5-4d67-aa55-93821c157c8e)


**After**

![Screenshot from 2025-01-12 16-26-05](https://github.com/user-attachments/assets/9b7c90ef-062f-4109-8580-9d685d967527)
