### PR TITLE
Unplug coeliac screen date validation from gluten free diet

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -943,15 +943,6 @@ class VisitForm(forms.ModelForm):
                 [{"thyroid_treatment_status": thyroid_treatment_status}],
             )
 
-        coeliac_screen_date = cleaned_data.get("coeliac_screen_date")
-        gluten_free_diet = cleaned_data.get("gluten_free_diet")
-        if any([coeliac_screen_date, gluten_free_diet]):
-            measure_must_have_date_and_value(
-                coeliac_screen_date,
-                "coeliac_screen_date",
-                [{"gluten_free_diet": gluten_free_diet}],
-            )
-
         psychological_screening_assessment_date = cleaned_data.get(
             "psychological_screening_assessment_date"
         )

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -1144,11 +1144,9 @@ def test_coeliac_treatment_status_unrecognized_form_fails_validation():
     ), f"Invalid coeliac function status offered but test passed"
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/628
 @pytest.mark.django_db
-def test_coeliac_treatment_status_none_form_fails_validation():
-    """
-    Test that missing coeliac function status is invalid
-    """
+def test_coeliac_treatment_status_none_form_passes_validation():
     patient = PatientFactory()
 
     form = VisitForm(
@@ -1159,16 +1157,12 @@ def test_coeliac_treatment_status_none_form_fails_validation():
         initial={"patient": patient},
     )
     # Trigger the cleaners
-    assert (
-        form.is_valid() == False
-    ), f"No coeliac function status offered but test passed"
+    assert "gluten_free_diet" not in form.errors
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/628
 @pytest.mark.django_db
 def test_coeliac_screen_date_none_form_fails_validation():
-    """
-    Test that missing coeliac function date is invalid
-    """
     patient = PatientFactory()
 
     form = VisitForm(
@@ -1179,7 +1173,7 @@ def test_coeliac_screen_date_none_form_fails_validation():
         initial={"patient": patient},
     )
     # Trigger the cleaners
-    assert form.is_valid() == False, f"No coeliac function date offered but test passed"
+    assert "gluten_free_diet" not in form.errors
 
 
 """

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -2054,11 +2054,9 @@ def test_coeliac_screening_impossible_value_fails_validation(
     assert visit.gluten_free_diet == 94
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/628
 @pytest.mark.django_db
 def test_coeliac_screening_missing_fails_validation(test_user, single_row_valid_df):
-    """
-    Test that a missing coeliac screening value is rejected
-    """
     single_row_valid_df.loc[0, "Observation Date: Coeliac Disease Screening"] = (
         "01/01/2022"
     )
@@ -2068,7 +2066,7 @@ def test_coeliac_screening_missing_fails_validation(test_user, single_row_valid_
 
     errors = csv_upload_sync(test_user, single_row_valid_df)
 
-    assert "gluten_free_diet" in errors[0]
+    assert "gluten_free_diet" not in errors[0]
 
     visit = Visit.objects.first()
 
@@ -2076,13 +2074,11 @@ def test_coeliac_screening_missing_fails_validation(test_user, single_row_valid_
     assert visit.gluten_free_diet is None
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/628
 @pytest.mark.django_db
-def test_coeliac_screening_date_missing_fails_validation(
+def test_coeliac_screening_date_missing_passes_validation(
     test_user, single_row_valid_df
 ):
-    """
-    Test that a missing coeliac screening date is rejected
-    """
     single_row_valid_df.loc[0, "Observation Date: Coeliac Disease Screening"] = None
     single_row_valid_df.loc[
         0, "Has the patient been recommended a Gluten-free diet?"
@@ -2090,7 +2086,7 @@ def test_coeliac_screening_date_missing_fails_validation(
 
     errors = csv_upload_sync(test_user, single_row_valid_df)
 
-    assert "coeliac_screen_date" in errors[0]
+    assert "coeliac_screen_date" not in errors[0]
 
     visit = Visit.objects.first()
 


### PR DESCRIPTION
Part of #628

Coeliac screen date and gluten free diet are related but independent data points in in the audit. It's fine to have one and not the other.

[From the guidance](https://www.rcpch.ac.uk/sites/default/files/2024-02/npda_dataset_2021_guidance_updated_feb_2024.pdf):

> Date of coeliac disease screening only to be completed if patient was diagnosed within audit year.
> Process complete if date is within 90 days of diagnosis for patient with Type 1 diabetes.

> Provide dietary status for all patients:
>  A 'yes' response will be interpreted as the patient having a diagnosis of coeliac disease.

> Dietary status should be reported for every patient within each audit year to allow prevalence of coeliac disease to be calculated