### PR TITLE
Fix audit year when logging in Jan to April

### DIFF
--- a/project/npda/general_functions/audit_period.py
+++ b/project/npda/general_functions/audit_period.py
@@ -3,6 +3,15 @@ from dateutil.relativedelta import relativedelta
 
 
 # TODO MRB: How will we add new audit years (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/481)
+SUPPORTED_AUDIT_YEARS = [
+    # submitted on the old platform, re-uploaded to test this one
+    2023,
+    2024,
+    # first year submitted on this platform
+    2025,
+    2026
+]
+
 def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
     """Get the start and end date of the audit period for the given date.
 
@@ -19,7 +28,7 @@ def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
           a ValueError as undefined.
     """
 
-    if input_date < date(2023, 4, 1) or input_date > date(2027, 3, 31):
+    if input_date < date(SUPPORTED_AUDIT_YEARS[0], 4, 1) or input_date > date(SUPPORTED_AUDIT_YEARS[-1], 3, 31):
         raise ValueError(
             f"Audit period is only available for the years 2024 to 2027. Provided date: {input_date}"
         )
@@ -36,6 +45,11 @@ def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
     audit_end_date = date(audit_year + 1, 3, 31)
 
     return audit_start_date, audit_end_date
+
+
+def get_current_audit_year() -> int:
+    (start_date, _) = get_audit_period_for_date(date.today())
+    return start_date.year
 
 
 def get_quarters_for_audit_period(

--- a/project/npda/general_functions/audit_period.py
+++ b/project/npda/general_functions/audit_period.py
@@ -20,9 +20,9 @@ def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
 
     Data:
         Audit Period	Audit period start	Audit period end
+        2023 - 2024	        1-Apr-23	        31-Mar-24
         2024 - 2025	        1-Apr-24	        31-Mar-25
         2025 - 2026	        1-Apr-25	        31-Mar-26
-        2026 - 2027	        1-Apr-26	        31-Mar-27
 
     NOTE: dates outside of the audit period will raise
           a ValueError as undefined.

--- a/project/npda/general_functions/audit_period.py
+++ b/project/npda/general_functions/audit_period.py
@@ -2,6 +2,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 
 
+# TODO MRB: How will we add new audit years (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/481)
 def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
     """Get the start and end date of the audit period for the given date.
 
@@ -18,7 +19,7 @@ def get_audit_period_for_date(input_date: date) -> tuple[date, date]:
           a ValueError as undefined.
     """
 
-    if input_date < date(2024, 4, 1) or input_date > date(2027, 3, 31):
+    if input_date < date(2023, 4, 1) or input_date > date(2027, 3, 31):
         raise ValueError(
             f"Audit period is only available for the years 2024 to 2027. Provided date: {input_date}"
         )

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -31,7 +31,14 @@ def create_session_object(user):
         )
     )
 
-    audit_years = [year for year in range(date.today().year - 5, date.today().year + 1)]
+    # TODO MRB: How will we add new audit years (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/481)
+    audit_years = [
+        # submitted on the old platform, re-uploaded to test this one
+        2023,
+        2024,
+        # first year submitted on this platform
+        2025
+    ]
 
     can_upload_csv = True
     can_complete_questionnaire = True

--- a/project/npda/tests/general_functions_tests/test_get_audit_period_for_date.py
+++ b/project/npda/tests/general_functions_tests/test_get_audit_period_for_date.py
@@ -38,14 +38,6 @@ logger = logging.getLogger(__name__)
             date(2026, 3, 31),
             (date(2025, 4, 1), date(2026, 3, 31)),
         ),  # End of the 2025 audit year
-        (
-            date(2026, 4, 1),
-            (date(2026, 4, 1), date(2027, 3, 31)),
-        ),  # Start of the 2026 audit year
-        (
-            date(2027, 3, 31),
-            (date(2026, 4, 1), date(2027, 3, 31)),
-        ),  # End of the 2026 audit year
     ],
 )
 def test_get_audit_period_for_date_returns_correct_start_and_end_date_bounds(

--- a/project/npda/tests/general_functions_tests/test_get_audit_period_for_date.py
+++ b/project/npda/tests/general_functions_tests/test_get_audit_period_for_date.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
     "input_date,expected_date_bounds",
     [
         (
+            date(2023, 4, 1),
+            (date(2023, 4, 1), date(2024, 3, 31)),
+        ),  # Start of the 2023 audit year
+        (
+            date(2024, 3, 31),
+            (date(2023, 4, 1), date(2024, 3, 31)),
+        ),  # End of the 2023 audit year
+        (
             date(2024, 4, 1),
             (date(2024, 4, 1), date(2025, 3, 31)),
         ),  # Start of the 2024 audit year
@@ -50,12 +58,12 @@ def test_ensure_error_raised_for_date_outside_audit_period():
     """
     Test that a ValueError is raised when a date outside the audit period is passed to the function:
 
-    - date(2024, 3, 31) is before
+    - date(2023, 3, 31) is before
     - date(2027, 4, 1) is after
     """
 
     with pytest.raises(ValueError):
-        get_audit_period_for_date(date(2024, 3, 31))
+        get_audit_period_for_date(date(2023, 3, 31))
 
     with pytest.raises(ValueError):
         get_audit_period_for_date(date(2028, 4, 1))


### PR DESCRIPTION
Fixes #460. Audit years run April -> March so the current audit year (as of 13 Jan 2025) is 2024 not 2025.

I've raised #481 to track how we want to add new audit years. 