### PR TITLE
Fix incomplete year of care in patient list

### DIFF
--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -211,19 +211,3 @@ class Patient(models.Model):
         ).exists():
             return True
         return False
-
-    def has_completed_a_full_year_of_care(self):
-        """
-        Returns True if the patient has completed a full year of care
-        This includes:
-        - Patients who have been diagnosed with diabetes for more than a year
-        - Patients who are still alive
-        """
-
-        if self.diagnosis_date:
-            if (
-                self.diagnosis_date + timedelta(days=365) < date.today()
-                and self.death_date is None
-            ):
-                return True
-        return False

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -42,7 +42,7 @@
       </thead>
       <tbody>
         {% for patient in page_obj %}
-          {% if patient.is_first_valid or patient.is_first_error or patient.is_first_incomplete_full_year %}
+          {% if patient.is_first_valid or patient.is_first_error or patient.is_first_valid_incomplete_full_year %}
             <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50">
               <tr>
                 <th colspan="13" class="px-6 py-3">
@@ -50,7 +50,7 @@
                     Patients where all records have been validated
                   {% elif patient.is_first_error %}
                     Patients with records failing validation
-                  {% elif patient.is_first_incomplete_full_year %}
+                  {% elif patient.is_first_valid_incomplete_full_year %}
                     Patients with an incomplete year of care
                   {% endif %}
                 </th>

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -42,14 +42,14 @@
       </thead>
       <tbody>
         {% for patient in page_obj %}
-          {% if patient.is_first_valid or patient.is_first_error or patient.is_first_valid_incomplete_full_year %}
+          {% if patient.is_first_error or patient.is_first_valid or patient.is_first_valid_incomplete_full_year %}
             <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50">
               <tr>
                 <th colspan="13" class="px-6 py-3">
-                  {% if patient.is_first_valid %}
-                    Patients where all records have been validated
-                  {% elif patient.is_first_error %}
-                    Patients with records failing validation
+                  {% if patient.is_first_error %}
+                    Patients with data quality issues
+                  {% elif patient.is_first_valid %}
+                    Patients with a full year of care
                   {% elif patient.is_first_valid_incomplete_full_year %}
                     Patients with an incomplete year of care
                   {% endif %}

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -121,14 +121,10 @@ class PatientListView(
 
         a_year_ago = timezone.now() - timezone.timedelta(days=365)
 
-        has_completed_a_full_year = Q(
-            diagnosis_date__gt=a_year_ago,
-        )
-
         patient_queryset = patient_queryset.annotate(
             audit_year=F("submissions__audit_year"),
             visit_error_count=Count(Case(When(visit__is_valid=False, then=1))),
-            full_year_of_care=has_completed_a_full_year,
+            incomplete_full_year_of_care=Case(When(diagnosis_date__gt=a_year_ago, then=True), default=False),
             last_upload_date=Max("submissions__submission_date"),
             most_recent_visit_date=Max("visit__visit_date"),
             distance_from_lead_organisation=Distance(
@@ -147,7 +143,9 @@ class PatientListView(
             patient_queryset = patient_queryset.order_by(sort_by)
         else:
             patient_queryset = patient_queryset.order_by(
-                "is_valid", "-visit_error_count", "full_year_of_care"
+                "is_valid", # Patient model has errors
+                "-visit_error_count", # Any Visits associated to the patient have errors
+                "incomplete_full_year_of_care"
             )
 
         return patient_queryset
@@ -202,60 +200,43 @@ class PatientListView(
         context["current_page"] = self.request.GET.get("page", 1)
         context["sort_by"] = self.get_sort_by()
 
+        seen_first_error = False
+        seen_first_valid = False
+        seen_first_valid_incomplete_full_year = False
+        seen_first_died = False
+
         # Add extra fields to the patient that we can't add to the query. This is ok because the queryset will be max the page size.
-        error_count_in_page = 0
-        valid_count_in_page = 0
-        first_incomplete_year_count_in_page = 0
-
         for patient in context["page_obj"]:
-
-            patient.is_first_error = False
-            patient.is_first_valid = False
-            patient.is_first_incomplete_full_year = False
-
             # Signpost the latest quarter
             if patient.most_recent_visit_date is not None:
                 patient.latest_quarter = retrieve_quarter_for_date(
                     patient.most_recent_visit_date
                 )
+        
+        seen_first_error = False
+        seen_first_valid = False
+        seen_first_valid_incomplete_full_year = False
 
-            # Highlight the separation between patients with errors and those without
-            # unless we are sorting by a particular field in which case errors appear mixed
-            if not context["sort_by"]:
-                if (
-                    (not patient.is_valid or patient.visit_error_count > 0)
-                    and patient.full_year_of_care
-                    and patient.death_date is None
-                ):
-                    if error_count_in_page == 0:
+        # Highlight the separation between categories of patients unless we are sorting by a particular field.
+        # Each category could be empty.
+        if not context["sort_by"]:
+            for patient in context["page_obj"]:
+                # Patients with records that need fixing or have visits that need fixing
+                # This could include patients with an incomplete year of care
+                if not patient.is_valid or patient.visit_error_count > 0:
+                    if not seen_first_error:
                         patient.is_first_error = True
+                        seen_first_error = True
+                else:
+                    if not seen_first_valid_incomplete_full_year and patient.incomplete_full_year_of_care:
+                        patient.is_first_valid_incomplete_full_year = True
 
-                    error_count_in_page += 1
-
-                if (
-                    patient.is_valid
-                    and patient.visit_error_count == 0
-                    and patient.full_year_of_care
-                    and patient.death_date is None
-                ):
-                    if valid_count_in_page == 0:
+                        seen_first_valid_incomplete_full_year = True
+                        # Edge case: all the valid patients could have an incomplete year of care
+                        seen_first_valid = True
+                    elif not seen_first_valid:
                         patient.is_first_valid = True
-
-                    valid_count_in_page += 1
-
-                if patient.full_year_of_care is False or patient.death_date is not None:
-                    if first_incomplete_year_count_in_page == 0:
-                        patient.is_first_incomplete_full_year = True
-                    else:
-                        patient.is_first_incomplete_full_year = False
-
-                    first_incomplete_year_count_in_page += 1
-
-        context["error_count_in_page"] = error_count_in_page
-        context["valid_count_in_page"] = valid_count_in_page
-        context["first_incomplete_year_count_in_page"] = (
-            first_incomplete_year_count_in_page
-        )
+                        seen_first_valid = True
 
         return context
 


### PR DESCRIPTION
Fixes #644 

Patients with an incomplete year of care are now correctly placed at the end of the list unless sorting by a particular field. I've also tweaked the wording of the categories based on discussions in our catch ups, trying to indicate this view does not show issues or errors with the patient themselves but with the data about them.

| Before                                         | After                             |
|------------------------------------------------|-----------------------------------|
| Patients with records failing validation       | Patients with data quality issues |
| Patients where all records have been validated | Patients with a full year of care |
| Patients with an incomplete year of care       | (as before, but bugs fixed)       |