### PR TITLE
Log exception on httpx error

### DIFF
--- a/project/npda/forms/external_patient_validators.py
+++ b/project/npda/forms/external_patient_validators.py
@@ -44,7 +44,7 @@ async def _validate_postcode(
                 )
             return normalised_postcode
         except HTTPError as err:
-            logger.warning(f"Error validating postcode {err}")
+            logger.warning(f"Error validating postcode {postcode} {err}", exc_info=True)
 
 
 async def _imd_for_postcode(
@@ -56,7 +56,7 @@ async def _imd_for_postcode(
 
             return imd
         except HTTPError as err:
-            logger.warning(f"Cannot calculate deprivation score for {postcode} {err}")
+            logger.warning(f"Cannot calculate deprivation score for {postcode} {err}", exc_info=True)
 
 
 async def _location_for_postcode(
@@ -70,7 +70,7 @@ async def _location_for_postcode(
 
             return location_wgs84, location_bng
         except HTTPError as err:
-            logger.warning(f"Cannot calculate location for {postcode} {err}")
+            logger.warning(f"Cannot calculate location for {postcode} {err}", exc_info=True)
 
 
 async def _gp_details_from_ods_code(
@@ -88,7 +88,7 @@ async def _gp_details_from_ods_code(
             postcode = result["GeoLoc"]["Location"]["PostCode"]
             return [ods_code, postcode]
     except HTTPError as err:
-        logger.warning(f"Error looking up GP practice by ODS code {err}")
+        logger.warning(f"Error looking up GP practice by ODS code {ods_code} {err}", exc_info=True)
 
 
 async def _gp_details_from_postcode(
@@ -108,7 +108,7 @@ async def _gp_details_from_postcode(
         else:
             return [ods_code, normalised_postcode]
     except HTTPError as err:
-        logger.warning(f"Error looking up GP practice by postcode {err}")
+        logger.warning(f"Error looking up GP practice by postcode {normalised_postcode} {err}", exc_info=True)
 
 
 # Run lookups to external APIs asynchronously to speed up CSV upload by processing patients in parallel

--- a/project/npda/forms/external_visit_validators.py
+++ b/project/npda/forms/external_visit_validators.py
@@ -53,7 +53,7 @@ async def _calculate_centiles_z_scores(
 
         return CentileAndSDS(centile, sds)
     except HTTPError as err:
-        logger.warning(f"Error calculating centiles and z-scores for {measurement_method} {err}")
+        logger.warning(f"Error calculating centiles and z-scores for {measurement_method} {err}", exc_info=True)
 
 # TODO: test questionnaire missing height, weight and observation_date. Do we get blank values for them?
 


### PR DESCRIPTION
Part of #560. The logs were full of:

```
django-1   | WARNING [project.npda.forms.external_patient_validators:47] Error validating postcode
```

But it wasn't actually saying what the error was, despite the error message including the string representation of it.

Add `exc_info=True` (these are still warnings for now so `logger.exception` wasn't appropriate) and hey presto, you get the actual error pop out:

```
django-1   | WARNING [project.npda.forms.external_patient_validators:47] Error validating postcode [REDACTED]
django-1   | Traceback (most recent call last):
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_transports/default.py", line 72, in map_httpcore_exceptions
django-1   |     yield
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_transports/default.py", line 377, in handle_async_request
django-1   |     resp = await self._pool.handle_async_request(req)
django-1   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
django-1   |     raise exc from None
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 232, in handle_async_request
django-1   |     connection = await pool_request.wait_for_connection(timeout=timeout)
django-1   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 35, in wait_for_connection
django-1   |     await self._connection_acquired.wait(timeout=timeout)
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpcore/_synchronization.py", line 149, in wait
django-1   |     with map_exceptions(anyio_exc_map):
django-1   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
django-1   |     self.gen.throw(value)
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
django-1   |     raise to_exc(exc) from exc
django-1   | httpcore.PoolTimeout
django-1   |
django-1   | The above exception was the direct cause of the following exception:
django-1   |                                                                                                                                                                                                                                                                                                                                              django-1   | Traceback (most recent call last):
django-1   |   File "/app/project/npda/forms/external_patient_validators.py", line 39, in _validate_postcode
django-1   |     normalised_postcode = await validate_postcode(postcode, async_client)
django-1   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                    django-1   |   File "/app/project/npda/general_functions/validate_postcode.py", line 22, in validate_postcode
django-1   |     response = await async_client.get(
django-1   |                ^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1814, in get
django-1   |     return await self.request(
django-1   |            ^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1585, in request
django-1   |     return await self.send(request, auth=auth, follow_redirects=follow_redirects)
django-1   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1674, in send
django-1   |     response = await self._send_handling_auth(                                                                                                                                                                                                                                                                                               django-1   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                               django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1702, in _send_handling_auth                                                                                                                                                                                                                                         django-1   |     response = await self._send_handling_redirects(
django-1   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                          django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1739, in _send_handling_redirects
django-1   |     response = await self._send_single_request(request)                                                                                                                                                                                                                                                                                      django-1   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                      django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_client.py", line 1776, in _send_single_request
django-1   |     response = await transport.handle_async_request(request)                                                                                                                                                                                                                                                                                 django-1   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                 django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_transports/default.py", line 376, in handle_async_request                                                                                                                                                                                                                             django-1   |     with map_httpcore_exceptions():
django-1   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
django-1   |   File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__                                                                                                                                                                                                                                                                      django-1   |     self.gen.throw(value)
django-1   |   File "/usr/local/lib/python3.12/site-packages/httpx/_transports/default.py", line 89, in map_httpcore_exceptions                                                                                                                                                                                                                           django-1   |     raise mapped_exc(message) from exc                                                                                                                                                                                                                                                                                                       django-1   | httpx.PoolTimeout
```