### PR TITLE
[Dashboard error fix] Adds missing url

### DIFF
--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -137,6 +137,11 @@ dashboard_urlpatterns = [
         name="get_simple_bar_chart_pcts_partial",
     ),
     path(
+        "get_simple_bar_chart_absolutes_partial",
+        view=partials.get_simple_bar_chart_absolutes_partial,
+        name="get_simple_bar_chart_absolutes_partial",
+    ),
+    path(
         "get_hcl_scatter_plot",
         view=partials.get_hcl_scatter_plot,
         name="get_hcl_scatter_plot",


### PR DESCRIPTION
### Overview
 
adds back missing url to dashboard, must have accidentally removed in #676 

