### PR TITLE
Don't raise error on invalid dates in CSV uploads

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -121,7 +121,7 @@ def csv_parse(csv_file, is_jersey=False):
     for column in ALL_DATES:
         if column in df.columns:
             # Support DD/MM/YYYY and DD/MM/YY
-            df[column] = pd.to_datetime(df[column], format="mixed", dayfirst=True, errors="raise")
+            df[column] = pd.to_datetime(df[column], format="mixed", dayfirst=True, errors="coerce")
 
     # Apply the dtype to non-date columns
     for column, dtype in CSV_DATA_TYPES_MINUS_DATES.items():

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -892,11 +892,42 @@ def test_dates_with_short_year(one_patient_two_visits):
     assert(df.equals(one_patient_two_visits))
 
 
+@pytest.mark.parametrize(
+    "column",
+    [
+        pytest.param("Date of Birth"),
+        pytest.param("Date of Diabetes Diagnosis"),
+    ],
+)
 @pytest.mark.django_db
-def test_bad_date_format(one_patient_two_visits):
-    csv = one_patient_two_visits.to_csv(index=False, date_format="%d/%m")
-    with pytest.raises(ValueError):
-        read_csv_from_str(csv)
+def test_bad_date_format_on_mandatory_column(one_patient_two_visits, column):
+    df = one_patient_two_visits
+    
+    df[column] = df[column].astype(str)
+    df[column] = "beep"
+
+    csv = df.to_csv(index=False, date_format="%d/%m/%Y")
+
+    df = read_csv_from_str(csv).df
+    errors = csv_upload_sync(test_user, df)
+
+    print(errors)
+    assert(False == True)
+
+
+@pytest.mark.django_db
+def test_bad_date_format_on_optional_column(one_patient_two_visits):
+    df = one_patient_two_visits
+
+    column = "Date of Level 3 carbohydrate counting education received"
+    
+    df[column] = df[column].astype(str)
+    df[column] = "beep"
+
+    csv = df.to_csv(index=False, date_format="%d/%m/%Y")
+    
+    df = read_csv_from_str(csv).df
+    assert(len(df) == 2)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Follow on from #569 where I made it throw errors if the dates were invalid. Unfortunately the same live file I'm testing has a totally invalid date in one of the cells, not just the short year format.

So this PR changes us back to `errors=coerce` and adds unit tests that bad date input crashes writing that patient to the database but doesn't tank the CSV upload.