### PR TITLE
validation-patient-nhs-number

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -198,6 +198,31 @@ class PatientForm(forms.ModelForm):
                 ),
             )
 
+        if nhs_number:
+            if (
+                Patient.objects.filter(nhs_number=nhs_number)
+                .exclude(id=self.instance.id)
+                .exists()
+            ):
+                self.add_error(
+                    "nhs_number",
+                    ValidationError(
+                        "A patient with this NHS number already exists in the database."
+                    ),
+                )
+        if unique_reference_number:
+            if (
+                Patient.objects.filter(unique_reference_number=unique_reference_number)
+                .exclude(id=self.instance.id)
+                .exists()
+            ):
+                self.add_error(
+                    "unique_reference_number",
+                    ValidationError(
+                        "A patient with this Unique Reference Number already exists in the database."
+                    ),
+                )
+
         reason_leaving_service = cleaned_data.get("reason_leaving_service")
         date_leaving_service = cleaned_data.get("date_leaving_service")
         if date_leaving_service and not reason_leaving_service:

--- a/project/npda/general_functions/map.py
+++ b/project/npda/general_functions/map.py
@@ -107,29 +107,29 @@ def generate_distance_from_organisation_scatterplot_figure(
     """
 
     english_colorscale = [
-        [0, RCPCH_PINK_DARK_TINT],  # Very dark pink
-        [0.11, RCPCH_PINK],  # pink
-        [0.22, RCPCH_PINK_LIGHT_TINT1],  # Medium light pink
-        [0.33, RCPCH_PINK_LIGHT_TINT2],  # light pink
-        [0.44, RCPCH_PINK_LIGHT_TINT3],  # very light pink
-        [0.55, RCPCH_LIGHT_BLUE_TINT3],  # Very light blue
-        [0.66, RCPCH_LIGHT_BLUE_TINT2],  # Light blue
-        [0.77, RCPCH_LIGHT_BLUE_TINT1],  # Medium light blue
-        [0.88, RCPCH_LIGHT_BLUE],  # blue
-        [1, RCPCH_LIGHT_BLUE_DARK_TINT],  # Dark blue
+        [0, RCPCH_LIGHT_BLUE_DARK_TINT],  # Dark blue
+        [0.11, RCPCH_LIGHT_BLUE],  # blue
+        [0.22, RCPCH_LIGHT_BLUE_TINT1],  # Medium light blue
+        [0.33, RCPCH_LIGHT_BLUE_TINT2],  # Light blue
+        [0.44, RCPCH_LIGHT_BLUE_TINT3],  # Very light blue
+        [0.55, RCPCH_PINK_LIGHT_TINT3],  # very light pink
+        [0.66, RCPCH_PINK_LIGHT_TINT2],  # light pink
+        [0.77, RCPCH_PINK_LIGHT_TINT1],  # Medium light pink
+        [0.88, RCPCH_PINK],  # pink
+        [1, RCPCH_PINK_DARK_TINT],  # Very dark pink
     ]
 
     welsh_colorscale = [
-        [0, RCPCH_RED_DARK_TINT],
-        [0.11, RCPCH_RED],
-        [0.22, RCPCH_RED_LIGHT_TINT1],
-        [0.33, RCPCH_RED_LIGHT_TINT2],
-        [0.44, RCPCH_RED_LIGHT_TINT3],
-        [0.55, RCPCH_STRONG_GREEN_LIGHT_TINT3],
-        [0.66, RCPCH_STRONG_GREEN_LIGHT_TINT2],
-        [0.77, RCPCH_STRONG_GREEN_LIGHT_TINT1],
-        [0.88, RCPCH_STRONG_GREEN],
-        [1, RCPCH_STRONG_GREEN_DARK_TINT],
+        [0, RCPCH_STRONG_GREEN_DARK_TINT],
+        [0.11, RCPCH_STRONG_GREEN],
+        [0.22, RCPCH_STRONG_GREEN_LIGHT_TINT1],
+        [0.33, RCPCH_STRONG_GREEN_LIGHT_TINT2],
+        [0.44, RCPCH_STRONG_GREEN_LIGHT_TINT3],
+        [0.55, RCPCH_RED_LIGHT_TINT3],
+        [0.66, RCPCH_RED_LIGHT_TINT2],
+        [0.77, RCPCH_RED_LIGHT_TINT1],
+        [0.88, RCPCH_RED],
+        [1, RCPCH_RED_DARK_TINT],
     ]
 
     # # Load the IMD data (there are two files of merged data, one with IMD ranks merged with english LSOA shapes,

--- a/project/npda/templates/dashboard/components/cards/ethnicity_card.html
+++ b/project/npda/templates/dashboard/components/cards/ethnicity_card.html
@@ -1,27 +1,20 @@
 {% extends 'dashboard/components/bases/base_card.html' %}
 {% block card_title %}
   Ethnicity
-{% endblock card_title%}
+{% endblock card_title %}
 {% block card_body %}
-{% if charts.pt_ethnicity_tree_map_data.no_eligible_patients %}
-  <div class="alert alert-info">
-    <i class="fa-solid fa-person-circle-exclamation"></i> No eligible patients.
-  </div>
-{% else %}
-  <div
-  hx-get="{% url 'get_treemap_chart_partial' %}"
-  hx-vals='{{ charts.pt_ethnicity_tree_map_data }}'
-  hx-trigger="load" hx-swap="innerHTML"
-  _="on htmx:afterSwap remove #loading-spinner-ethnicity-card"></div>
-
-  <div id="loading-spinner-ethnicity-card"
-  class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
-  </div>
-{% endif %}
+  {% if charts.pt_ethnicity_tree_map_data.no_eligible_patients %}
+    <div class="alert alert-info">
+      <i class="fa-solid fa-person-circle-exclamation"></i> No eligible patients.
+    </div>
+  {% else %}
+    <div hx-get="{% url 'get_treemap_chart_partial' %}"
+         hx-vals='{{ charts.pt_ethnicity_tree_map_data }}'
+         hx-trigger="load"
+         hx-swap="innerHTML"
+         _="on htmx:afterSwap remove #loading-spinner-ethnicity-card"></div>
+    <div id="loading-spinner-ethnicity-card"
+         class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
+    </div>
+  {% endif %}
 {% endblock %}
-
-
-
-
-
-

--- a/project/npda/templates/dashboard/treemap_chart_partial.html
+++ b/project/npda/templates/dashboard/treemap_chart_partial.html
@@ -1,7 +1,7 @@
 {% if error %}
-<div class="alert alert-danger">
-  <i class="fa-solid fa-person-circle-exclamation"></i> {{ error }}
-</div>
+  <div class="alert alert-danger">
+    <i class="fa-solid fa-person-circle-exclamation"></i> {{ error }}
+  </div>
 {% elif chart_html %}
   {{ chart_html|safe }}
 {% endif %}

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -43,7 +43,7 @@
       <tbody>
         {% for patient in page_obj %}
           {% if patient.is_first_valid or patient.is_first_error or patient.is_first_incomplete_full_year %}
-            <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50">
+            <thead class="{% if patient.is_first_incomplete_full_year %} bg-rcpch_strong_blue_dark_tint text-xs {% else %} bg-rcpch_strong_blue text-xs {% endif %} text-white text-gray-700 uppercase bg-gray-50">
               <tr>
                 <th colspan="13" class="px-6 py-3">
                   {% if patient.is_first_valid %}
@@ -57,7 +57,7 @@
               </tr>
             </thead>
           {% endif %}
-          <tr class="{% if forloop.counter|divisibleby:2 %} bg-gray-100 {% endif %} hover:bg-gray-200 {% if patient.is_in_transfer_in_the_last_year %}bg-rcpch_yellow hover:bg-rcpch_yellow_dark_tint {% endif %}">
+          <tr class="{% if forloop.counter|divisibleby:2 %} bg-gray-100 {% endif %} hover:bg-gray-200 {% if patient.is_in_transfer_in_the_last_year %}bg-rcpch_yellow hover:bg-rcpch_yellow_dark_tint {% elif patient.incomplete_full_year_of_care %} bg-rcpch_strong_blue_light_tint3 hover:bg-rcpch_strong_blue_light_tint2 {% endif %}">
             {% with nhs_number_error=patient.errors|error_for_field:"nhs_number" unique_reference_number_error=patient_errors|error_for_field:"unique_reference_number" gp_error=patient.errors|error_for_field:"gp_practice_ods_code" %}
               {% jersify_errors_for_unique_patient_identifier pz_code nhs_number_error unique_reference_number_error as unique_identifier_error %}
               <td class="whitespace-nowrap">

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -323,14 +323,14 @@ def dashboard(request):
             "pt_sex_value_counts_pct": {
                 "data": json.dumps(pt_sex_value_counts_pct),
             },
-            "pt_ethnicity_tree_map_data": json.dumps(
+            "pt_ethnicity_tree_map_data": 
                 {
                     "no_eligible_patients": not pt_ethnicity_value_counts,
                     "data": pt_ethnicity_value_counts,
                     "parent_color_map": constants.ethnicities.ETHNICITY_PARENT_COLOR_MAP,
                     "child_parent_map": constants.ethnicities.ETHNICITY_CHILD_PARENT_MAP,
                 }
-            ),
+            ,
             "pt_imd_value_counts_pct": {
                 "data": json.dumps(pt_imd_value_counts_pct),
             },
@@ -354,7 +354,5 @@ def dashboard(request):
         # at that point
         "aggregation_level": "pdu",
     }
-
-    print(f"!! {context['charts']['pt_ethnicity_tree_map_data']}")
 
     return render(request, template_name=template, context=context)

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -770,7 +770,7 @@ def get_treemap_chart_partial(request):
                 textinfo="label+percent parent",  # Show labels and percentages
                 marker=dict(
                     # Apply parent colors to subcategories
-                    colors=[all_colors[label] for label in all_labels]
+                    colors=[all_colors[label] for label in all_labels],
                 ),
                 hovertemplate=(
                     "<b>%{label}</b><br>" "N=%{value} (%{percentRoot:.0%})<br><extra></extra>"

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -767,13 +767,10 @@ def get_treemap_chart_partial(request):
                 labels=all_labels,  # Labels including parents
                 parents=all_parents,  # Hierarchical structure
                 values=all_values,  # Sizes
-                textinfo="label+percent parent",  # Show labels and percentages
+                hoverinfo="label+percent parent",  # Show labels and percentages
                 marker=dict(
                     # Apply parent colors to subcategories
                     colors=[all_colors[label] for label in all_labels],
-                ),
-                hovertemplate=(
-                    "<b>%{label}</b><br>" "N=%{value} (%{percentRoot:.0%})<br><extra></extra>"
                 ),
             )
         )


### PR DESCRIPTION
Fixes #585 

Add validation in the clean method to the patient form
- if nhs_number is present, check if does not already exists
- if urn is present, check if does not already exist
already exists

In both of these circumstances it raises a validation error. 

**this now breaks most of the tests because it causes an async error**

Other things:
1. fix for the headers in the patient table. Reorganises the filtering so that those patients that have not completed a full year or died now come at the bottom and have a dark blue header
2. fix the hovertext console non-critical error relating to pyplot
3. reorganise the deprivation colours so that pink and red are deprived, blue and green are not