### PR TITLE
[Dashboard] Health checks chart fix and deprivation subtitle explainer fix on smaller screens

### DIFF
--- a/project/npda/templates/dashboard/components/bases/base_card.html
+++ b/project/npda/templates/dashboard/components/bases/base_card.html
@@ -2,6 +2,7 @@
   <h2 class="text-lg text-center font-bold p-2">
     {% block card_title %}{% endblock card_title %}
   </h2>
+  {% block subtitle %}{% endblock %}
   <div class="p-3 h-full">
     {% block card_body %}{% endblock %}
   </div>

--- a/project/npda/templates/dashboard/components/cards/imd_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_card.html
@@ -2,6 +2,11 @@
 {% block card_title %}
   Index of Multiple Deprivation (Quintile)
 {% endblock card_title%}
+
+{% block subtitle %}
+<p class="text-sm text-center">1st Most Deprived - 5th Least Deprived</p>
+{% endblock %}
+
 {% block card_body %}
 <div
 hx-get="{% url 'get_waffle_chart_partial' %}"

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -19,7 +19,7 @@ from project.npda.tests.kpi_calculations.test_calculate_kpis import \
 def test_kpi_calculation_33(AUDIT_START_DATE):
     """Tests that KPI33 is calculated correctly.
 
-    Calculates KPI 32: HbA1c 4+ (%)
+    Calculates KPI 33: HbA1c 4+ (%)
 
     Numerator: Number of eligible patients with at least four entries for HbA1c value (item 17) with an observation date (item 19) within the audit period
 

--- a/project/npda/views/dashboard/helpers.py
+++ b/project/npda/views/dashboard/helpers.py
@@ -104,11 +104,11 @@ def get_hc_completion_rate_vcs(
     vcs = {}
     for ix, kpi_values in enumerate([kpi_32_1_values, kpi_32_2_values, kpi_32_3_values], start=1):
         if ix == 1:
-            kpi_label = "<12 years old"
-        elif ix == 2:
-            kpi_label = ">=12 years old"
-        else:
             kpi_label = "Overall"
+        elif ix == 2:
+            kpi_label = "<12 years old"
+        else:
+            kpi_label = ">=12 years old"
 
         vcs[f"kpi_32_{ix}_values"] = {
             "count": kpi_values["total_passed"],
@@ -120,7 +120,7 @@ def get_hc_completion_rate_vcs(
             ),
             "label": kpi_label,
         }
-
+    logger.debug(f'{vcs=}')
     return vcs
 
 

--- a/project/npda/views/dashboard/helpers.py
+++ b/project/npda/views/dashboard/helpers.py
@@ -102,25 +102,43 @@ def get_hc_completion_rate_vcs(
 
     # Just need pass and fail
     vcs = {}
-    for ix, kpi_values in enumerate([kpi_32_1_values, kpi_32_2_values, kpi_32_3_values], start=1):
-        if ix == 1:
-            kpi_label = "Overall"
-        elif ix == 2:
-            kpi_label = "<12 years old"
-        else:
-            kpi_label = ">=12 years old"
 
-        vcs[f"kpi_32_{ix}_values"] = {
-            "count": kpi_values["total_passed"],
-            "total": kpi_values["total_eligible"],
-            "pct": (
-                int(kpi_values["total_passed"] / kpi_values["total_eligible"] * 100)
-                if kpi_values["total_passed"]
-                else 0
-            ),
-            "label": kpi_label,
-        }
-    logger.debug(f'{vcs=}')
+    kpi_32_2_passed = kpi_32_2_values["total_passed"]
+    kpi_32_2_total = kpi_32_2_values["total_eligible"]
+    kpi_32_3_passed = kpi_32_3_values["total_passed"]
+    kpi_32_3_total = kpi_32_3_values["total_eligible"]
+
+    # Overall
+    # For overall, we need to sum total passed and total eligible for kpis 31_2 and 32_3.
+    # We IGNORE 32_1 as this is a count of health checks, not patients!
+    kpi_32_1_pct = (
+        int((kpi_32_2_passed + kpi_32_3_passed) / (kpi_32_2_total + kpi_32_3_total) * 100)
+        if kpi_32_2_total + kpi_32_3_total
+        else 0
+    )
+    vcs["kpi_32_1_values"] = {
+        "count": kpi_32_2_passed + kpi_32_3_passed,
+        "total": kpi_32_2_total + kpi_32_3_total,
+        "pct": kpi_32_1_pct,
+        "label": "Overall",
+    }
+
+    # <12 years old
+    vcs["kpi_32_2_values"] = {
+        "count": kpi_32_2_passed,
+        "total": kpi_32_2_total,
+        "pct": int(kpi_32_2_passed / kpi_32_2_total * 100) if kpi_32_2_total else 0,
+        "label": "<12 years old",
+    }
+
+    # >=12 years old
+    vcs["kpi_32_3_values"] = {
+        "count": kpi_32_3_passed,
+        "total": kpi_32_3_total,
+        "pct": int(kpi_32_3_passed / kpi_32_3_total * 100) if kpi_32_3_total else 0,
+        "label": ">=12 years old",
+    }
+
     return vcs
 
 
@@ -330,9 +348,7 @@ def get_additional_care_processes_value_counts(
         value_counts[kpi_attr]["count"] = total_passed
         value_counts[kpi_attr]["total"] = total_eligible
         value_counts[kpi_attr]["pct"] = (
-            round(total_passed / total_eligible * 100, 1)
-            if total_eligible > 0
-            else 0
+            round(total_passed / total_eligible * 100, 1) if total_eligible > 0 else 0
         )
         value_counts[kpi_attr]["label"] = labels[ix]
 

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -247,7 +247,9 @@ def get_waffle_chart_partial(request):
             margin=dict(l=0, r=0, t=0, b=0),
             legend=dict(
                 orientation="h",
-                y=1.25,  # Move legend higher above the plot
+                # Move legend higher above the plot
+                # IMD plot has subtitle so move up less
+                y=1.15 if is_imd_plot else 1.2,  
                 x=0.5,
                 xanchor="center",
                 font=dict(size=10),
@@ -255,17 +257,6 @@ def get_waffle_chart_partial(request):
             paper_bgcolor="rgba(0,0,0,0)",
             plot_bgcolor="rgba(0,0,0,0)",
         )
-
-        if is_imd_plot:
-            fig.update_layout(
-                title=dict(
-                    text="1st Most Deprived - 5th Least Deprived",
-                    font=dict(size=11),
-                    y=0.9,
-                    x=0.5,
-                    xanchor="center"
-                )
-            )
 
         # Convert Plotly figure to HTML
         chart_html = fig.to_html(


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

Health check calculations shown on graph we incorrect previously because:
1. Incorrect indexing (e.g. labelling <12yo with the KPI value counts for >= 12yo)
2. KPI `32_1` was being used for overall but this is a count of health checks; instead overall should be a sum of values from `32_2` and `32_3`

Can't show all hover labels but denominators now add up and are right:

<img width="504" alt="image" src="https://github.com/user-attachments/assets/9b4f3473-a5cb-4406-9970-9bcb4a4a1546" />


Also moved IMD deprivation explainer text into HTMl for nicer responsive rendering on smaller screens (previous overlapped):

<img width="514" alt="image" src="https://github.com/user-attachments/assets/cb89ce94-fe44-43c4-8d0f-339e44e7574c" />


### Code changes
- health check value count fix
- template update for IMD text



### Related Issues
https://github.com/orgs/rcpch/projects/13/views/1?pane=issue&itemId=98425149&issue=rcpch%7Cnational-paediatric-diabetes-audit%7C636

#659 


