### PR TITLE
Speculative fix for missing add patient button

### DIFF
--- a/project/npda/templates/partials/page_elements/patient_table_actions.html
+++ b/project/npda/templates/partials/page_elements/patient_table_actions.html
@@ -34,7 +34,7 @@
             </button>
         </label>
     </label>
-    {% if user.view_preference == 1 %}
+    {% if user.view_preference != 2 %}
         {% if can_complete_questionnaire %}
             <a href="{% url 'patient-add' %}"
                 class="btn btn-info h-auto w-full md:w-auto {% if not can_alter_this_audit_year_submission %} btn-disabled {% endif %}">


### PR DESCRIPTION
Speculative fix for #687. I can't reproduce the issue but the only way it could be happening is if the `view_preference` is an unexpected value. So change the comparison to hopefully handle that, by hiding the UI if the view preference is national rather than only showing it if it's trust (in reality PDU).