### PR TITLE
Fix patient list overflowing on smaller screens

### DIFF
--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -13,22 +13,23 @@
               NHS Number
             </span>
           </th>
-          <th scope="col" class="px-2 py-3 text-center">Sex</th>
           <th scope="col" class="px-2 py-3 text-center">Date of Birth</th>
-          <th scope="col" class="px-2 py-3 text-center">Postcode</th>
-          <th scope="col" class="px-2 py-3 text-center">
-            <span class="flex flex-row">
-              {% include 'partials/page_elements/sort_icon.html' with field="index_of_multiple_deprivation_quintile" %}
-              Deprivation Quintile
-            </span>
-          </th>
-          <th scope="col" class="px-2 py-3 text-center">Ethnicity</th>
+          <th scope="col" class="px-2 py-3 text-center">Sex</th>
           <th scope="col" class="px-2 py-3 text-center">Diabetes Type</th>
           <th scope="col" class="px-2 py-3 text-center">Diagnosis Date</th>
-          <th scope="col"
-              class="px-2 py-3 text-center tooltip tooltip-bottom"
-              data-tip="The distance travelled to the PDU.">
-            <span>
+          <th scope="col" class="px-2 py-3 text-center">Postcode</th>
+          <th scope="col" class="px-2 py-3 text-center">
+            <span
+              class="tooltip tooltip-bottom"
+              data-tip="The 'Index of Multiple Deprivation' quintile for the patients postcode.">
+              {% include 'partials/page_elements/sort_icon.html' with field="index_of_multiple_deprivation_quintile" %}
+              IMD <i class="fa-question-circle fas"></i>
+            </span>
+          </th>
+          <th scope="col" class="px-2 py-3 text-center">
+            <span
+              class="tooltip tooltip-bottom"
+              data-tip="The distance 'as the crow flies' from the patients postcode to this PDU.">
               {% include 'partials/page_elements/sort_icon.html' with field="distance_from_lead_organisation" %}
               Distance to PDU <i class="fa-question-circle fas"></i>
             </span>
@@ -72,20 +73,6 @@
                 </a>
               </td>
             {% endwith %}
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
-              {% if patient.errors|error_for_field:"sex" %}
-                <div class="inline-flex tooltip tooltip-top"
-                     data-tip="{{ patient.errors|error_for_field:'sex' }}">
-                  <span class="fa-stack">
-                    <i class="fa-circle fa-stack-1x fas"></i>
-                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                  </span>
-                  {{ patient.get_sex_display }}
-                </div>
-              {% else %}
-                {{ patient.get_sex_display }}
-              {% endif %}
-            </td>
             <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'date_of_birth' %}text-rcpch_red{% endif %}">
               {% if patient.errors|error_for_field:"date_of_birth" %}
                 <div class="inline-flex tooltip tooltip-top"
@@ -100,46 +87,18 @@
                 {{ patient.date_of_birth }}
               {% endif %}
             </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'postcode' %}text-rcpch_red{% endif %}">
-              {% if patient.errors|error_for_field:"postcode" %}
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'sex' %}text-rcpch_red{% endif %}">
+              {% if patient.errors|error_for_field:"sex" %}
                 <div class="inline-flex tooltip tooltip-top"
-                     data-tip="{{ patient.errors|error_for_field:'postcode' }}">
+                     data-tip="{{ patient.errors|error_for_field:'sex' }}">
                   <span class="fa-stack">
                     <i class="fa-circle fa-stack-1x fas"></i>
                     <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
                   </span>
-                  {{ patient.postcode }}
+                  {{ patient.get_sex_display }}
                 </div>
               {% else %}
-                {{ patient.postcode }}
-              {% endif %}
-            </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' %}text-rcpch_red{% endif %}">
-              {% if patient.errors|error_for_field:"index_of_multiple_deprivation_quintile" %}
-                <div class="inline-flex tooltip tooltip-top"
-                     data-tip="{{ patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' }}">
-                  <span class="fa-stack">
-                    <i class="fa-circle fa-stack-1x fas"></i>
-                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                  </span>
-                  {{ patient.index_of_multiple_deprivation_quintile }}
-                </div>
-              {% else %}
-                {{ patient.index_of_multiple_deprivation_quintile }}
-              {% endif %}
-            </td>
-            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'ethnicity' %}text-rcpch_red{% endif %}">
-              {% if patient.errors|error_for_field:"ethnicity" %}
-                <div class="inline-flex tooltip tooltip-top"
-                     data-tip="{{ patient.errors|error_for_field:'ethnicity' }}">
-                  <span class="fa-stack">
-                    <i class="fa-circle fa-stack-1x fas"></i>
-                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
-                  </span>
-                  {{ patient.get_ethnicity_display }}
-                </div>
-              {% else %}
-                {{ patient.get_ethnicity_display }}
+                {{ patient.get_sex_display }}
               {% endif %}
             </td>
             <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'diabetes_type' %}text-rcpch_red{% endif %}">
@@ -168,6 +127,34 @@
                 </div>
               {% else %}
                 {{ patient.diagnosis_date }}
+              {% endif %}
+            </td>
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'postcode' %}text-rcpch_red{% endif %}">
+              {% if patient.errors|error_for_field:"postcode" %}
+                <div class="inline-flex tooltip tooltip-top"
+                     data-tip="{{ patient.errors|error_for_field:'postcode' }}">
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
+                  {{ patient.postcode }}
+                </div>
+              {% else %}
+                {{ patient.postcode }}
+              {% endif %}
+            </td>
+            <td class="px-6 py-4 text-center {% if patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' %}text-rcpch_red{% endif %}">
+              {% if patient.errors|error_for_field:"index_of_multiple_deprivation_quintile" %}
+                <div class="inline-flex tooltip tooltip-top"
+                     data-tip="{{ patient.errors|error_for_field:'index_of_multiple_deprivation_quintile' }}">
+                  <span class="fa-stack">
+                    <i class="fa-circle fa-stack-1x fas"></i>
+                    <i class="fa-exclamation fa-stack-1x fa-inverse fas"></i>
+                  </span>
+                  {{ patient.index_of_multiple_deprivation_quintile }}
+                </div>
+              {% else %}
+                {{ patient.index_of_multiple_deprivation_quintile }}
               {% endif %}
             </td>
             <td class="px-6 py-4 text-center">

--- a/project/npda/templates/patients.html
+++ b/project/npda/templates/patients.html
@@ -5,7 +5,7 @@
   <div hx-get="/patients"
        hx-trigger="patients from:body"
        hx-target="#patient_table">
-    <div class="flex flex-col justify-center px-10 mt-5">
+    <div class="flex flex-col justify-center px-1 mt-5">
       <div class="flex flex-wrap">
         <label class="form-control flex items-center gap-2 grow">
           <label class="bg-rcpch_strong_blue mx-6 text-white input flex items-center gap-2 w-full h-auto">


### PR DESCRIPTION
Adding the distance to the PDU (#516) overflows the patient list on smaller screens so you can't click the visits link.

This PR gains back some space by:

- Removing the Ethnicity column (need to check with the team this is OK)
- Renaming `Deprivation Quintile` column to `IMD` and adding a tooltip describing what it is
- Reducing the padding around the table from 10 to 1

The table is now good to display without overflow down to about 1200px wide. I think this will include most desktops and laptops people are likely to use NPDA on but there is an open question how we could make the "Visits" link accessible even if the table overflows on something smaller (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/528)

**Before**


![Capture](https://github.com/user-attachments/assets/2c6c23c8-310d-4485-8fca-ed2c41902c2c)

**After**
![Capture](https://github.com/user-attachments/assets/ac9c7532-fa6e-4556-95d2-bee8167ce8a1)

