### PR TITLE
Support DD/MM/YY (short year) for CSV uploads

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -120,7 +120,7 @@ def csv_parse(csv_file, is_jersey=False):
 
     for column in ALL_DATES:
         if column in df.columns:
-            df[column] = pd.to_datetime(df[column], format="%d/%m/%Y", errors="coerce")
+            df[column] = pd.to_datetime(df[column], format="mixed", dayfirst=True, errors="coerce")
 
     # Apply the dtype to non-date columns
     for column, dtype in CSV_DATA_TYPES_MINUS_DATES.items():

--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -120,7 +120,8 @@ def csv_parse(csv_file, is_jersey=False):
 
     for column in ALL_DATES:
         if column in df.columns:
-            df[column] = pd.to_datetime(df[column], format="mixed", dayfirst=True, errors="coerce")
+            # Support DD/MM/YYYY and DD/MM/YY
+            df[column] = pd.to_datetime(df[column], format="mixed", dayfirst=True, errors="raise")
 
     # Apply the dtype to non-date columns
     for column, dtype in CSV_DATA_TYPES_MINUS_DATES.items():

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -862,6 +862,13 @@ def test_dates_with_short_year(one_patient_two_visits):
 
 
 @pytest.mark.django_db
+def test_bad_date_format(one_patient_two_visits):
+    csv = one_patient_two_visits.to_csv(index=False, date_format="%d/%m")
+    with pytest.raises(ValueError):
+        read_csv_from_str(csv)
+
+
+@pytest.mark.django_db
 def test_upload_csv_with_bool_values_instead_of_int(test_user, single_row_valid_df):
     single_row_valid_df["Has the patient been recommended a Gluten-free diet?"] = True
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -15,6 +15,7 @@ from django.contrib.gis.geos import Point
 from httpx import HTTPError
 
 from project.npda.general_functions.csv import csv_upload, csv_parse
+from project.constants import ALL_DATES
 from project.npda.models import NPDAUser, Patient, Visit
 from project.npda.tests.factories.patient_factory import (
     INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
@@ -850,6 +851,14 @@ def test_upload_without_headers(test_user, one_patient_two_visits):
     # No patients or associated visits should be saved
     assert Patient.objects.count() == 0
     assert Visit.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_dates_with_short_year(one_patient_two_visits):
+    csv = one_patient_two_visits.to_csv(index=False, date_format="%d/%m/%y")
+    df = read_csv_from_str(csv).df
+
+    assert(df.equals(one_patient_two_visits))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #568. DD/MM/YY seen in the wild in an uploaded file from last year