### PR TITLE
Fix additional care processes graph

### DIFF
--- a/project/npda/templates/dashboard/components/cards/additional_care_processes_card.html
+++ b/project/npda/templates/dashboard/components/cards/additional_care_processes_card.html
@@ -1,6 +1,6 @@
 {% extends 'dashboard/components/bases/base_card.html' %}
 {% block card_title %}
-  Additional Care Proccesses
+  Additional Care Processes
   {% include 'common/docs_icon_link_button.html' with rel_url="developer/kpis/additional_processes" fa_icon_class="fa-solid fa-eye" %}
 {% endblock card_title%}
 {% block card_body %}
@@ -11,7 +11,7 @@
 {% else %}
   <div
   hx-get="{% url 'get_simple_bar_chart_pcts_partial' %}?color=E00087"
-  hx-vals='{"data" : {{ charts.additional_care_processes_value_counts_pct.data }}}'
+  hx-vals='{"data" : {{ charts.additional_care_processes_value_counts_pct.data }}, "yaxis_title": "% Eligible"}'
   hx-trigger="load" hx-swap="innerHTML"
   _="on htmx:afterSwap remove #loading-spinner-additional-care-processes-card"></div>
 

--- a/project/npda/views/dashboard/helpers.py
+++ b/project/npda/views/dashboard/helpers.py
@@ -324,14 +324,14 @@ def get_additional_care_processes_value_counts(
 
     for ix, kpi_attr in enumerate(additional_care_processes_kpi_attr_names):
         total_eligible = kpi_calculations_object[kpi_attr]["total_eligible"]
-        total_ineligible = kpi_calculations_object[kpi_attr]["total_ineligible"]
+        total_passed = kpi_calculations_object[kpi_attr]["total_passed"]
 
         # Need all 3 for front end chart
-        value_counts[kpi_attr]["count"] = total_eligible
-        value_counts[kpi_attr]["total"] = total_eligible + total_ineligible
+        value_counts[kpi_attr]["count"] = total_passed
+        value_counts[kpi_attr]["total"] = total_eligible
         value_counts[kpi_attr]["pct"] = (
-            round(total_eligible / value_counts[kpi_attr]["total"] * 100, 1)
-            if value_counts[kpi_attr]["total"] > 0
+            round(total_passed / total_eligible * 100, 1)
+            if total_eligible > 0
             else 0
         )
         value_counts[kpi_attr]["label"] = labels[ix]

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -519,6 +519,8 @@ def get_simple_bar_chart_pcts_partial(request):
         # NOTE: don't need to handle empty data as the template handles this
         data_raw = json.loads(request.GET.get("data"))
 
+        yaxis_title = request.GET.get("yaxis_title", "% CYP with T1DM")
+
         x, y = [], []
         passed, eligible = [], []
         for _, values in data_raw.items():
@@ -550,7 +552,6 @@ def get_simple_bar_chart_pcts_partial(request):
             tickvals=[0, 25, 50, 75, 100],
             ticktext=["0", "25", "50", "75", "100"],
         )
-        yaxis_title = "% CYP with T1DM"
         fig.update_layout(
             title="",
             xaxis_title="",

--- a/project/npda/views/dashboard/template_data.py
+++ b/project/npda/views/dashboard/template_data.py
@@ -27,7 +27,7 @@ TEXT = {
         },
     },
     "additional_care_processes": {
-        "title": "Additional Care Proccesses",
+        "title": "Additional Care Processes",
         "description": "These additional care processes are recommended by NICE for children and young people with Type 1 diabetes of all ages (and ineligible otherwise), with the exception of smoking status and referral to smoking cessation services, which apply to young people aged 12 and above.",
         "headers": [
             "NHS NUMBER",


### PR DESCRIPTION
Fixes #658 

I believe it was incorrectly comparing `total_eligible` to `total_ineligible` when it should compare `total_passed` to `total_eligible` as we already do for treatment regimen and glucose monitoring.

Also fix a typo in the graph name and change the Y axis label to `% Eligible`, as the criteria differs across different bars.