### PR TITLE
Fix crash for CSV upload with missing date of birth

### DIFF
--- a/project/npda/tests/form_tests/test_external_visit_validators.py
+++ b/project/npda/tests/form_tests/test_external_visit_validators.py
@@ -1,0 +1,130 @@
+from datetime import date
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from httpx import HTTPError
+from django.core.exceptions import ValidationError
+
+from project.npda.forms.external_visit_validators import validate_visit_async, VisitExternalValidationResult
+
+async_client = AsyncMock()
+
+VALID_FIELDS = {
+    "birth_date": date(2000, 1, 1),
+    "observation_date": date(2021, 1, 1),
+    "sex": 1,
+    "height": 123,
+    "weight": 35,
+    "async_client": async_client
+}
+
+EMPTY_RESULT = VisitExternalValidationResult(None, None, None, None)
+
+VALIDATION_ERROR = ValidationError("invalid!")
+HTTP_ERROR = HTTPError("oopsie!")
+
+async def test_missing_birth_date():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores") as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"birth_date": None})
+        )
+
+        assert(result == EMPTY_RESULT)
+        assert(not mock.called)
+
+
+async def test_missing_observation_date():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores") as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"observation_date": None})
+        )
+
+        assert(result == EMPTY_RESULT)
+        assert(not mock.called)
+
+
+async def test_missing_sex():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores") as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"sex": None})
+        )
+
+        assert(result == EMPTY_RESULT)
+        assert(not mock.called)
+
+
+async def test_invalid_sex():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores") as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"sex": 999})
+        )
+
+        assert(result == EMPTY_RESULT)
+        assert(not mock.called)
+
+
+async def test_missing_height():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"height": None})
+        )
+
+        assert(result.height_result is None)
+
+        assert(result.weight_result.centile == 1)
+        assert(result.weight_result.sds == 2)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
+async def test_missing_weight():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"weight": None})
+        )
+
+        assert(result.height_result.centile == 1)
+        assert(result.height_result.sds == 2)
+
+        assert(result.weight_result is None)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
+async def test_validation_error():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(side_effect=VALIDATION_ERROR)) as mock:
+        result = await validate_visit_async(**VALID_FIELDS)
+
+        assert(result.height_result is VALIDATION_ERROR)
+        assert(result.weight_result is VALIDATION_ERROR)
+
+        assert(result.bmi == 23.1)
+        assert(result.bmi_result is VALIDATION_ERROR)
+
+        assert(mock.call_count == 3)
+
+
+async def test_ignores_http_error():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(side_effect=HTTP_ERROR)) as mock:
+        result = await validate_visit_async(**VALID_FIELDS)
+
+        assert(result.height_result is None)
+        assert(result.weight_result is None)
+
+        assert(result.bmi == 23.1)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 3)
+
+
+async def test_passes_through_unexpected_error():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(side_effect=Exception("oopsie!"))) as mock:
+        with pytest.raises(Exception):
+            await validate_visit_async(**VALID_FIELDS)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -214,9 +214,10 @@ def test_multiple_patients(
     "column,model_field",
     [
         pytest.param("NHS Number", "nhs_number"),
+        pytest.param("Date of Birth", "date_of_birth"),
         pytest.param("Diabetes Type", "diabetes_type"),
         pytest.param("Date of Diabetes Diagnosis", "diagnosis_date"),
-    ]
+    ],
 )
 @pytest.mark.django_db
 def test_missing_mandatory_field(test_user, valid_df, column, model_field):
@@ -226,19 +227,6 @@ def test_missing_mandatory_field(test_user, valid_df, column, model_field):
         errors = csv_upload_sync(test_user, valid_df, None, ALDER_HEY_PZ_CODE)
 
     assert model_field in errors[0]
-
-    # Catastrophic - we can't save this patient at all so we won't save any of the patients in the submission
-    assert Patient.objects.count() == 0
-
-
-@pytest.mark.django_db
-def test_missing_date_of_birth(test_user, single_row_valid_df):
-    single_row_valid_df.loc[0, "Date of Birth"] = None
-
-    with transaction.atomic():
-        errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
-    
-    assert "date_of_birth" in errors[0]
 
     # Catastrophic - we can't save this patient at all so we won't save any of the patients in the submission
     assert Patient.objects.count() == 0
@@ -878,3 +866,4 @@ def test_cleaned_fields_are_stored_when_other_fields_are_invalid(test_user, sing
 
     assert(visit.weight == round(Decimal("7.89"), 1)) # cleaned version saved
     assert(visit.height == 38) # saved but invalid
+    

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -214,10 +214,9 @@ def test_multiple_patients(
     "column,model_field",
     [
         pytest.param("NHS Number", "nhs_number"),
-        pytest.param("Date of Birth", "date_of_birth"),
         pytest.param("Diabetes Type", "diabetes_type"),
         pytest.param("Date of Diabetes Diagnosis", "diagnosis_date"),
-    ],
+    ]
 )
 @pytest.mark.django_db
 def test_missing_mandatory_field(test_user, valid_df, column, model_field):
@@ -227,6 +226,19 @@ def test_missing_mandatory_field(test_user, valid_df, column, model_field):
         errors = csv_upload_sync(test_user, valid_df, None, ALDER_HEY_PZ_CODE)
 
     assert model_field in errors[0]
+
+    # Catastrophic - we can't save this patient at all so we won't save any of the patients in the submission
+    assert Patient.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_missing_date_of_birth(test_user, single_row_valid_df):
+    single_row_valid_df.loc[0, "Date of Birth"] = None
+
+    with transaction.atomic():
+        errors = csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE)
+    
+    assert "date_of_birth" in errors[0]
 
     # Catastrophic - we can't save this patient at all so we won't save any of the patients in the submission
     assert Patient.objects.count() == 0
@@ -866,4 +878,3 @@ def test_cleaned_fields_are_stored_when_other_fields_are_invalid(test_user, sing
 
     assert(visit.weight == round(Decimal("7.89"), 1)) # cleaned version saved
     assert(visit.height == 38) # saved but invalid
-    


### PR DESCRIPTION
```
django-1   |     | Traceback (most recent call last):
django-1   |     |   File "/app/project/npda/general_functions/csv/csv_upload.py", line 120, in validate_rows
django-1   |     |     visit_form = await validate_visit_using_form(
django-1   |     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |     |   File "/app/project/npda/general_functions/csv/csv_upload.py", line 96, in validate_visit_using_form
django-1   |     |     form.async_validation_results = await validate_visit_async(
django-1   |     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |     |   File "/app/project/npda/forms/external_visit_validators.py", line 113, in validate_visit_async
django-1   |     |     raise result
django-1   |     |   File "/app/project/npda/forms/external_visit_validators.py", line 45, in _calculate_centiles_z_scores
django-1   |     |     centile, sds = await calculate_centiles_z_scores(
django-1   |     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |     |   File "/app/project/npda/general_functions/dgc_centile_calculations.py", line 29, in calculate_centiles_z_scores
django-1   |     |     "birth_date": birth_date.strftime("%Y-%m-%d"),
django-1   |     |                   ^^^^^^^^^^^^^^^^^^^
django-1   |     | AttributeError: 'NoneType' object has no attribute 'strftime'
```

Added unit tests in the process which also caught a crash if height and weight were missing.