### PR TITLE
Fix dGC height, weight and BMI fields for CSV upload 

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -179,7 +179,7 @@ class PatientForm(forms.ModelForm):
         ]:
             self.handle_async_validation_result(key)
 
-    def save(self):
+    def save(self, commit=True):
         # We deliberately don't call super.save here as it throws ValueError on validation errors
         # and for CSV uploads we don't want that to stop us. As of Django 5.1.5 it doesn't do anything
         # else other than saving the model or setting up save_m2m. We don't use the latter so
@@ -193,6 +193,7 @@ class PatientForm(forms.ModelForm):
         self.instance.location_bng = self.async_validation_results.location_bng
         self.instance.location_wgs84 = self.async_validation_results.location_wgs84
 
-        self.instance.save()
+        if commit:
+            self.instance.save()
 
         return self.instance

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -794,7 +794,7 @@ class VisitForm(forms.ModelForm):
 
         return cleaned_data
 
-    def save(self):
+    def save(self, commit=True):
         # We deliberately don't call super.save here as it throws ValueError on validation errors
         # and for CSV uploads we don't want that to stop us. As of Django 5.1.5 it doesn't do anything
         # else other than saving the model or setting up save_m2m. We don't use the latter so
@@ -813,6 +813,7 @@ class VisitForm(forms.ModelForm):
                     setattr(self.instance, f"{field_prefix}_centile", result.centile)
                     setattr(self.instance, f"{field_prefix}_sds", result.sds)
 
-        self.instance.save()
+        if commit:
+            self.instance.save()
 
         return self.instance

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -383,6 +383,8 @@ def test_lookup_location():
 def test_error_looking_up_index_of_multiple_deprivation():
     # TODO MRB: report this back somehow rather than just eat it in the log? (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/334)
     form = PatientForm(VALID_FIELDS)
+    form.is_valid()
+
     patient = form.save()
 
     patient.index_of_multiple_deprivation_quintile = None

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -11,6 +11,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 from django.apps import apps
 from django.core.exceptions import ValidationError
+from django.contrib.gis.geos import Point
 from httpx import HTTPError
 
 from project.npda.general_functions.csv import csv_upload, csv_parse
@@ -26,6 +27,7 @@ from project.npda.forms.external_patient_validators import (
 )
 from project.npda.forms.external_visit_validators import (
     VisitExternalValidationResult,
+    CentileAndSDS
 )
 
 
@@ -34,12 +36,15 @@ MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
     gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
     gp_practice_postcode=None,
     index_of_multiple_deprivation_quintile=INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
-    location_bng=None,
-    location_wgs84=None,
+    location_bng=Point(100, -100),
+    location_wgs84=Point(200, -200),
 )
 
 MOCK_VISIT_EXTERNAL_VALIDATION_RESULT = VisitExternalValidationResult(
-    None, None, None, None
+    height_result=CentileAndSDS(centile=Decimal(0.5), sds=Decimal(0.5)),
+    weight_result=CentileAndSDS(centile=Decimal(0.5), sds=Decimal(0.5)),
+    bmi=Decimal(0.5),
+    bmi_result=CentileAndSDS(centile=Decimal(0.5), sds=Decimal(0.5))
 )
 
 
@@ -617,6 +622,31 @@ def test_error_looking_up_index_of_multiple_deprivation(test_user, single_row_va
 
 
 @pytest.mark.django_db
+def test_save_location_from_postcode(test_user, single_row_valid_df):
+    csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE, 2024)
+
+    patient = Patient.objects.first()
+    assert patient.location_bng == MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT.location_bng
+    assert patient.location_wgs84 == MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT.location_wgs84
+
+
+@pytest.mark.django_db
+@patch(
+    "project.npda.general_functions.csv.csv_upload.validate_patient_async",
+    mock_patient_external_validation_result(
+        location_bng=None,
+        location_wgs84=None,
+    ),
+)
+def test_missing_location_from_postcode(test_user, single_row_valid_df):
+    csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE, 2024)
+
+    patient = Patient.objects.first()
+    assert patient.location_bng is None
+    assert patient.location_wgs84 is None
+
+
+@pytest.mark.django_db
 def test_strip_first_spaces_in_column_name(test_user, dummy_sheet_csv):
     csv = dummy_sheet_csv.replace("NHS Number", "  NHS Number")
     df = read_csv_from_str(csv).df
@@ -864,4 +894,20 @@ def test_cleaned_fields_are_stored_when_other_fields_are_invalid(test_user, sing
 
     assert(visit.weight == round(Decimal("7.89"), 1)) # cleaned version saved
     assert(visit.height == 38) # saved but invalid
-    
+
+
+@pytest.mark.django_db
+def test_async_visit_fields_are_saved(test_user, single_row_valid_df):
+    csv_upload_sync(test_user, single_row_valid_df, None, ALDER_HEY_PZ_CODE, 2024)
+    visit = Visit.objects.first()
+
+    assert(visit.height_centile == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.height_result.centile)
+    assert(visit.height_sds == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.height_result.sds)
+
+    assert(visit.weight_centile == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.weight_result.centile)
+    assert(visit.weight_sds == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.weight_result.sds)
+
+    assert(visit.bmi == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.bmi)
+
+    assert(visit.bmi_centile == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.bmi_result.centile)
+    assert(visit.bmi_sds == MOCK_VISIT_EXTERNAL_VALIDATION_RESULT.bmi_result.sds)


### PR DESCRIPTION
Fixes #523 

The code to save these fields was in `VisitForm.save()`. This wasn't being called during CSV upload.

I had previously tried this with `PatientForm.save()` but hit two road blocks:

- There was no asynchronous version to call
- The `ModelForm` base implementation throws a `ValueError` if validation has failed
  - For CSV uploads we still want to save the instance anyway and errors are stored on a separate field

I've decided the best thing to do is just to call these methods, as otherwise it's likely we'll forget to update both places where derived fields need to be saved. Our overrides of `save` don't call `super().save` but that's not a problem in current versions of Django. The risk is that future versions will add functionality in there that we'll miss out on. But for CSV uploads at least the functionality is heavily unit tested at a higher level.

I've tested a 1600 row CSV (100 patients, 16 visits each) and it takes the same amount of time to upload as before, so the new `sync_to_async` calls don't regress performance in any practical sense.