### PR TITLE
[Dashboard] FINALLY fix health check denominators!

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -99,13 +99,9 @@ class CalculateKPIS:
         """
 
         # Set various attributes used in calculations
-        self.calculation_date = (
-            calculation_date if calculation_date is not None else date.today()
-        )
+        self.calculation_date = calculation_date if calculation_date is not None else date.today()
         # Set the start and end audit dates
-        self.audit_start_date, self.audit_end_date = (
-            self._get_audit_start_and_end_dates()
-        )
+        self.audit_start_date, self.audit_end_date = self._get_audit_start_and_end_dates()
         self.AUDIT_DATE_RANGE = (self.audit_start_date, self.audit_end_date)
 
         # Set the return_pt_querysets attribute
@@ -213,17 +209,13 @@ class CalculateKPIS:
         if type(patient) != Patient:
             raise ValueError(f"patient must be a Patient instance, got {type(patient)}")
         if type(pdu) != PaediatricDiabetesUnit:
-            raise ValueError(
-                f"pdu must be a PaediatricDiabetesUnit instance, got {type(pdu)}"
-            )
+            raise ValueError(f"pdu must be a PaediatricDiabetesUnit instance, got {type(pdu)}")
 
         # Get values that are simple look ups
         calculation_datetime = datetime.now()
         audit_start_date = self.audit_start_date
         audit_end_date = self.audit_end_date
-        gte_12yo = patient.date_of_birth <= calculation_datetime.date() - relativedelta(
-            years=12
-        )
+        gte_12yo = patient.date_of_birth <= calculation_datetime.date() - relativedelta(years=12)
         diagnosed_in_period = patient.diagnosis_date in self.AUDIT_DATE_RANGE
         died_in_period = patient.death_date in self.AUDIT_DATE_RANGE
         transfer_in_period = (
@@ -375,8 +367,8 @@ class CalculateKPIS:
                 kpi_number = 320 + int(name_split[2])
 
             # Assign the KPI label
-            return_obj["calculated_kpi_values"][kpi_name]["kpi_label"] = (
-                self._get_kpi_label(kpi_number)
+            return_obj["calculated_kpi_values"][kpi_name]["kpi_label"] = self._get_kpi_label(
+                kpi_number
             )
 
         return return_obj
@@ -389,9 +381,7 @@ class CalculateKPIS:
 
         return kpi_registry.get_rendered_label(kpi_number)
 
-    def _run_kpi_calculation_method(
-        self, kpi_method_name: str
-    ) -> Union[KPIResult | str]:
+    def _run_kpi_calculation_method(self, kpi_method_name: str) -> Union[KPIResult | str]:
         """Will find and run kpi calculation method
         (name schema is calculation_KPI_NAME_MAP_VALUE)
         """
@@ -706,7 +696,10 @@ class CalculateKPIS:
             self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
         )
 
-        eligible_patients = total_kpi_1_eligible_pts_base_query_set.exclude(
+        eligible_patients = total_kpi_1_eligible_pts_base_query_set.filter(
+            # T1DM
+            diabetes_type=DIABETES_TYPES[0][0],
+        ).exclude(
             # EXCLUDE Date of diagnosis within the audit period
             Q(diagnosis_date__range=(self.AUDIT_DATE_RANGE))
             # EXCLUDE Date of leaving service within the audit period
@@ -798,11 +791,7 @@ class CalculateKPIS:
                 | Q(total_cholesterol_date__range=(self.AUDIT_DATE_RANGE))
                 | Q(thyroid_function_date__range=(self.AUDIT_DATE_RANGE))
                 | Q(coeliac_screen_date__range=(self.AUDIT_DATE_RANGE))
-                | Q(
-                    psychological_screening_assessment_date__range=(
-                        self.AUDIT_DATE_RANGE
-                    )
-                )
+                | Q(psychological_screening_assessment_date__range=(self.AUDIT_DATE_RANGE))
             ),
             patient=OuterRef("pk"),
             visit_date__range=self.AUDIT_DATE_RANGE,
@@ -813,9 +802,7 @@ class CalculateKPIS:
             valid_kpi_6_visits=Exists(valid_visit_subquery)
         )
 
-        eligible_patients = eligible_pts_annotated_kpi_6_visits.filter(
-            valid_kpi_6_visits__gte=1
-        )
+        eligible_patients = eligible_pts_annotated_kpi_6_visits.filter(valid_kpi_6_visits__gte=1)
 
         # Count eligible patients
         total_eligible = eligible_patients.count()
@@ -882,32 +869,12 @@ class CalculateKPIS:
                     # this requires checking for a date in any of the Visit model's
                     # observation fields (found simply by searching for date fields
                     # with the word 'observation' in the field verbose_name)
-                    Q(
-                        visit__height_weight_observation_date__range=(
-                            self.AUDIT_DATE_RANGE
-                        )
-                    )
+                    Q(visit__height_weight_observation_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__hba1c_date__range=(self.AUDIT_DATE_RANGE))
-                    | Q(
-                        visit__blood_pressure_observation_date__range=(
-                            self.AUDIT_DATE_RANGE
-                        )
-                    )
-                    | Q(
-                        visit__foot_examination_observation_date__range=(
-                            self.AUDIT_DATE_RANGE
-                        )
-                    )
-                    | Q(
-                        visit__retinal_screening_observation_date__range=(
-                            self.AUDIT_DATE_RANGE
-                        )
-                    )
-                    | Q(
-                        visit__albumin_creatinine_ratio_date__range=(
-                            self.AUDIT_DATE_RANGE
-                        )
-                    )
+                    | Q(visit__blood_pressure_observation_date__range=(self.AUDIT_DATE_RANGE))
+                    | Q(visit__foot_examination_observation_date__range=(self.AUDIT_DATE_RANGE))
+                    | Q(visit__retinal_screening_observation_date__range=(self.AUDIT_DATE_RANGE))
+                    | Q(visit__albumin_creatinine_ratio_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__total_cholesterol_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__thyroid_function_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__coeliac_screen_date__range=(self.AUDIT_DATE_RANGE))
@@ -1015,11 +982,7 @@ class CalculateKPIS:
 
         eligible_patients = base_eligible_patients.filter(
             # a leaving date in the audit period
-            Q(
-                paediatric_diabetes_units__date_leaving_service__range=(
-                    self.AUDIT_DATE_RANGE
-                )
-            )
+            Q(paediatric_diabetes_units__date_leaving_service__range=(self.AUDIT_DATE_RANGE))
         )
 
         # Count eligible patients
@@ -1069,15 +1032,9 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
         eligible_patients = base_query_set.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
 
         # Count eligible patients
@@ -1121,23 +1078,15 @@ class CalculateKPIS:
         """
         # Define the subquery to find the latest visit where thyroid_treatment_status__in = 2 or 3
         latest_visit_subquery = (
-            Visit.objects.filter(
-                patient=OuterRef("pk"), thyroid_treatment_status__in=[2, 3]
-            )
+            Visit.objects.filter(patient=OuterRef("pk"), thyroid_treatment_status__in=[2, 3])
             .order_by("-visit_date")
             .values("pk")[:1]
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
         eligible_patients = base_query_set.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
 
         # Count eligible patients
@@ -1187,15 +1136,9 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
         eligible_patients = base_query_set.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
 
         # Count eligible patients
@@ -1458,9 +1401,7 @@ class CalculateKPIS:
 
         # Define the subquery to find the latest visit
         latest_visit_subquery = (
-            Visit.objects.filter(patient=OuterRef("pk"))
-            .order_by("-visit_date")
-            .values("pk")[:1]
+            Visit.objects.filter(patient=OuterRef("pk")).order_by("-visit_date").values("pk")[:1]
         )
         # Filter the Patient queryset based on the subquery if treatment_regimen = 5
         passed_patients = eligible_patients.filter(
@@ -1662,11 +1603,7 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1708,11 +1645,7 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1755,11 +1688,7 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(
-                id__in=Subquery(
-                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
-                )
-            )
+            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1815,9 +1744,9 @@ class CalculateKPIS:
         eligible_patients_kpi_24 = total_kpi_1_eligible_pts_base_query_set.filter(
             Q(
                 id__in=Subquery(
-                    Patient.objects.filter(
-                        visit__in=eligible_kpi_24_latest_visit_subquery
-                    ).values("id")
+                    Patient.objects.filter(visit__in=eligible_kpi_24_latest_visit_subquery).values(
+                        "id"
+                    )
                 )
             )
         )
@@ -1878,10 +1807,13 @@ class CalculateKPIS:
         )
 
         # Get quarter dates
-        quarter_end_dates = [quarter[1] for quarter in get_quarters_for_audit_period(
-            audit_start_date=self.audit_start_date,
-            audit_end_date=self.audit_end_date,
-        )]
+        quarter_end_dates = [
+            quarter[1]
+            for quarter in get_quarters_for_audit_period(
+                audit_start_date=self.audit_start_date,
+                audit_end_date=self.audit_end_date,
+            )
+        ]
         # Only up to current quarter
         current_quarter = retrieve_quarter_for_date(date.today())
         quarter_end_dates = quarter_end_dates[:current_quarter]
@@ -1934,11 +1866,7 @@ class CalculateKPIS:
                 "total_passed": total_passed,
                 "total_eligible": total_eligible_kpi_24,
                 "pct": round(
-                    (
-                        (total_passed / total_eligible_kpi_24) * 100
-                        if total_eligible_kpi_24
-                        else 0
-                    ),
+                    ((total_passed / total_eligible_kpi_24) * 100 if total_eligible_kpi_24 else 0),
                     1,
                 ),
             }
@@ -2433,13 +2361,10 @@ class CalculateKPIS:
             ]
         )
 
-        actual_health_checks_overall = (
-            total_health_checks_lt_12yo + total_health_checks_gte_12yo
-        )
+        actual_health_checks_overall = total_health_checks_lt_12yo + total_health_checks_gte_12yo
 
         expected_total_health_checks = (
-            eligible_patients_lt_12yo.count() * 3
-            + eligible_patients_gte_12yo.count() * 6
+            eligible_patients_lt_12yo.count() * 3 + eligible_patients_gte_12yo.count() * 6
         )
 
         # Also set pt querysets to be returned if required
@@ -2977,10 +2902,8 @@ class CalculateKPIS:
                 ),
             )
         )
-        total_passed_query_set = (
-            eligible_pts_annotated_dietician_additional_visits.filter(
-                dietician_additional_valid_visits__gte=1
-            )
+        total_passed_query_set = eligible_pts_annotated_dietician_additional_visits.filter(
+            dietician_additional_valid_visits__gte=1
         )
 
         total_passed = total_passed_query_set.count()
@@ -3020,13 +2943,15 @@ class CalculateKPIS:
 
         # Find patients with at least one entry for Influzena Immunisation
         # Recommended (item 24) within the audit period
-        eligible_pts_annotated_flu_immunisation_recommended_date_visits = eligible_patients.annotate(
-            flu_immunisation_recommended_date_valid_visits=Count(
-                "visit",
-                filter=Q(
-                    visit__visit_date__range=self.AUDIT_DATE_RANGE,
-                    visit__flu_immunisation_recommended_date__range=self.AUDIT_DATE_RANGE,
-                ),
+        eligible_pts_annotated_flu_immunisation_recommended_date_visits = (
+            eligible_patients.annotate(
+                flu_immunisation_recommended_date_valid_visits=Count(
+                    "visit",
+                    filter=Q(
+                        visit__visit_date__range=self.AUDIT_DATE_RANGE,
+                        visit__flu_immunisation_recommended_date__range=self.AUDIT_DATE_RANGE,
+                    ),
+                )
             )
         )
         total_passed_query_set = (
@@ -3129,10 +3054,8 @@ class CalculateKPIS:
                 "visit",
                 # NOTE: relativedelta not supported
                 filter=Q(
-                    visit__coeliac_screen_date__gte=F("diagnosis_date")
-                    - timedelta(days=90),
-                    visit__coeliac_screen_date__lte=F("diagnosis_date")
-                    + timedelta(days=90),
+                    visit__coeliac_screen_date__gte=F("diagnosis_date") - timedelta(days=90),
+                    visit__coeliac_screen_date__lte=F("diagnosis_date") + timedelta(days=90),
                 ),
             )
         )
@@ -3181,10 +3104,8 @@ class CalculateKPIS:
                 "visit",
                 # NOTE: relativedelta not supported
                 filter=Q(
-                    visit__thyroid_function_date__gte=F("diagnosis_date")
-                    - timedelta(days=90),
-                    visit__thyroid_function_date__lte=F("diagnosis_date")
-                    + timedelta(days=90),
+                    visit__thyroid_function_date__gte=F("diagnosis_date") - timedelta(days=90),
+                    visit__thyroid_function_date__lte=F("diagnosis_date") + timedelta(days=90),
                 ),
             )
         )
@@ -3241,13 +3162,9 @@ class CalculateKPIS:
         # Date of Diabetes Diagnosis (item 7)
         valid_visit_subquery = Visit.objects.filter(
             patient=OuterRef("pk"),
-            carbohydrate_counting_level_three_education_date__gte=F(
-                "patient__diagnosis_date"
-            )
+            carbohydrate_counting_level_three_education_date__gte=F("patient__diagnosis_date")
             - timedelta(days=7),
-            carbohydrate_counting_level_three_education_date__lte=F(
-                "patient__diagnosis_date"
-            )
+            carbohydrate_counting_level_three_education_date__lte=F("patient__diagnosis_date")
             + timedelta(days=14),
         )
 
@@ -3299,14 +3216,10 @@ class CalculateKPIS:
         )
         total_ineligible = self.total_patients_count - total_eligible
 
-        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
-            eligible_patients
-        )
+        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(eligible_patients)
 
         # Extract just the median values
-        median_hba1cs = [
-            values["median"] for values in hba1c_values_by_patient.values()
-        ]
+        median_hba1cs = [values["median"] for values in hba1c_values_by_patient.values()]
 
         # Finally calculate the mean of the medians
         mean_of_median_hba1cs = self.calculate_mean(median_hba1cs)
@@ -3359,13 +3272,9 @@ class CalculateKPIS:
         # calculate_median method
         # We're doing this in Python instead of Django ORM because median
         # aggregation gets complicated
-        hba1c_values_by_patient = defaultdict(
-            lambda: {"hb1ac_values": [], "nhs_number": ""}
-        )
+        hba1c_values_by_patient = defaultdict(lambda: {"hb1ac_values": [], "nhs_number": ""})
         for visit in valid_visits:
-            hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(
-                visit["hba1c"]
-            )
+            hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(visit["hba1c"])
             hba1c_values_by_patient[visit["patient__pk"]]["nhs_number"] = visit[
                 "patient__nhs_number"
             ]
@@ -3418,14 +3327,10 @@ class CalculateKPIS:
             hba1c_values_by_patient[visit["patient__pk"]].append(visit["hba1c"])
 
         # For each patient, calculate the median of their HbA1c values
-        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
-            eligible_patients
-        )
+        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(eligible_patients)
 
         # Extract just the median values
-        median_hba1cs = [
-            values["median"] for values in hba1c_values_by_patient.values()
-        ]
+        median_hba1cs = [values["median"] for values in hba1c_values_by_patient.values()]
 
         # Finally calculate the median of the medians
         median_of_median_hba1cs = self.calculate_median(median_hba1cs)
@@ -3470,12 +3375,8 @@ class CalculateKPIS:
         total_ineligible = self.total_patients_count - total_eligible
 
         # Filter eligible patients to just relevant diabetes types
-        eligible_patients_t1dm = eligible_patients.filter(
-            diabetes_type=DIABETES_TYPES[0][0]
-        )
-        eligible_patients_t2dm = eligible_patients.filter(
-            diabetes_type=DIABETES_TYPES[1][0]
-        )
+        eligible_patients_t1dm = eligible_patients.filter(diabetes_type=DIABETES_TYPES[0][0])
+        eligible_patients_t2dm = eligible_patients.filter(diabetes_type=DIABETES_TYPES[1][0])
 
         hba1c_vals = {
             "t1dm": {},
@@ -3491,12 +3392,8 @@ class CalculateKPIS:
                 eligible_patients=eligible_pts,
             ).values("patient__pk", "hba1c")
 
-            hba1c_vals[key]["mean"] = round(
-                self._calculate_mean_hba1cs(valid_visits), 1
-            )
-            hba1c_vals[key]["median"] = round(
-                self._calculate_median_hba1cs(valid_visits), 1
-            )
+            hba1c_vals[key]["mean"] = round(self._calculate_mean_hba1cs(valid_visits), 1)
+            hba1c_vals[key]["median"] = round(self._calculate_median_hba1cs(valid_visits), 1)
 
         return hba1c_vals
 
@@ -3571,9 +3468,7 @@ class CalculateKPIS:
                 | Q(hospital_discharge_date__range=self.AUDIT_DATE_RANGE)
             ),
             # valid reason for admission
-            hospital_admission_reason__in=[
-                choice[0] for choice in HOSPITAL_ADMISSION_REASONS
-            ],
+            hospital_admission_reason__in=[choice[0] for choice in HOSPITAL_ADMISSION_REASONS],
             patient=OuterRef("pk"),
             visit_date__range=self.AUDIT_DATE_RANGE,
         )
@@ -3616,9 +3511,7 @@ class CalculateKPIS:
         valid_visit_with_admission_count = Visit.objects.filter(
             Q(hospital_admission_date__range=self.AUDIT_DATE_RANGE)
             | Q(hospital_discharge_date__range=self.AUDIT_DATE_RANGE),
-            hospital_admission_reason__in=[
-                choice[0] for choice in HOSPITAL_ADMISSION_REASONS
-            ],
+            hospital_admission_reason__in=[choice[0] for choice in HOSPITAL_ADMISSION_REASONS],
             patient__pk=pt_pk,
             visit_date__range=self.AUDIT_DATE_RANGE,
         ).count()
@@ -3967,9 +3860,7 @@ class CalculateKPIS:
             )
 
         # First get new T1DM diagnoses pts
-        base_query_set, _ = (
-            self._get_total_kpi_7_eligible_pts_base_query_set_and_total_count()
-        )
+        base_query_set, _ = self._get_total_kpi_7_eligible_pts_base_query_set_and_total_count()
 
         # Filter for those diagnoses at least 90 days before audit end date
         self.t1dm_pts_diagnosed_90D_before_end_base_query_set = base_query_set.filter(

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -689,7 +689,8 @@ class CalculateKPIS:
         *a valid date of birth
         *a valid PDU number
         * a visit date or admission date within the audit period
-        * Below the age of 25 at the start of the audit period* Diagnosis of Type 1 diabetes
+        * Below the age of 25 at the start of the audit period
+        * Diagnosis of Type 1 diabetes
 
         Excluding
         * Date of diagnosis within the audit period

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -320,14 +320,8 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
     # Visit date before audit period
     ineligible_patient_visit_date: List[Patient] = PatientFactory(
         postcode="ineligible_patient_visit_date",
-        diabetes_type=DIABETES_TYPES[0][0], # T1DM
-        # other eligibilty criteria met
-        # KPI1 eligible
-        visit__visit_date=AUDIT_START_DATE + relativedelta(days=2),
-        date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
-        # Date of diagnosis within the audit period
-        diagnosis_date=AUDIT_START_DATE - relativedelta(days=2),
-        
+        visit__visit_date=AUDIT_START_DATE - relativedelta(days=10),
+         diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
     # Above age 25 at start of audit period
     ineligible_patient_too_old: List[Patient] = PatientFactory(
@@ -339,12 +333,13 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
     # KPI5 specific ineligible patients
     ineligible_patient_diabetes_type_not_t1dm = PatientFactory(
         postcode="ineligible_patient_diabetes_type_not_t1dm",
+        diabetes_type=DIABETES_TYPES[1][0], # T2DM
+        # Other eligibility criteria met
         # KPI1 eligible
         visit__visit_date=AUDIT_START_DATE + relativedelta(days=2),
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of diagnosis within the audit period
-        diagnosis_date=AUDIT_START_DATE + relativedelta(days=2),
-        diabetes_type=DIABETES_TYPES[1][0], # T2DM
+        diagnosis_date=AUDIT_START_DATE - relativedelta(days=2),
     )
     ineligible_patient_diag_within_audit_period = PatientFactory(
         postcode="ineligible_patient_diag_within_audit_period",

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -292,6 +292,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of diagnosis within the audit period
         diagnosis_date=AUDIT_START_DATE - relativedelta(days=2),
+        diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
 
     eligible_patient_date_leaving_NOT_within_audit_period = PatientFactory(
@@ -302,6 +303,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         # Date of leaving service within the audit period
         # transfer date only not None if they have left
         transfer__date_leaving_service=None,
+        diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
 
     eligible_patient_death_NOT_within_audit_period = PatientFactory(
@@ -311,21 +313,39 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of death within the audit period"
         death_date=None,
+        diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
 
-    # Create Patients and Visits that should FAIL KPI1
+    # Create Patients and Visits that should FAIL KPI1 (ineligible)
     # Visit date before audit period
     ineligible_patient_visit_date: List[Patient] = PatientFactory(
         postcode="ineligible_patient_visit_date",
-        visit__visit_date=AUDIT_START_DATE - relativedelta(days=10),
+        diabetes_type=DIABETES_TYPES[0][0], # T1DM
+        # other eligibilty criteria met
+        # KPI1 eligible
+        visit__visit_date=AUDIT_START_DATE + relativedelta(days=2),
+        date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
+        # Date of diagnosis within the audit period
+        diagnosis_date=AUDIT_START_DATE - relativedelta(days=2),
+        
     )
     # Above age 25 at start of audit period
     ineligible_patient_too_old: List[Patient] = PatientFactory(
         postcode="ineligible_patient_too_old",
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 26),
+         diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
 
-    # KPI5 specific
+    # KPI5 specific ineligible patients
+    ineligible_patient_diabetes_type_not_t1dm = PatientFactory(
+        postcode="ineligible_patient_diabetes_type_not_t1dm",
+        # KPI1 eligible
+        visit__visit_date=AUDIT_START_DATE + relativedelta(days=2),
+        date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
+        # Date of diagnosis within the audit period
+        diagnosis_date=AUDIT_START_DATE + relativedelta(days=2),
+        diabetes_type=DIABETES_TYPES[1][0], # T2DM
+    )
     ineligible_patient_diag_within_audit_period = PatientFactory(
         postcode="ineligible_patient_diag_within_audit_period",
         # KPI1 eligible
@@ -333,6 +353,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of diagnosis within the audit period
         diagnosis_date=AUDIT_START_DATE + relativedelta(days=2),
+         diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
     ineligible_patient_date_leaving_within_audit_period = PatientFactory(
         postcode="ineligible_patient_date_leaving_within_audit_period",
@@ -341,6 +362,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of leaving service within the audit period
         transfer__date_leaving_service=AUDIT_START_DATE + relativedelta(days=2),
+         diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
     ineligible_patient_death_within_audit_period = PatientFactory(
         postcode="ineligible_patient_death_within_audit_period",
@@ -349,7 +371,9 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
         # Date of death within the audit period"
         death_date=AUDIT_START_DATE + relativedelta(days=2),
+         diabetes_type=DIABETES_TYPES[0][0], # T1DM
     )
+    
 
     # The default pz_code is "PZ130" for PaediatricsDiabetesUnitFactory
     calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
@@ -358,7 +382,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
     calc_kpis.total_patients_count = Patient.objects.count()
 
     EXPECTED_TOTAL_ELIGIBLE = 3
-    EXPECTED_TOTAL_INELIGIBLE = 5
+    EXPECTED_TOTAL_INELIGIBLE = 6
 
     EXPECTED_KPIRESULT = KPIResult(
         total_eligible=EXPECTED_TOTAL_ELIGIBLE,

--- a/project/npda/tests/kpi_calculations/test_kpis_1_12.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_1_12.py
@@ -272,6 +272,9 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
 
     Essentialy KPI1 but also check
 
+        Inclusions:
+        * Diagnosis of Type 1 diabetes
+
         Excluding
         * Date of diagnosis within the audit period
         * Date of leaving service within the audit period
@@ -310,7 +313,7 @@ def test_kpi_calculation_5(AUDIT_START_DATE):
         death_date=None,
     )
 
-    # Create Patients and Visits that should FAIL KPI3
+    # Create Patients and Visits that should FAIL KPI1
     # Visit date before audit period
     ineligible_patient_visit_date: List[Patient] = PatientFactory(
         postcode="ineligible_patient_visit_date",

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -166,6 +166,8 @@ def test_kpi_calculation_26(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -300,6 +300,8 @@ def test_kpi_calculation_27(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -43,6 +43,8 @@ def test_kpi_calculation_25(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_25_32.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_25_32.py
@@ -932,6 +932,8 @@ def test_kpi_calculation_32_1(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Create Patients < 12 yo
@@ -1119,6 +1121,8 @@ def test_kpi_calculation_32_2(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Create Patients < 12 yo
@@ -1287,6 +1291,8 @@ def test_kpi_calculation_32_3(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Create Patients >= 12 yo

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -707,6 +707,8 @@ def test_kpi_calculation_38(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -42,6 +42,8 @@ def test_kpi_calculation_33(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -833,6 +833,8 @@ def test_kpi_calculation_39(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -201,6 +201,8 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -582,6 +582,8 @@ def test_kpi_calculation_37(AUDIT_START_DATE):
         "transfer__date_leaving_service": None,
         # Date of death NOT within the audit period"
         "death_date": None,
+        # T1DM
+        "diabetes_type": DIABETES_TYPES[0][0],
     }
 
     # Passing patients

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -163,11 +163,9 @@ def dashboard(request):
 
     # Health checks
     # Get attr names for KPIs 32.1, 32.2, 32.3
-    kpi_32_1_attr_name = calculate_kpis.kpi_name_registry.get_attribute_name(321)
     kpi_32_2_attr_name = calculate_kpis.kpi_name_registry.get_attribute_name(322)
     kpi_32_3_attr_name = calculate_kpis.kpi_name_registry.get_attribute_name(323)
     hc_completion_rate_value_counts_pct = hp.get_hc_completion_rate_vcs(
-        kpi_32_1_values=kpi_calculations_object["calculated_kpi_values"][kpi_32_1_attr_name],
         kpi_32_2_values=kpi_calculations_object["calculated_kpi_values"][kpi_32_2_attr_name],
         kpi_32_3_values=kpi_calculations_object["calculated_kpi_values"][kpi_32_3_attr_name],
     )

--- a/project/npda/views/dashboard/helpers.py
+++ b/project/npda/views/dashboard/helpers.py
@@ -92,7 +92,6 @@ def get_care_at_diagnosis_vcs_pct(
 
 
 def get_hc_completion_rate_vcs(
-    kpi_32_1_values: dict,
     kpi_32_2_values: dict,
     kpi_32_3_values: dict,
 ):


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

TL/DR: health check denominators rely on KPI5. This was missing a filter for only patients with T1DM. Adding it back makes numbers line up again

<img width="1115" alt="image" src="https://github.com/user-attachments/assets/e570bf02-b308-49ec-8a75-abd96a48993c" />


### Code changes
- additional filter in `calculate_kpi_5`'s eligible patients for `diabetes_type=` T1DM
- update kpi5 test to additionally have an ineligible patient who's ineligible only because their diabetes type is NOT T1DM
- fix all other broken tests (for other kpis that rely on KPI5) by ensuring their eligible patients have diabetes_type = T1DM


### Related Issues
#671 

and @mbarton possibly #617 ?


