### PR TITLE
Patient level report as a top level navigation item 

### DIFF
--- a/project/npda/templates/dashboard/dashboard_base.html
+++ b/project/npda/templates/dashboard/dashboard_base.html
@@ -7,9 +7,6 @@
      hx-trigger="dashboard from:body"
      hx-swap="innerHTML">
   <div class="my-6">
-    <h1 class="text-5xl text-center">
-      PDU Dashboard for {{ lead_organisation }} ({{ pdu_object.pz_code }})
-    </h1>
     <p class="text-center text-gray-500 mt-2">
       Calculated at {{ kpi_calculations_object.calculation_datetime }}
     </p>

--- a/project/npda/templates/dashboard/dashboard_base.html
+++ b/project/npda/templates/dashboard/dashboard_base.html
@@ -65,8 +65,4 @@
   <div class="grid grid-cols-1 min-h-80">
     {% include 'dashboard/components/cards/imd_map_card.html' with scatterplot_of_cases_for_selected_organisation=charts.scatterplot_of_cases_for_selected_organisation pdu_lead_organisation=pdu_lead_organisation pdu_object=pdu_object %}
   </div>
-  <!-- PATIENT LEVEL REPORT -->
-  <h1 class="text-5xl text-center my-6">Patient-Level Report</h1>
-  <!-- SELECT TABS & TABLE -->
-  {% include 'dashboard/pt_level_report_table_partial.html' with text=default_pt_level_menu_text selected=default_pt_level_menu_tab_selected highlight=default_highlight table_data=default_table_data %}
 </div>

--- a/project/npda/templates/dashboard/patient_report_base.html
+++ b/project/npda/templates/dashboard/patient_report_base.html
@@ -1,9 +1,6 @@
 <script src="https://unpkg.com/konva@9/konva.min.js"></script>
 <div class="lg:container mx-auto p-4 font-montserrat text-rcpch_dark_blue">
   <div class="my-6">
-    <h1 class="text-5xl text-center">
-      Patient report for {{ lead_organisation }} ({{ pdu_object.pz_code }})
-    </h1>
     <p class="text-center text-gray-500 mt-2">
       Calculated at {{ kpi_calculations_object.calculation_datetime }}
     </p>

--- a/project/npda/templates/dashboard/patient_report_base.html
+++ b/project/npda/templates/dashboard/patient_report_base.html
@@ -1,0 +1,14 @@
+<script src="https://unpkg.com/konva@9/konva.min.js"></script>
+<div class="lg:container mx-auto p-4 font-montserrat text-rcpch_dark_blue">
+  <div class="my-6">
+    <h1 class="text-5xl text-center">
+      Patient report for {{ lead_organisation }} ({{ pdu_object.pz_code }})
+    </h1>
+    <p class="text-center text-gray-500 mt-2">
+      Calculated at {{ kpi_calculations_object.calculation_datetime }}
+    </p>
+    <p class="text-center">This data has not been validated by the NPDA team.</p>
+  </div>
+  <!-- SELECT TABS & TABLE -->
+  {% include 'dashboard/pt_level_report_table_partial.html' with text=default_pt_level_menu_text selected=default_pt_level_menu_tab_selected highlight=default_highlight table_data=default_table_data %}
+</div>

--- a/project/npda/templates/dashboard/pt_level_report_table_partial.html
+++ b/project/npda/templates/dashboard/pt_level_report_table_partial.html
@@ -45,15 +45,15 @@
         <div class="flex gap-4">
           <div class="flex gap-2 items-center">
             <i class="fa-solid fa-circle-check text-success"></i>
-            <p>Pass</p>
+            <p>{{ text.key|get_item:"pass" }}</p>
           </div>
           <div class="flex gap-2 items-center">
             <i class="fa-solid fa-circle-exclamation text-error"></i>
-            <p>Fail</p>
+            <p>{{ text.key|get_item:"fail" }}</p>
           </div>
           <div class="flex gap-2 items-center">
             <i class="fa-solid fa-ban text-muted"></i>
-            <p>Ineligible</p>
+            <p>{{ text.key|get_item:"ineligible" }}</p>
           </div>
         </div>
       </div>

--- a/project/npda/templates/navbar/components/nav_links.html
+++ b/project/npda/templates/navbar/components/nav_links.html
@@ -1,12 +1,13 @@
 {% load npda_tags %}
 {% if user.is_authenticated %}
-  {% comment %} DASHBOARD {% endcomment %}
   <li class="">
-    {% include "navbar/components/nav_link.html" with url_name="dashboard" nav_text="Dashboard" %}
+    {% include "navbar/components/nav_link.html" with url_name="dashboard" nav_text="Unit Report" %}
   </li>
-  {% comment %} SUBMISSIONS {% endcomment %}
   <li class="">
-    {% include "navbar/components/nav_link.html" with url_name="patients" nav_text="Submissions" %}
+    {% include "navbar/components/nav_link.html" with url_name="patient-report" nav_text="Patient Report" %}
+  </li>
+  <li class="">
+    {% include "navbar/components/nav_link.html" with url_name="patients" nav_text="Patient Data" %}
   </li>
 {% endif %}
 <li>

--- a/project/npda/templates/patient-report.html
+++ b/project/npda/templates/patient-report.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load npda_tags %}
+{% block content %}
+  {% include 'dashboard/patient_report_base.html' %}
+{% endblock content %}

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -15,9 +15,10 @@ from ...constants import (
 from django.contrib.gis.measure import D
 from datetime import date
 
+
 register = template.Library()
 
-# logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @register.filter

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -115,6 +115,11 @@ dashboard_urlpatterns = [
         name="dashboard",
     ),
     path(
+        "patient-report",
+        view=dashboard.patient_report,
+        name="patient-report"
+    ),
+    path(
         "get_patient_level_report_partial",
         view=partials.get_patient_level_report_partial,
         name="get_patient_level_report_partial",

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -346,3 +346,61 @@ def dashboard(request):
     }
 
     return render(request, template_name=template, context=context)
+
+
+@login_and_otp_required()
+def patient_report(request):
+    template = "patient-report.html"
+
+    pz_code = request.session.get("pz_code")
+
+    PaediatricDiabetesUnit: PaediatricDiabetesUnitClass = apps.get_model(
+        "npda", "PaediatricDiabetesUnit"
+    )
+    try:
+        pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+    except PaediatricDiabetesUnit.DoesNotExist:
+        messages.error(
+            request=request,
+            message=f"Paediatric Diabetes Unit with PZ code {pz_code} does not exist",
+        )
+        return render(request, "patient-report.html")
+
+    selected_audit_year = int(request.session.get("selected_audit_year"))
+
+    if selected_audit_year <= 2024:
+        # The day after the audit year end date
+        calculation_date = date(selected_audit_year, 4, 1)
+    else:
+        today = date.today()
+        calculation_date = date(selected_audit_year, today.month, today.day)
+
+    calculate_kpis = CalculateKPIS(calculation_date=calculation_date, return_pt_querysets=True)
+
+    kpi_calculations_object = calculate_kpis.calculate_kpis_for_pdus(pz_codes=[pz_code])
+
+    default_pt_level_menu_text = template_data.TEXT["health_checks"]
+    default_pt_level_menu_tab_selected = "health_checks"
+    highlight = {
+        f"{key}": key == default_pt_level_menu_tab_selected for key in template_data.TEXT.keys()
+    }
+    default_pt_level_table_headers, default_pt_level_table_data = hp.get_pt_level_table_data(
+        category="health_checks",
+        calculate_kpis_object=calculate_kpis,
+        kpi_calculations_object=kpi_calculations_object,
+    )
+
+    context = {
+        "pdu_object": pdu,
+        "kpi_calculations_object": kpi_calculations_object,
+        "default_pt_level_menu_text": default_pt_level_menu_text,
+        "default_pt_level_menu_tab_selected": default_pt_level_menu_tab_selected,
+        "default_highlight": highlight,
+        "default_table_data": {
+            "headers": default_pt_level_table_headers,
+            "row_data": default_pt_level_table_data,
+            "ineligible_hover_reason": template_data.TEXT["health_checks"]["ineligible_hover_reason"],
+        }
+    }
+
+    return render(request, template_name=template, context=context)

--- a/project/npda/views/dashboard/template_data.py
+++ b/project/npda/views/dashboard/template_data.py
@@ -25,6 +25,11 @@ TEXT = {
             "kpi_30_retinal_screening": "Does not fulfil criteria for KPI 6",
             "kpi_31_foot_examination": "Does not fulfil criteria for KPI 6",
         },
+        "key": {
+            "pass": "Complete",
+            "fail": "Incomplete",
+            "ineligible": "Not required"
+        }
     },
     "additional_care_processes": {
         "title": "Additional Care Proccesses",
@@ -50,6 +55,11 @@ TEXT = {
             "kpi_39_influenza_immunisation_recommended": "Does not fulfil criteria for KPI 5",
             "kpi_40_sick_day_rules_advice": "Does not fulfil criteria for KPI 1",
         },
+        "key": {
+            "pass": "Complete",
+            "fail": "Incomplete",
+            "ineligible": "Not required"
+        }
     },
     "care_at_diagnosis": {
         "title": "Care at Diagnosis",
@@ -65,6 +75,11 @@ TEXT = {
             "kpi_42_thyroid_disease_screening": "Does not fulfil criteria for KPI 7, diagnosed at least 90 days before the end of the audit period",
             "kpi_43_carbohydrate_counting_education": "Does not fulfil criteria for KPI 7, diagnosed at least 90 days before the end of the audit period",
         },
+        "key": {
+            "pass": "Complete",
+            "fail": "Incomplete",
+            "ineligible": "Not required"
+        }
     },
     "outcomes": {
         "title": "Outcomes",


### PR DESCRIPTION
Fixes #642 

Avoids scrolling all the way down past the dashboard to get to the patient level KPI reports. In practice we think this report is so important it should replace or merge with the existing patient list but this is a simple first step.

| Before      | After          |
|-------------|----------------|
| Dashboard   | Unit Report    |
|             | Patient Report |
| Submissions | Patient Data   |
| User Guide  | User Guide     |

![Screenshot 2025-02-28 124230](https://github.com/user-attachments/assets/d8720bad-d04f-4606-b15d-a4c0b62c6489)
