### PR TITLE
Resync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,3 +88,4 @@ volumes:
   npda-caddy-data:
   npda-postgis-data:
   npda-flower-data:
+  npda-django-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,4 +88,3 @@ volumes:
   npda-caddy-data:
   npda-postgis-data:
   npda-flower-data:
-  npda-django-data:

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1158,7 +1158,7 @@ class VisitForm(forms.ModelForm):
         # I haven't implemented it here. The risk is that future versions of Django will add more
         # behaviour that we miss out on.
 
-        if getattr(self, "async_validation_results"):
+        if hasattr(self, "async_validation_results"):
             self.instance.bmi = self.async_validation_results.bmi
 
             for field_prefix in ["height", "weight", "bmi"]:
@@ -1169,6 +1169,10 @@ class VisitForm(forms.ModelForm):
                 if result and not type(result) is ValidationError:
                     setattr(self.instance, f"{field_prefix}_centile", result.centile)
                     setattr(self.instance, f"{field_prefix}_sds", result.sds)
+
+        self.instance.patient = (
+            self.patient
+        )  # This is the patient object that is passed to the form
 
         if commit:
             self.instance.save()

--- a/project/npda/general_functions/csv/csv_upload_celery.py
+++ b/project/npda/general_functions/csv/csv_upload_celery.py
@@ -1,7 +1,4 @@
-from datetime import date
-from asgiref.sync import sync_to_async
 import logging
-import json
 import timeit
 
 # django imports
@@ -10,6 +7,7 @@ from django.utils import timezone
 from django.core.exceptions import ValidationError
 
 # third part imports
+from celery import chord
 import pandas as pd
 import numpy as np
 
@@ -19,13 +17,10 @@ from project.constants import (
     UNIQUE_IDENTIFIER_ENGLAND,
     UNIQUE_IDENTIFIER_JERSEY,
 )
-from project.npda.tasks import save_patient_and_visits_to_submission
+from project.npda.tasks import save_patient_and_visits_to_submission, gather_errors
 
 # Logging setup
 logger = logging.getLogger(__name__)
-
-from project.npda.forms.patient_form import PatientForm
-from project.npda.forms.visit_form import VisitForm
 
 
 def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_year):
@@ -69,9 +64,6 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
                 ret[model_field_name] = model_field_value
 
         return ret
-
-    def validate_transfer(row):
-        return row_to_dict(row, Transfer)
 
     if pz_code == "PZ248":
         CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
@@ -167,24 +159,24 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
         visits_by_patient = dataframe.groupby("NHS Number", sort=False, dropna=False)
 
     # Process each patient and their visits
+    tasks = []
     for patient_index, patient_group in visits_by_patient:
         patient_row = patient_group.iloc[0]
         patient_dict = row_to_dict(patient_row, Patient, csv_headings=CSV_HEADINGS)
 
-        patients_submission = save_patient_and_visits_to_submission.delay(
+        patients_submission_task = save_patient_and_visits_to_submission.s(
             patient_row.to_dict(),
             patient_dict,
             patient_group.to_dict(orient="records"),
             pdu.id,
             new_submission.id,
         )
+        tasks.append(patients_submission_task)
+
+    grouped_tasks = chord(tasks)(gather_errors.s(new_submission.id))
 
     end = timeit.default_timer()
 
     logger.debug(f"Time taken to process the CSV file: {end - start} seconds")
 
-    return 0
-
-    # # Store the errors to report back to the user in the Data Quality Report
-
-    # return errors_to_return
+    return grouped_tasks.id

--- a/project/npda/general_functions/csv/csv_upload_celery.py
+++ b/project/npda/general_functions/csv/csv_upload_celery.py
@@ -1,0 +1,259 @@
+from datetime import date
+from asgiref.sync import sync_to_async
+import logging
+import asyncio
+import collections
+import json
+
+# django imports
+from django.apps import apps
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+
+# third part imports
+import pandas as pd
+import numpy as np
+import httpx
+
+# RCPCH imports
+from project.constants import (
+    CSV_HEADING_OBJECTS,
+    UNIQUE_IDENTIFIER_ENGLAND,
+    UNIQUE_IDENTIFIER_JERSEY,
+)
+
+# Logging setup
+logger = logging.getLogger(__name__)
+
+from project.npda.forms.patient_form import PatientForm
+from project.npda.forms.visit_form import VisitForm
+
+
+def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_year):
+    """
+    Function to upload a CSV file to the database
+    """
+    # Get the models
+    Patient = apps.get_model("npda", "Patient")
+    Transfer = apps.get_model("npda", "Transfer")
+    Visit = apps.get_model("npda", "Visit")
+    Submission = apps.get_model("npda", "Submission")
+    PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
+
+    # Helper functions
+    def csv_value_to_model_value(model_field, value):
+        if pd.isnull(value):
+            return None
+
+        if isinstance(value, pd.Timestamp):
+            return value.to_pydatetime().date()
+
+        # Pass Django forms native Python values not numpy ones
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/425
+        return value.item() if isinstance(value, np.generic) else value
+
+    def row_to_dict(row, model):
+        ret = {}
+
+        for entry in CSV_HEADINGS:
+            if "model" in entry and apps.get_model("npda", entry["model"]) == model:
+                model_field_name = entry["model_field"]
+                model_field_definition = model._meta.get_field(model_field_name)
+
+                csv_value = row[entry["heading"]]
+                model_field_value = csv_value_to_model_value(
+                    model_field_definition, csv_value
+                )
+
+                ret[model_field_name] = model_field_value
+
+        return ret
+
+    def validate_transfer(row):
+        return row_to_dict(row, Transfer)
+
+    def retain_errors_and_invalid_field_data(form):
+        # We want to retain fields even if they're invalid so that we can return them to the user
+        # Use the field value from cleaned_data, falling back to data if it's not there
+        for key, value in form.cleaned_data.items():
+            setattr(form.instance, key, value)
+
+        for key, value in form.data.items():
+            if key not in form.cleaned_data:
+                setattr(form.instance, key, value)
+
+        form.instance.is_valid = form.is_valid()
+        form.instance.errors = (
+            None if form.is_valid() else form.errors.get_json_data(escape_html=True)
+        )
+
+    def record_errors_from_form(errors_to_return, row_index, form):
+        for field, errors in form.errors.as_data().items():
+            for error in errors:
+                errors_to_return[row_index][field].extend(error.messages)
+
+    if pz_code == "PZ248":
+        CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
+    else:
+        CSV_HEADINGS = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+
+    """
+    Work starts here - create a new submission and delete the previous one
+    """
+
+    # get the PDU object
+    # TODO #249 MRB: handle case where PDU does not exist
+    pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+
+    # Set previous submission to inactive
+    if Submission.objects.filter(
+        paediatric_diabetes_unit__pz_code=pdu.pz_code,
+        audit_year=audit_year,
+        submission_active=True,
+    ).exists():
+        original_submission = Submission.objects.filter(
+            submission_active=True,
+            paediatric_diabetes_unit__pz_code=pdu.pz_code,
+            audit_year=audit_year,
+        ).get()  # there can be only one of these - store it in a variable in case we need to revert
+    else:
+        original_submission = None
+
+    # Create new submission for the audit year
+    # It is not possble to create submissions in years other than the current year
+    try:
+        new_submission = Submission.objects.create(
+            paediatric_diabetes_unit=pdu,
+            audit_year=audit_year,
+            submission_date=timezone.now(),
+            submission_by=user,  # user is the user who is logged in. Passed in as a parameter
+            submission_active=True,
+            csv_file=csv_file_bytes,
+            csv_file_name=csv_file_name,
+        )
+
+        new_submission.save()
+
+    except Exception as e:
+        logger.error(f"Error creating new submission: {e}")
+        # the new submission was not created  - no action required as the previous submission is still active
+        raise ValidationError(
+            {
+                "csv_upload": "Error creating new submission. The old submission has been restored."
+            }
+        )
+
+    # now can delete all patients and visits from the previous active submission
+    if original_submission:
+        try:
+            original_submission_patient_count = Patient.objects.filter(
+                submissions=original_submission
+            ).count()
+            logger.debug(
+                f"Deleting patients from previous submission: {original_submission_patient_count}"
+            )
+            Patient.objects.filter(submissions=original_submission).delete()
+        except Exception as e:
+            raise ValidationError(
+                {"csv_upload": "Error deleting patients from previous submission"}
+            )
+
+    # now can delete the any previous active submission's csv file (if it exists)
+    # and remove the path from the field by setting it to None
+    # the rest of the submission will be retained
+    if original_submission:
+        original_submission.submission_active = False
+        try:
+            original_submission.save()  # this action will delete the csv file also as per the save method in the model
+        except Exception as e:
+            raise ValidationError(
+                {"csv_upload": "Error deactivating previous submission"}
+            )
+
+    """
+    Process the csv file and validate and save the data in the tables, parsing any errors
+    """
+
+    # Remember the original row number to help users find where the problem was in the CSV
+    dataframe = dataframe.assign(row_index=np.arange(dataframe.shape[0]))
+
+    # We only one to create one patient per NHS number (or URN if in Jersey) and we can't create their visits if we fail to save the patient model
+    if new_submission.paediatric_diabetes_unit.pz_code == "PZ248":
+        visits_by_patient = dataframe.groupby(
+            "Unique Reference Number", sort=False, dropna=False
+        )
+    else:
+        visits_by_patient = dataframe.groupby("NHS Number", sort=False, dropna=False)
+
+    # Gather all error messages indexed by row number and the field that caused them (__all__ if we don't know which one)
+    # dict[number, dict[str, list[str]]]
+    errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
+
+    # Process each patient and their visits
+    for patient_index, patient_group in visits_by_patient:
+        patient_row = patient_group.iloc[0]
+
+        patient_dict = row_to_dict(patient_row, Patient)
+        # patient_dict["submissions"] = [new_submission]
+
+        patient_form = PatientForm(data=patient_dict)
+
+        if not patient_form.is_valid():
+            retain_errors_and_invalid_field_data(patient_form)
+            record_errors_from_form(
+                errors_to_return, patient_row["row_index"], patient_form
+            )
+
+        patient = patient_form.save()
+
+        # Save or update the patient transfer record
+        Transfer.objects.update_or_create(
+            patient=patient, paediatric_diabetes_unit=pdu, date_leaving_service=None
+        )
+
+        # Add the patient to the submission
+        new_submission.patients.add(patient)
+
+        # Process each visit for the patient
+        for visit_index, visit_row in patient_group.iterrows():
+            visit_dict = row_to_dict(visit_row, Visit)
+            visit_dict["patient"] = patient
+
+            visit_form = VisitForm(data=visit_dict, initial={"patient": patient})
+
+            if not visit_form.is_valid():
+                retain_errors_and_invalid_field_data(visit_form)
+                record_errors_from_form(
+                    errors_to_return, visit_row["row_index"], visit_form
+                )
+
+            visit = visit_form.save()
+            visit.is_valid = visit_form.is_valid()
+            visit.save()
+
+    # Store the errors to report back to the user in the Data Quality Report
+    if errors_to_return:
+        errors_to_return = convert_numpy_types(errors_to_return)
+        new_submission.errors = json.dumps(errors_to_return)
+        new_submission.save()
+
+    return errors_to_return
+
+
+def convert_numpy_types(data):
+    """
+    Recursively convert numpy types to native Python types.
+    """
+    if isinstance(data, dict):
+        return {
+            convert_numpy_types(key): convert_numpy_types(value)
+            for key, value in data.items()
+        }
+    elif isinstance(data, list):
+        return [convert_numpy_types(element) for element in data]
+    elif isinstance(data, np.generic):
+        return data.item()
+    elif isinstance(data, np.ndarray):
+        return data.tolist()
+    else:
+        return data

--- a/project/npda/general_functions/csv/csv_upload_celery.py
+++ b/project/npda/general_functions/csv/csv_upload_celery.py
@@ -38,7 +38,7 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
 
     # Helper functions
     def csv_value_to_model_value(model_field, value):
-        if pd.isnull(value):
+        if pd.isnull(value) or value == pd.NaT:
             return None
 
         if isinstance(value, pd.Timestamp):
@@ -165,7 +165,7 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
         patient_dict = row_to_dict(patient_row, Patient, csv_headings=CSV_HEADINGS)
 
         patients_submission_task = save_patient_and_visits_to_submission.s(
-            patient_row.to_dict(),
+            patient_row.to_json(date_format="iso"),
             patient_dict,
             patient_group.to_dict(orient="records"),
             pdu.id,

--- a/project/npda/general_functions/csv/csv_upload_celery.py
+++ b/project/npda/general_functions/csv/csv_upload_celery.py
@@ -1,9 +1,8 @@
 from datetime import date
 from asgiref.sync import sync_to_async
 import logging
-import asyncio
-import collections
 import json
+import timeit
 
 # django imports
 from django.apps import apps
@@ -13,7 +12,6 @@ from django.core.exceptions import ValidationError
 # third part imports
 import pandas as pd
 import numpy as np
-import httpx
 
 # RCPCH imports
 from project.constants import (
@@ -21,6 +19,7 @@ from project.constants import (
     UNIQUE_IDENTIFIER_ENGLAND,
     UNIQUE_IDENTIFIER_JERSEY,
 )
+from project.npda.tasks import save_patient_and_visits_to_submission
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -40,6 +39,8 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
     Submission = apps.get_model("npda", "Submission")
     PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
 
+    start = timeit.default_timer()
+
     # Helper functions
     def csv_value_to_model_value(model_field, value):
         if pd.isnull(value):
@@ -52,10 +53,10 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
         # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/425
         return value.item() if isinstance(value, np.generic) else value
 
-    def row_to_dict(row, model):
+    def row_to_dict(row, model, csv_headings):
         ret = {}
 
-        for entry in CSV_HEADINGS:
+        for entry in csv_headings:
             if "model" in entry and apps.get_model("npda", entry["model"]) == model:
                 model_field_name = entry["model_field"]
                 model_field_definition = model._meta.get_field(model_field_name)
@@ -71,26 +72,6 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
 
     def validate_transfer(row):
         return row_to_dict(row, Transfer)
-
-    def retain_errors_and_invalid_field_data(form):
-        # We want to retain fields even if they're invalid so that we can return them to the user
-        # Use the field value from cleaned_data, falling back to data if it's not there
-        for key, value in form.cleaned_data.items():
-            setattr(form.instance, key, value)
-
-        for key, value in form.data.items():
-            if key not in form.cleaned_data:
-                setattr(form.instance, key, value)
-
-        form.instance.is_valid = form.is_valid()
-        form.instance.errors = (
-            None if form.is_valid() else form.errors.get_json_data(escape_html=True)
-        )
-
-    def record_errors_from_form(errors_to_return, row_index, form):
-        for field, errors in form.errors.as_data().items():
-            for error in errors:
-                errors_to_return[row_index][field].extend(error.messages)
 
     if pz_code == "PZ248":
         CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
@@ -185,75 +166,25 @@ def csv_upload(user, dataframe, csv_file_name, csv_file_bytes, pz_code, audit_ye
     else:
         visits_by_patient = dataframe.groupby("NHS Number", sort=False, dropna=False)
 
-    # Gather all error messages indexed by row number and the field that caused them (__all__ if we don't know which one)
-    # dict[number, dict[str, list[str]]]
-    errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
-
     # Process each patient and their visits
     for patient_index, patient_group in visits_by_patient:
         patient_row = patient_group.iloc[0]
+        patient_dict = row_to_dict(patient_row, Patient, csv_headings=CSV_HEADINGS)
 
-        patient_dict = row_to_dict(patient_row, Patient)
-        # patient_dict["submissions"] = [new_submission]
-
-        patient_form = PatientForm(data=patient_dict)
-
-        if not patient_form.is_valid():
-            retain_errors_and_invalid_field_data(patient_form)
-            record_errors_from_form(
-                errors_to_return, patient_row["row_index"], patient_form
-            )
-
-        patient = patient_form.save()
-
-        # Save or update the patient transfer record
-        Transfer.objects.update_or_create(
-            patient=patient, paediatric_diabetes_unit=pdu, date_leaving_service=None
+        patients_submission = save_patient_and_visits_to_submission.delay(
+            patient_row.to_dict(),
+            patient_dict,
+            patient_group.to_dict(orient="records"),
+            pdu.id,
+            new_submission.id,
         )
 
-        # Add the patient to the submission
-        new_submission.patients.add(patient)
+    end = timeit.default_timer()
 
-        # Process each visit for the patient
-        for visit_index, visit_row in patient_group.iterrows():
-            visit_dict = row_to_dict(visit_row, Visit)
-            visit_dict["patient"] = patient
+    logger.debug(f"Time taken to process the CSV file: {end - start} seconds")
 
-            visit_form = VisitForm(data=visit_dict, initial={"patient": patient})
+    return 0
 
-            if not visit_form.is_valid():
-                retain_errors_and_invalid_field_data(visit_form)
-                record_errors_from_form(
-                    errors_to_return, visit_row["row_index"], visit_form
-                )
+    # # Store the errors to report back to the user in the Data Quality Report
 
-            visit = visit_form.save()
-            visit.is_valid = visit_form.is_valid()
-            visit.save()
-
-    # Store the errors to report back to the user in the Data Quality Report
-    if errors_to_return:
-        errors_to_return = convert_numpy_types(errors_to_return)
-        new_submission.errors = json.dumps(errors_to_return)
-        new_submission.save()
-
-    return errors_to_return
-
-
-def convert_numpy_types(data):
-    """
-    Recursively convert numpy types to native Python types.
-    """
-    if isinstance(data, dict):
-        return {
-            convert_numpy_types(key): convert_numpy_types(value)
-            for key, value in data.items()
-        }
-    elif isinstance(data, list):
-        return [convert_numpy_types(element) for element in data]
-    elif isinstance(data, np.generic):
-        return data.item()
-    elif isinstance(data, np.ndarray):
-        return data.tolist()
-    else:
-        return data
+    # return errors_to_return

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -1,6 +1,7 @@
 # Python Imports
 import collections
 from collections import defaultdict
+from datetime import datetime
 import json
 import logging
 
@@ -33,7 +34,7 @@ def hello():
 
 @shared_task
 def save_patient_and_visits_to_submission(
-    patient_row_dict, patient_dict, patient_group_dict, pdu_id, submission_id
+    patient_row_json, patient_dict, patient_group_dict, pdu_id, submission_id
 ):
     """
     Accepts a list of patient visits, creates a patient instance (validating using a patient form), then iterates
@@ -64,38 +65,6 @@ def save_patient_and_visits_to_submission(
             for error in errors:
                 errors_to_return[row_index][field].extend(error.messages)
 
-    def convert_numpy_types(data):
-        """
-        Recursively convert numpy types to native Python types.
-        """
-        if isinstance(data, dict):
-            return {
-                convert_numpy_types(key): convert_numpy_types(value)
-                for key, value in data.items()
-            }
-        elif isinstance(data, list):
-            return [convert_numpy_types(element) for element in data]
-        elif isinstance(data, np.generic):
-            return data.item()
-        elif isinstance(data, np.ndarray):
-            return data.tolist()
-        else:
-            return data
-
-    def merge_errors(existing_errors, new_errors):
-        """
-        Merge new errors into existing errors.
-        """
-        for key, value in new_errors.items():
-            if key in existing_errors:
-                if isinstance(value, dict):
-                    merge_errors(existing_errors[key], value)
-                else:
-                    existing_errors[key].extend(value)
-            else:
-                existing_errors[key] = value
-        return existing_errors
-
     def row_to_dict(row, model, csv_headings):
         ret = {}
         for entry in csv_headings:
@@ -108,6 +77,9 @@ def save_patient_and_visits_to_submission(
                     model_field_definition, csv_value
                 )
 
+                if model_field_name in ['diabetes_type','reason_leaving_service','hba1c_format','closed_loop_system','glucose_monitoring','retinal_screening_result','albuminuria_stage','thyroid_treatment_status','gluten_free_diet','psychological_additional_support_status','smoking_status','dietician_additional_appointment_offered','ketone_meter_training','hospital_admission_reason','dka_additional_therapies']:
+                    # this is a workaround - these fields are integer fields but the csv sometimes has them as floats
+                    model_field_value = int(model_field_value) if model_field_value else None
                 ret[model_field_name] = model_field_value
 
         return ret
@@ -128,28 +100,72 @@ def save_patient_and_visits_to_submission(
             return UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
 
     def csv_value_to_model_value(model_field, value):
-        if pd.isnull(value):
+        if pd.isnull(value) or value == pd.NaT:
             return None
 
+        if type(value) == datetime:
+            if value == datetime(1, 1, 1, 0, 0):
+                return None
+            return value.date()
+
         if isinstance(value, pd.Timestamp):
+            # Convert datetime(1, 1, 1, 0, 0) to None - this is an invalid date
+            # A workaround because in the process of converting the DataFrame to a dictionary
+            # datefields that are empty are converted to datetime(1, 1, 1, 0, 0) which is invalid
             return value.to_pydatetime().date()
 
         # Pass Django forms native Python values not numpy ones
         # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/425
-        return value.item() if isinstance(value, np.generic) else value
+        if isinstance(value, np.generic):
+            return value.item()
+
+        return value
+
+    def convert_invalid_dates_to_none(data):
+        """
+        Recursively convert datetime(1, 1, 1, 0, 0) to None in the given data.
+        """
+        if isinstance(data, dict):
+            return {
+                key: convert_invalid_dates_to_none(value) for key, value in data.items()
+            }
+        elif isinstance(data, list):
+            return [convert_invalid_dates_to_none(element) for element in data]
+        elif isinstance(data, datetime) and data == datetime(1, 1, 1, 0, 0):
+            return None
+        else:
+            return data
+
+    def convert_iso_dates(obj):
+        """Recursively converts ISO 8601 date strings in a JSON-like object to datetime."""
+        if isinstance(obj, dict):
+            return {k: convert_iso_dates(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [convert_iso_dates(i) for i in obj]
+        elif isinstance(obj, str):
+            try:
+                return (
+                    pd.to_datetime(obj) if "T" in obj else obj
+                )  # Check for ISO format
+            except ValueError:
+                return obj
+        return obj
 
     """
     Main function
     """
     Submission = apps.get_model("npda", "Submission")
     PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
+    Transfer = apps.get_model("npda", "Transfer")
 
     print("running save patient in celery...")
 
     # Gather all error messages indexed by row number and the field that caused them (__all__ if we don't know which one)
     # dict[number, dict[str, list[str]]]
     errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
-    patient_row = pd.Series(patient_row_dict)
+    deserialized_patient_row = json.loads(patient_row_json)
+
+    patient_row = pd.Series(convert_iso_dates(deserialized_patient_row))
     patient_group = pd.DataFrame(patient_group_dict)
     patient_form = PatientForm(data=patient_dict)
     pdu = PaediatricDiabetesUnit.objects.get(pk=pdu_id)
@@ -167,9 +183,9 @@ def save_patient_and_visits_to_submission(
         patient_row, Transfer, csv_headings=get_csv_headings(pdu.pz_code)
     )
 
-    # Save or update the patient transfer record
-    Transfer.objects.update_or_create(
-        patient=patient, paediatric_diabetes_unit=pdu, defaults=transfer_fields
+    # Save the patient transfer record
+    Transfer.objects.create(
+        **transfer_fields, patient=patient, paediatric_diabetes_unit=pdu
     )
 
     # Add the patient to the submission
@@ -180,6 +196,8 @@ def save_patient_and_visits_to_submission(
         visit_dict = row_to_dict(
             visit_row, Visit, csv_headings=get_csv_headings(pdu.pz_code)
         )
+        # Convert invalid numpy types to None
+        visit_dict = convert_invalid_dates_to_none(visit_dict)
         visit_dict["patient"] = patient
 
         visit_form = VisitForm(data=visit_dict, initial={"patient": patient})

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -1,6 +1,6 @@
 # Python Imports
 import collections
-from io import StringIO
+from collections import defaultdict
 import json
 import logging
 
@@ -163,9 +163,13 @@ def save_patient_and_visits_to_submission(
 
     patient = patient_form.save()
 
+    transfer_fields = row_to_dict(
+        patient_row, Transfer, csv_headings=get_csv_headings(pdu.pz_code)
+    )
+
     # Save or update the patient transfer record
     Transfer.objects.update_or_create(
-        patient=patient, paediatric_diabetes_unit=pdu, date_leaving_service=None
+        patient=patient, paediatric_diabetes_unit=pdu, defaults=transfer_fields
     )
 
     # Add the patient to the submission
@@ -190,20 +194,31 @@ def save_patient_and_visits_to_submission(
         visit.is_valid = visit_form.is_valid()
         visit.save()
 
-    if errors_to_return:
-        # Update the submission with the errors - merge them with any existing errors
-        errors_to_return = convert_numpy_types(errors_to_return)
-        existing_errors = submission.errors or {}
-        merged_errors = merge_errors(existing_errors, errors_to_return)
-        submission.errors = json.dumps(merged_errors)
-        submission.save()
+    return errors_to_return
 
 
 @shared_task
-def gather_errors(submission_id):
+def gather_errors(results, submission_id):
     """
-    Retrieve all errors from a submission and return them
+    Gather errors from all tasks and store them in the submission.
     """
+    errors_to_return = defaultdict(lambda: defaultdict(list))
+
+    # Combine errors from all tasks
+    for task_errors in results:
+        for row_index, field_errors in task_errors.items():
+            for field, errors in field_errors.items():
+                errors_to_return[row_index][field].extend(errors)
+
+    # Get the Submission model
     Submission = apps.get_model("npda", "Submission")
-    submission = Submission.objects.get(pk=submission_id)
-    return submission.errors
+
+    # Get the submission instance
+    submission = Submission.objects.get(id=submission_id)
+
+    # Store the errors in the submission
+    if errors_to_return:
+        submission.errors = json.dumps(errors_to_return)
+        submission.save()
+
+    return errors_to_return

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -98,7 +98,6 @@ def save_patient_and_visits_to_submission(
 
     def row_to_dict(row, model, csv_headings):
         ret = {}
-        print(model, csv_headings)
         for entry in csv_headings:
             if "model" in entry and apps.get_model("npda", entry["model"]) == model:
                 model_field_name = entry["model_field"]
@@ -198,3 +197,13 @@ def save_patient_and_visits_to_submission(
         merged_errors = merge_errors(existing_errors, errors_to_return)
         submission.errors = json.dumps(merged_errors)
         submission.save()
+
+
+@shared_task
+def gather_errors(submission_id):
+    """
+    Retrieve all errors from a submission and return them
+    """
+    Submission = apps.get_model("npda", "Submission")
+    submission = Submission.objects.get(pk=submission_id)
+    return submission.errors

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -1,16 +1,22 @@
 # Python Imports
+import collections
+from io import StringIO
+import json
 import logging
 
 # Django Imports
+from django.apps import apps
 from django.conf import settings
 
 # Third party imports
 from celery import shared_task
+import numpy as np
+import pandas as pd
 
 # Project Imports
-from .models import Visit
+from .models import Patient, Transfer, Visit
+from .forms.patient_form import PatientForm
 from .forms.visit_form import VisitForm
-from .general_functions.csv.csv_upload import validate_visit_async
 
 # Logging setup
 logger = logging.getLogger(__name__)
@@ -25,28 +31,170 @@ def hello():
     logger.debug("0600 cron check task ran successfully")
 
 
-# @shared_task
-# def validate_visit_using_form(patient_form, row, async_client):
-#     fields = row_to_dict(
-#         row,
-#         Visit,
-#     )
-
-#     form = VisitForm(data=fields, initial={"patient": patient_form.instance})
-#     # form.async_validation_results = await validate_visit_async(
-#     #     birth_date=patient_form.cleaned_data.get("date_of_birth"),
-#     #     observation_date=fields["height_weight_observation_date"],
-#     #     height=fields["height"],
-#     #     weight=fields["weight"],
-#     #     sex=patient_form.cleaned_data.get("sex"),
-#     #     async_client=async_client,
-#     # )
-
-#     return form
-
-
 @shared_task
-def fuck():
-    print(
-        "FuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuckFuck"
+def save_patient_and_visits_to_submission(
+    patient_row_dict, patient_dict, patient_group_dict, pdu_id, submission_id
+):
+    """
+    Accepts a list of patient visits, creates a patient instance (validating using a patient form), then iterates
+    through the visits, creating a form for each and gathering up the errors
+    """
+
+    """
+    Helper functions
+    """
+
+    def retain_errors_and_invalid_field_data(form):
+        # We want to retain fields even if they're invalid so that we can return them to the user
+        # Use the field value from cleaned_data, falling back to data if it's not there
+        for key, value in form.cleaned_data.items():
+            setattr(form.instance, key, value)
+
+        for key, value in form.data.items():
+            if key not in form.cleaned_data:
+                setattr(form.instance, key, value)
+
+        form.instance.is_valid = form.is_valid()
+        form.instance.errors = (
+            None if form.is_valid() else form.errors.get_json_data(escape_html=True)
+        )
+
+    def record_errors_from_form(errors_to_return, row_index, form):
+        for field, errors in form.errors.as_data().items():
+            for error in errors:
+                errors_to_return[row_index][field].extend(error.messages)
+
+    def convert_numpy_types(data):
+        """
+        Recursively convert numpy types to native Python types.
+        """
+        if isinstance(data, dict):
+            return {
+                convert_numpy_types(key): convert_numpy_types(value)
+                for key, value in data.items()
+            }
+        elif isinstance(data, list):
+            return [convert_numpy_types(element) for element in data]
+        elif isinstance(data, np.generic):
+            return data.item()
+        elif isinstance(data, np.ndarray):
+            return data.tolist()
+        else:
+            return data
+
+    def merge_errors(existing_errors, new_errors):
+        """
+        Merge new errors into existing errors.
+        """
+        for key, value in new_errors.items():
+            if key in existing_errors:
+                if isinstance(value, dict):
+                    merge_errors(existing_errors[key], value)
+                else:
+                    existing_errors[key].extend(value)
+            else:
+                existing_errors[key] = value
+        return existing_errors
+
+    def row_to_dict(row, model, csv_headings):
+        ret = {}
+        print(model, csv_headings)
+        for entry in csv_headings:
+            if "model" in entry and apps.get_model("npda", entry["model"]) == model:
+                model_field_name = entry["model_field"]
+                model_field_definition = model._meta.get_field(model_field_name)
+
+                csv_value = row[entry["heading"]]
+                model_field_value = csv_value_to_model_value(
+                    model_field_definition, csv_value
+                )
+
+                ret[model_field_name] = model_field_value
+
+        return ret
+
+    def get_csv_headings(pz_code):
+        """
+        Get the csv headings for England or Jersey
+        """
+        from project.constants import (
+            CSV_HEADING_OBJECTS,
+            UNIQUE_IDENTIFIER_ENGLAND,
+            UNIQUE_IDENTIFIER_JERSEY,
+        )
+
+        if pz_code == "PZ248":
+            return UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
+        else:
+            return UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+
+    def csv_value_to_model_value(model_field, value):
+        if pd.isnull(value):
+            return None
+
+        if isinstance(value, pd.Timestamp):
+            return value.to_pydatetime().date()
+
+        # Pass Django forms native Python values not numpy ones
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/425
+        return value.item() if isinstance(value, np.generic) else value
+
+    """
+    Main function
+    """
+    Submission = apps.get_model("npda", "Submission")
+    PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
+
+    print("running save patient in celery...")
+
+    # Gather all error messages indexed by row number and the field that caused them (__all__ if we don't know which one)
+    # dict[number, dict[str, list[str]]]
+    errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
+    patient_row = pd.Series(patient_row_dict)
+    patient_group = pd.DataFrame(patient_group_dict)
+    patient_form = PatientForm(data=patient_dict)
+    pdu = PaediatricDiabetesUnit.objects.get(pk=pdu_id)
+    submission = Submission.objects.get(pk=submission_id)
+
+    if not patient_form.is_valid():
+        retain_errors_and_invalid_field_data(patient_form)
+        record_errors_from_form(
+            errors_to_return, patient_row["row_index"], patient_form
+        )
+
+    patient = patient_form.save()
+
+    # Save or update the patient transfer record
+    Transfer.objects.update_or_create(
+        patient=patient, paediatric_diabetes_unit=pdu, date_leaving_service=None
     )
+
+    # Add the patient to the submission
+    submission.patients.add(patient)
+
+    # Process each visit for the patient
+    for visit_index, visit_row in patient_group.iterrows():
+        visit_dict = row_to_dict(
+            visit_row, Visit, csv_headings=get_csv_headings(pdu.pz_code)
+        )
+        visit_dict["patient"] = patient
+
+        visit_form = VisitForm(data=visit_dict, initial={"patient": patient})
+
+        if not visit_form.is_valid():
+            retain_errors_and_invalid_field_data(visit_form)
+            record_errors_from_form(
+                errors_to_return, visit_row["row_index"], visit_form
+            )
+
+        visit = visit_form.save()
+        visit.is_valid = visit_form.is_valid()
+        visit.save()
+
+    if errors_to_return:
+        # Update the submission with the errors - merge them with any existing errors
+        errors_to_return = convert_numpy_types(errors_to_return)
+        existing_errors = submission.errors or {}
+        merged_errors = merge_errors(existing_errors, errors_to_return)
+        submission.errors = json.dumps(merged_errors)
+        submission.save()

--- a/project/npda/templates/upload_csv/file_upload.html
+++ b/project/npda/templates/upload_csv/file_upload.html
@@ -47,6 +47,7 @@
           <button id="submit-button"
                   class="font-montserrat tooltip-trigger w-full px-4 py-2 text-white bg-gray-400"
                   type="submit"
+                  {% if grouped_tasks_id %} hx-post="{% url 'task_status' grouped_tasks_id=grouped_tasks_id %}" hx-swap="innerHTML" hx-target="#upload-spinner" hx-indicator="#upload-spinner" {% endif %}
                   disabled
                   _="on click remove .hidden from #upload-spinner">
             Submit data

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path("view_preference", view=view_preference, name="view_preference"),
     path("audit-year", view=audit_year, name="audit-year"),
     path("upload_csv", view=upload_csv, name="upload_csv"),
+    path("task_status/<uuid:grouped_tasks_id>", view=task_status, name="task_status"),
     # Submission views
     path(
         "submissions",

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -13,12 +13,13 @@ from django.apps import apps
 from django.contrib import messages
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.conf import settings
 
 
-# HTMX imports
+# Third party imports
 from django_htmx.http import trigger_client_event
+from celery.result import AsyncResult
 
 from project.npda.general_functions.csv import csv_parse, csv_header
 from project.npda.general_functions.csv.csv_upload_celery import csv_upload
@@ -86,7 +87,7 @@ def home(request):
             audit_year = request.session.get("selected_audit_year")
 
             # CSV is valid, parse any errors and store the data in the tables.
-            errors_by_row_index = csv_upload(
+            grouped_tasks_id = csv_upload(
                 user=request.user,
                 dataframe=parsed_csv.df,
                 csv_file_name=user_csv_filename,
@@ -108,18 +109,12 @@ def home(request):
             # update the session fields - this stores that the user has uploaded a csv and disables the ability to use the questionnaire
             # await sync_to_async(refresh_session_filters)(request)
             refresh_session_filters(request)
-
-            if errors_by_row_index:
-                messages.error(
-                    request=request,
-                    message=f"CSV has been uploaded, but errors were found in {len(errors_by_row_index.items())} rows. Please check the data quality report for details.",
-                )
-            else:
-                messages.success(
-                    request=request,
-                    message="Submission completed. There were no errors.",
-                )
-            return redirect("patients")
+            context = {
+                "grouped_tasks_id": str(grouped_tasks_id),
+                "file_uploaded": True,
+                "form": form,
+            }
+            return render(request=request, template_name="home.html", context=context)
         else:
             # If the user does not have permission to upload csvs, redirect them to the dashboard page
             messages.error(
@@ -190,3 +185,37 @@ def audit_year(request):
     response = render(
         request, template_name="partials/audit_year_select.html", context=context
     )
+
+    return response
+
+
+def task_status(request, grouped_tasks_id):
+    """
+    HTMX callback to get the status of a Celery task.
+    """
+
+    task_result = AsyncResult(str(grouped_tasks_id))
+
+    if task_result.state == "SUCCESS":
+        errors_by_row_index = task_result.result
+        if errors_by_row_index:
+            messages.error(
+                request=request,
+                message=f"CSV has been uploaded, but errors were found in {len(errors_by_row_index.items())} rows. Please check the data quality report for details.",
+            )
+        else:
+            messages.success(
+                request=request,
+                message="Submission completed. There were no errors.",
+            )
+        return redirect("patients")
+    elif task_result.state == "FAILURE":
+        messages.error(
+            request=request,
+            message="An error occurred while processing the CSV file. Please try again.",
+        )
+        return JsonResponse({"state": "FAILURE", "redirect_url": reverse("home")})
+    else:
+        return JsonResponse(
+            {"state": task_result.state, "grouped_tasks_id": grouped_tasks_id}
+        )

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -20,7 +20,8 @@ from django.conf import settings
 # HTMX imports
 from django_htmx.http import trigger_client_event
 
-from project.npda.general_functions.csv import csv_upload, csv_parse, csv_header
+from project.npda.general_functions.csv import csv_parse, csv_header
+from project.npda.general_functions.csv.csv_upload_celery import csv_upload
 from ..forms.upload import UploadFileForm
 from ..general_functions.session import refresh_session_filters
 from ..general_functions.view_preference import get_or_update_view_preference
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_and_otp_required()
-async def home(request):
+def home(request):
     """
     Home page view - contains the upload form.
     Only verified users can access this page.
@@ -85,18 +86,18 @@ async def home(request):
             audit_year = request.session.get("selected_audit_year")
 
             # CSV is valid, parse any errors and store the data in the tables.
-            errors_by_row_index = await csv_upload(
+            errors_by_row_index = csv_upload(
                 user=request.user,
                 dataframe=parsed_csv.df,
                 csv_file_name=user_csv_filename,
                 csv_file_bytes=user_csv_bytes,
-                pdu_pz_code=pz_code,
+                pz_code=pz_code,
                 audit_year=audit_year,
             )
             # log user activity
             VisitActivity = apps.get_model("npda", "VisitActivity")
             try:
-                await VisitActivity.objects.acreate(
+                VisitActivity.objects.create(
                     activity=8,
                     ip_address=request.META.get("REMOTE_ADDR"),
                     npdauser=request.user,
@@ -105,7 +106,8 @@ async def home(request):
                 logger.error(f"Failed to log user activity: {e}")
 
             # update the session fields - this stores that the user has uploaded a csv and disables the ability to use the questionnaire
-            await sync_to_async(refresh_session_filters)(request)
+            # await sync_to_async(refresh_session_filters)(request)
+            refresh_session_filters(request)
 
             if errors_by_row_index:
                 messages.error(
@@ -159,7 +161,7 @@ def view_preference(request):
         request.user, view_preference_selection
     )
     selected_pz_code = request.POST.get("pz_code_select_name", None)
-    
+
     # includes a validation step
     refresh_session_filters(request, pz_code=selected_pz_code)
 
@@ -174,7 +176,7 @@ def audit_year(request):
     """
     if request.method == "POST":
         audit_year = request.POST.get("audit_year_select_name", None)
-        
+
         refresh_session_filters(request, audit_year=audit_year)
 
         # Reload the page to apply the new view preference

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -47,7 +47,6 @@ from .mixins import (
     LoginAndOTPRequiredMixin,
 )
 from ..general_functions.session import refresh_session_filters
-from ..tasks import fuck
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +86,6 @@ class PatientListView(
         patient_queryset = super().get_queryset()
 
         PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
-
-        fuck.delay()
 
         # apply filters and annotations to the queryset
         pz_code = self.request.session.get("pz_code")

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -50,6 +50,7 @@ class PatientVisitsListView(
     template_name = "visits.html"
 
     def get_context_data(self, **kwargs):
+        PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
         patient_id = self.kwargs.get("patient_id")
         context = super(PatientVisitsListView, self).get_context_data(**kwargs)
         patient = Patient.objects.get(pk=patient_id)
@@ -67,16 +68,34 @@ class PatientVisitsListView(
         context["submission"] = submission
 
         if patient.is_in_transfer_in_the_last_year():
-            pz_code = (
-                Transfer.objects.filter(
-                    patient=patient,
-                )
+            previous_transfer = (
+                Transfer.objects.filter(patient=patient)
                 .order_by("-date_leaving_service")
                 .first()
-                .previous_pz_code
             )
-            PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
-            pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+            if hasattr(previous_transfer, "previous_pz_code"):
+                if previous_transfer.previous_pz_code is not None:
+                    pz_code = (
+                        Transfer.objects.filter(
+                            patient=patient,
+                        )
+                        .order_by("-date_leaving_service")
+                        .first()
+                        .previous_pz_code
+                    )
+                else:
+                    # this patient has been transferred but not yet received at a new PDU
+                    # Use the existing PDU in session
+                    pz_code = self.request.session.get("pz_code")
+                    print("pz_code", pz_code)
+                pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+            else:
+                # this patient has been transferred but not yet received at a new PDU
+                # Use the existing PDU
+                PaediatricDiabetesUnit = apps.get_model(
+                    "npda", "PaediatricDiabetesUnit"
+                )
+                pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
         # get the PDU for this patient - this is the PDU that the patient is currently under.
         # If the patient has left the PDU, the date_leaving_service will be set and it will be possible to view KPIs for the PDU up until transfer,
         # if this happened during the audit period. This is TODO

--- a/project/settings.py
+++ b/project/settings.py
@@ -368,19 +368,19 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = "Europe/London"
 
-CELERY_BEAT_SCHEDULE = {
-    "run-daily-at-six-am": {
-        "task": "project.npda.tasks.hello",
-        "schedule": crontab(hour="6", minute=0),
-        "options": {
-            "expires": 15.0,
-        },
-    },
-    "run-ever-10-seconds": {
-        "task": "project.npda.tasks.hello",
-        "schedule": 10,
-        "options": {
-            "expires": 15.0,
-        },
-    },
-}
+# CELERY_BEAT_SCHEDULE = {
+#     "run-daily-at-six-am": {
+#         "task": "project.npda.tasks.hello",
+#         "schedule": crontab(hour="6", minute=0),
+#         "options": {
+#             "expires": 15.0,
+#         },
+#     },
+#     "run-ever-10-seconds": {
+#         "task": "project.npda.tasks.hello",
+#         "schedule": 10,
+#         "options": {
+#             "expires": 15.0,
+#         },
+#     },
+# }


### PR DESCRIPTION
### Overview
This is the first working implementation of celery and `csv_upload`
The progress bar is still not in place
The tests have not been addressed

### Code changes
The async httpx code is still in place but used only for the API calls - these are made from each from instance in parallel.

The `csv_upload` file has been deprecated in favour or a new file `csv_upload_async.py` with a synchronous `csv_upload` function. This uses a lot of the same code to create/update/delete the submission instance and categorize the dataframe into patient visit batches.

This function then iterates each batch at a time, for each allocating a celery job which then loops through the visits, validates the fields and stores the results.

There is then a separate `gather_results` function which receives all the callbacks from each job and once the last job is complete, gathers up the errors and stores these in the submission.

There is a `timeit` function still in the calling function. It is very much quicker this way but celery has had some difficulties.

In particular, celery does not accept django objects or dataframes as parameters, so everything has to be serialized or converted to dicts before sending, and deserialized in the worker function. This has done some weird things with the dates and some integers have been converted to floats. There are therefore a few hacky work arounds to address this and there may yet be bugs that are not that obvious. For the moment, the `dummy_sheet.csv` and `dummy_sheet_invalid.csv` both parse sensibly.

TODO
1. figure out what to do about all the tests
2. implement a progress bar
3. test it with a really big file.