### PR TITLE
Fix crash viewing visit list for patients who have transferred

### DIFF
--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -66,29 +66,8 @@ class PatientVisitsListView(
         context["patient"] = patient
         context["submission"] = submission
 
-        if patient.is_in_transfer_in_the_last_year():
-            pz_code = (
-                Transfer.objects.filter(
-                    patient=patient,
-                )
-                .order_by("-date_leaving_service")
-                .first()
-                .previous_pz_code
-            )
-            PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
-            pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
-        # get the PDU for this patient - this is the PDU that the patient is currently under.
-        # If the patient has left the PDU, the date_leaving_service will be set and it will be possible to view KPIs for the PDU up until transfer,
-        # if this happened during the audit period. This is TODO
-        else:
-            #  this patient has been transferred but not yet received at a new PDU
-            pdu = (
-                Transfer.objects.filter(
-                    patient=patient, date_leaving_service__isnull=True
-                )
-                .first()
-                .paediatric_diabetes_unit
-            )
+        # If the patient has left the PDU, they may appear in another one but we record that as a separate Patient instance
+        pdu = Transfer.objects.get(patient=patient).paediatric_diabetes_unit
 
         calculate_kpis = CalculateKPIS(
             calculation_date=datetime.date.today(), return_pt_querysets=False


### PR DESCRIPTION
Fixes #651

Transfer records are currently per patient. When a patient transfers they will appear in the new PDU as a new patient instance once data is uploaded