### PR TITLE
Fix running Djangos native createsuperuser

### DIFF
--- a/project/npda/management/commands/create_npda_superuser.py
+++ b/project/npda/management/commands/create_npda_superuser.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         if not admin_user_model.objects.filter(email=LOCAL_DEV_ADMIN_EMAIL).exists():
             admin_user_model.objects.create_superuser(
                 first_name="SuperuserAda",
-                last_name="Lovelace",
+                surname="Lovelace",
                 email=LOCAL_DEV_ADMIN_EMAIL,
                 password=LOCAL_DEV_ADMIN_PASSWORD
             )

--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -66,7 +66,7 @@ class NPDAUserManager(BaseUserManager):
 
         return user
 
-    def create_superuser(self, first_name, last_name, email, password):
+    def create_superuser(self, first_name, surname, email, password, is_rcpch_audit_team_member=True, role=RCPCH_AUDIT_TEAM):
         """
         Create and save a SuperUser with the given email and password.
         """
@@ -77,12 +77,12 @@ class NPDAUserManager(BaseUserManager):
             email=email.lower(),
             password=password,
             first_name=first_name,
-            last_name=last_name,
-            role=RCPCH_AUDIT_TEAM,
+            last_name=surname,
+            role=role,
             is_superuser=True,
             is_active=True,
             is_staff=True,
-            is_rcpch_audit_team_member=True,
+            is_rcpch_audit_team_member=is_rcpch_audit_team_member,
             is_rcpch_staff=True,
             email_confirmed=True,
             view_preference=1


### PR DESCRIPTION
Part of #539. I found I couldn't create myself as the first superuser because we have overridden `create_superuser` but not allowed some of the arguments that the native Django call passes. Rather than pass `**kwargs` I have whackamoled each argument as it returned an error. This might break again in future versions of Django, but we are unlikely to use the native command apart from when we create brand new environments. 