### PR TITLE
Handle view_preference more securely

### DIFF
--- a/project/npda/general_functions/view_preference.py
+++ b/project/npda/general_functions/view_preference.py
@@ -1,5 +1,5 @@
 import logging
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, BadRequest
 from django.apps import apps
 
 logger = logging.getLogger(__name__)
@@ -8,16 +8,25 @@ logger = logging.getLogger(__name__)
 def get_or_update_view_preference(user, new_view_preference):
     new_view_preference = int(new_view_preference) if new_view_preference else None
     NPDAUser = apps.get_model("npda", "NPDAUser")
+
+    if new_view_preference is None:
+        return int(user.view_preference)
+
+    # View preference 0 was for organisation level view but that has been removed
+    if new_view_preference not in [1, 2]:
+        logger.warning(
+            f"User {user} requested an invalid view preference: {new_view_preference}"
+        )
+        raise BadRequest()
+    
     if new_view_preference == 2 and not user.is_rcpch_audit_team_member:  # national
         logger.warning(
             f"User {user} requested national view preference but they are not a member of the audit team"
         )
         raise PermissionDenied()
-    elif new_view_preference:
-        user = NPDAUser.objects.get(pk=user.pk)
-        user.view_preference = new_view_preference
-        user.save(update_fields=["view_preference"])
-    else:
-        user = NPDAUser.objects.get(pk=user.pk)
+    
+    user = NPDAUser.objects.get(pk=user.pk)
+    user.view_preference = new_view_preference
+    user.save(update_fields=["view_preference"])
 
     return int(user.view_preference)

--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -186,6 +186,9 @@ class NPDAUser(AbstractUser, PermissionsMixin):
     def get_all_employer_organisations(self):
         return self.organisation_employers.all()
 
+    def viewing_data_nationally(self):
+        return self.is_rcpch_audit_team_member and self.view_preference == 2
+
     def __unicode__(self):
         return self.email
 

--- a/project/npda/tests/factories/seed_users.py
+++ b/project/npda/tests/factories/seed_users.py
@@ -58,7 +58,7 @@ def _seed_users_fixture(django_db_setup, django_db_blocker, test_pz_codes_fixtur
                     view_preference=(
                         VIEW_PREFERENCES[2][0]
                         if user.role == RCPCH_AUDIT_TEAM
-                        else VIEW_PREFERENCES[0][0]
+                        else VIEW_PREFERENCES[1][0]
                     ),
                     organisation_employers=[pz_code],
                 )

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -169,3 +169,24 @@ def test_npda_user_list_view_normal_users_cannot_set_their_view_preference_to_na
 
     users = response.context_data["object_list"]
     check_all_users_in_pdu(ah_user, users, ALDER_HEY_PZ_CODE)
+
+
+@pytest.mark.django_db
+def test_npda_user_list_view_users_cannot_set_their_view_preference_to_anything_they_want(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
+    ).first()
+
+    client = login_and_verify_user(client, ah_user)
+
+    url = reverse("npda_users")
+
+    set_view_preference_response = client.post(
+        url, {"view_preference": 999}, headers={"HX-Request": "true"}
+    )
+
+    assert set_view_preference_response.status_code == HTTPStatus.BAD_REQUEST

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -166,7 +166,7 @@ def test_npda_user_list_view_normal_users_cannot_set_their_view_preference_to_na
 
 
 @pytest.mark.django_db
-def test_npda_user_list_view_users_cannot_set_their_view_preference_to_anything_they_want(
+def test_npda_user_list_view_users_cannot_set_their_view_preference_to_organisation(
     seed_groups_fixture,
     seed_users_fixture,
     client,
@@ -178,13 +178,13 @@ def test_npda_user_list_view_users_cannot_set_their_view_preference_to_anything_
     client = login_and_verify_user(client, ah_user)
 
     set_view_preference_response = client.post(
-        reverse("view_preference"), {"view_preference": 999}, headers={"HX-Request": "true"}
+        reverse("view_preference"), {"view_preference": 0}, headers={"HX-Request": "true"}
     )
 
     assert set_view_preference_response.status_code == HTTPStatus.BAD_REQUEST
 
     ah_user.refresh_from_db()
-    assert ah_user.view_preference == 0
+    assert ah_user.view_preference == 1
 
     # Check the session isn't modified anyway
     response = client.get(reverse("npda_users"))

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -98,17 +98,15 @@ def test_npda_user_list_view_rcpch_audit_team_can_view_all_users(
 
     client = login_and_verify_user(client, ah_audit_team_user)
 
-    url = reverse("npda_users")
-
     # The user still defaults to seeing users from just their PDU
     # This is the request made when you click the "All" button on the switcher in the UI
     set_view_preference_response = client.post(
-        url, {"view_preference": 2}, headers={"HX-Request": "true"}
+        reverse("view_preference"), {"view_preference": 2}, headers={"HX-Request": "true"}
     )
 
-    assert set_view_preference_response.status_code == HTTPStatus.OK
+    assert set_view_preference_response.status_code == HTTPStatus.NO_CONTENT
 
-    response = client.get(url)
+    response = client.get(reverse("npda_users"))
     assert response.status_code == HTTPStatus.OK
 
     users = response.context_data["object_list"]
@@ -126,18 +124,16 @@ def test_npda_user_list_view_users_cannot_switch_outside_their_pdu(
     ).first()
     client = login_and_verify_user(client, ah_user)
 
-    url = reverse("npda_users")
-
     set_view_preference_response = client.post(
-        url,
-        {"npdauser_pz_code_select_name": GOSH_PZ_CODE},
+        reverse("view_preference"),
+        {"pz_code_select_name": GOSH_PZ_CODE},
         headers={"HX-Request": "true"},
     )
 
     assert set_view_preference_response.status_code == HTTPStatus.FORBIDDEN
 
     # Check the session isn't modified anyway
-    response = client.get(url)
+    response = client.get(reverse("npda_users"))
     assert response.status_code == HTTPStatus.OK
 
     users = response.context_data["object_list"]
@@ -155,16 +151,14 @@ def test_npda_user_list_view_normal_users_cannot_set_their_view_preference_to_na
     ).first()
     client = login_and_verify_user(client, ah_user)
 
-    url = reverse("npda_users")
-
     set_view_preference_response = client.post(
-        url, {"view_preference": 2}, headers={"HX-Request": "true"}
+        reverse("view_preference"), {"view_preference": 2}, headers={"HX-Request": "true"}
     )
 
     assert set_view_preference_response.status_code == HTTPStatus.FORBIDDEN
 
     # Check the session isn't modified anyway
-    response = client.get(url)
+    response = client.get(reverse("npda_users"))
     assert response.status_code == HTTPStatus.OK
 
     users = response.context_data["object_list"]
@@ -183,10 +177,18 @@ def test_npda_user_list_view_users_cannot_set_their_view_preference_to_anything_
 
     client = login_and_verify_user(client, ah_user)
 
-    url = reverse("npda_users")
-
     set_view_preference_response = client.post(
-        url, {"view_preference": 999}, headers={"HX-Request": "true"}
+        reverse("view_preference"), {"view_preference": 999}, headers={"HX-Request": "true"}
     )
 
     assert set_view_preference_response.status_code == HTTPStatus.BAD_REQUEST
+
+    ah_user.refresh_from_db()
+    assert ah_user.view_preference == 0
+
+    # Check the session isn't modified anyway
+    response = client.get(reverse("npda_users"))
+    assert response.status_code == HTTPStatus.OK
+
+    users = response.context_data["object_list"]
+    check_all_users_in_pdu(ah_user, users, ALDER_HEY_PZ_CODE)

--- a/project/npda/tests/permissions_tests/test_patient_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_patient_model_actions.py
@@ -47,7 +47,7 @@ def set_view_preference(client, view_preference, pz_code):
     }
 
     response = client.post(url, params, headers={"HX-Request": "true"})
-    assert response.status_code == HTTPStatus.NO_CONTENT    
+    assert response.status_code == HTTPStatus.NO_CONTENT
 
 
 @pytest.mark.django_db
@@ -112,6 +112,42 @@ def test_rcpch_audit_team_can_see_patients_from_all_pdus(
     
     assert(len(patients) == 1)
     assert(patients.first().pk == ah_patient.pk)
+
+
+@pytest.mark.django_db
+def test_user_with_unexpected_view_preference(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    gosh_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE
+    ).first()
+
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
+    ).first()
+
+    rcpch_user = NPDAUser.objects.filter(
+        is_rcpch_audit_team_member=True
+    ).first()
+
+    gosh_patient = create_submission_with_patient(gosh_user)
+    ah_patient = create_submission_with_patient(ah_user)
+
+    client = login_and_verify_user(client, gosh_user)
+
+    # We test that you can't change your view preference to something unexpected in
+    #   test_npda_user_list_view_users_cannot_set_their_view_preference_to_anything_they_want
+    # but for safety's sake we test the behaviour again here
+    gosh_user.view_preference = 999
+    gosh_user.save()
+
+    # Triple check we can still only see our own patients
+    patients = get_patient_list(client)
+    
+    assert(len(patients) == 1)
+    assert(patients.first().pk == gosh_patient.pk)
 
 
 @pytest.mark.django_db

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -34,11 +34,9 @@ from ..general_functions import (
     send_email_to_recipients,
     group_for_role,
     organisations_adapter,
-    get_or_update_view_preference,
     refresh_session_filters
 )
 from .mixins import CheckPDUInstanceMixin, CheckPDUListMixin, LoginAndOTPRequiredMixin
-from project.constants import VIEW_PREFERENCES
 from .mixins import LoginAndOTPRequiredMixin
 
 # from ..signals import password_reset_sent
@@ -59,27 +57,14 @@ class NPDAUserListView(
 
     def get_queryset(self):
         # scope the queryset to filter only those users in organisations in the same PDU. This is to prevent users from seeing all users in the system
+        pz_code = self.request.session.get("pz_code")
 
-        # Organisation level
-        if self.request.user.view_preference == VIEW_PREFERENCES[0][0]:
-            # Organisation view - this is now deprecated
-            return NPDAUser.objects.filter(
-                organisation_employers__pz_code=self.request.session.get("pz_code")
-            ).order_by("surname")
-
-        # The user's organisation, PDU and siblings are stored in the session when they log in
-        elif self.request.user.view_preference == VIEW_PREFERENCES[1][0]:
-            # PDU view
-            # create a list of sibling organisations' ODS codes who share the same PDU as the user
-            pz_code = self.request.session.get("pz_code")
-            return NPDAUser.objects.filter(
-                organisation_employers__pz_code=pz_code
-            ).order_by("surname")
-        elif self.request.user.view_preference == VIEW_PREFERENCES[2][0]:
-            # RCPCH user/national view - get all users
+        if self.request.user.viewing_data_nationally():
             return NPDAUser.objects.all().order_by("surname")
-        else:
-            raise ValueError("Invalid view preference")
+        
+        return NPDAUser.objects.filter(
+            organisation_employers__pz_code=pz_code
+        ).order_by("surname")
 
     def get_context_data(self, **kwargs):
         context = super(NPDAUserListView, self).get_context_data(**kwargs)
@@ -110,44 +95,6 @@ class NPDAUserListView(
                 context=self.get_context_data(),
             )
         return response
-
-    def post(self, request, *args: str, **kwargs) -> HttpResponse:
-        """
-        Override POST method to requery the database for the list of users if view preference changes
-        """
-        if request.htmx:
-            view_preference = request.POST.get("view_preference", None)
-            selected_pz_code = request.POST.get("npdauser_pz_code_select_name", None)
-
-            refresh_session_filters(self.request, pz_code=selected_pz_code)
-
-            view_preference = get_or_update_view_preference(
-                self.request.user, view_preference
-            )
-
-            context = {
-                "view_preference": int(view_preference),
-                "pz_code": request.session.get("pz_code"),
-                "hx_post": reverse_lazy("npda_users"),
-                "organisation_choices": self.request.session.get(
-                    "organisation_choices"
-                ),
-                "pdu_choices": organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
-                    requesting_user=self.request.user, user_instance=self.request.user
-                ),
-                "chosen_pdu": request.session.get("pz_code"),
-                "pz_code_select_name": "npdauser_pz_code_select_name",
-                "hx_target": "#npdauser_view_preference",
-            }
-
-            response = render(request, "partials/view_preference.html", context=context)
-
-            trigger_client_event(
-                response=response, name="npda_users", params={}
-            )  # reloads the form to show the active steps
-            return response
-
-        return super().post(request, *args, **kwargs)
 
 
 class NPDAUserCreateView(

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -111,7 +111,7 @@ class PatientListView(
             )
 
         # filter patients to the view preference of the user
-        if self.request.user.view_preference < 2:
+        if not self.request.user.viewing_data_nationally():
             # PDU view
             filtered_patients &= Q(
                 submissions__paediatric_diabetes_unit__pz_code=pz_code

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -51,15 +51,15 @@ class SubmissionsListView(
         pdu = PaediatricDiabetesUnit.objects.get(
             pz_code=self.request.session.get("pz_code"),
         )
-        if self.request.user.view_preference == 1:
+        if self.request.user.viewing_data_nationally():
+            base_queryset = self.model.objects.filter(
+                audit_year=self.request.session.get("selected_audit_year")
+            ).all()
+        else:
             base_queryset = self.model.objects.filter(
                 paediatric_diabetes_unit=pdu,
                 audit_year=self.request.session.get("selected_audit_year"),
             )
-        else:
-            base_queryset = self.model.objects.filter(
-                audit_year=self.request.session.get("selected_audit_year")
-            ).all()
 
         final = base_queryset.annotate(
             patient_count=Count("patients"),


### PR DESCRIPTION
Fixes #612 

- Disallow setting `view_preference` other than 1 or 2
  - Fixes security issue where you could construct a malicious request to set view_preference to something larger than 2 and see everything
- Always check `is_rcpch_audit_team_member` alongside `view_preference=2` for defence in depth
- Remove view preference HTMX callback in users view - it's now handled in the `view_preference` route