### PR TITLE
dietician_additional_appointment_date

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1010,26 +1010,6 @@ class VisitForm(forms.ModelForm):
                     }
                 )
 
-        dietician_additional_appointment_offered = cleaned_data.get(
-            "dietician_additional_appointment_offered"
-        )
-        dietician_additional_appointment_date = cleaned_data.get(
-            "dietician_additional_appointment_date"
-        )
-
-        if dietician_additional_appointment_date is not None and (
-            dietician_additional_appointment_offered is None
-            or dietician_additional_appointment_offered == 2
-            or dietician_additional_appointment_offered == 3
-        ):  # No or Unknown
-            raise ValidationError(
-                {
-                    "dietician_additional_appointment_date": [
-                        "'Was the patient offered an additional appointment with a paediatric dietitian?' must be completed if 'Date of additional appointment with dietitian' is filled in"
-                    ]
-                }
-            )
-
         hospital_admission_date = cleaned_data.get("hospital_admission_date")
         hospital_discharge_date = cleaned_data.get("hospital_discharge_date")
         hospital_admission_reason = cleaned_data.get("hospital_admission_reason")

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1010,6 +1010,24 @@ class VisitForm(forms.ModelForm):
                     }
                 )
 
+        dietician_additional_appointment_offered = cleaned_data.get(
+            "dietician_additional_appointment_offered"
+        )
+        dietician_additional_appointment_date = cleaned_data.get(
+            "dietician_additional_appointment_date"
+        )
+
+        if dietician_additional_appointment_date is not None and (
+            dietician_additional_appointment_offered == 2
+        ):  # No
+            raise ValidationError(
+                {
+                    "dietician_additional_appointment_date": [
+                        "Answer to 'Was the patient offered an additional appointment with a paediatric dietitian?' cannot be No if 'Date of additional appointment with dietitian' is filled in"
+                    ]
+                }
+            )
+
         hospital_admission_date = cleaned_data.get("hospital_admission_date")
         hospital_discharge_date = cleaned_data.get("hospital_discharge_date")
         hospital_admission_reason = cleaned_data.get("hospital_admission_reason")

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -1472,16 +1472,16 @@ def test_dietician_additional_offered_date_missing_passes_validation():
 
 
 @pytest.mark.django_db
-def test_dietician_additional_offered_none_but_date_offered_fail_validation():
+def test_dietician_additional_offered_no_but_date_offered_fail_validation():
     """
-    Test that dietician additional appointment none but date offered should fail
+    Test that dietician additional appointment No but date offered should fail
     """
 
     patient = PatientFactory()
 
     form = VisitForm(
         data={
-            "dietician_additional_appointment_offered": None,  # None
+            "dietician_additional_appointment_offered": 2,  # No
             "dietician_additional_appointment_date": "2025-01-01",
             "carbohydrate_counting_level_three_education_date": "2025-01-01",
         },
@@ -1491,7 +1491,7 @@ def test_dietician_additional_offered_none_but_date_offered_fail_validation():
     # Trigger the cleaners
     assert (
         form.is_valid() == False
-    ), f"Dietician additional appointment none but date offered should fail"
+    ), f"Dietician additional appointment No but date offered should fail"
     assert "dietician_additional_appointment_date" in form.errors
 
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -2454,16 +2454,16 @@ def test_dietician_additional_offered_date_missing_passes_validation(
 
 
 @pytest.mark.django_db
-def test_dietician_additional_offered_none_but_date_offered_fail_validation(
+def test_dietician_additional_offered_no_but_date_offered_fail_validation(
     test_user, single_row_valid_df
 ):
     """
-    Test that dietician additional appointment none but date offered should fail
+    Test that dietician additional appointment answered No but date offered should fail
     """
     single_row_valid_df.loc[
         0,
         "Was the patient offered an additional appointment with a paediatric dietitian?",
-    ] = None
+    ] = 2
     single_row_valid_df.loc[0, "Date of additional appointment with dietitian"] = (
         "01/01/2022"
     )
@@ -2474,7 +2474,7 @@ def test_dietician_additional_offered_none_but_date_offered_fail_validation(
 
     visit = Visit.objects.first()
 
-    assert visit.dietician_additional_appointment_offered is None
+    assert visit.dietician_additional_appointment_offered == 2
     assert visit.dietician_additional_appointment_date == datetime.date(2022, 1, 1)
 
 


### PR DESCRIPTION
### Overview

fixes #703

`dietician_additional_appointment_date` and `dietician_additional_appointment_date_offered` are not required together - it is possible to have an appointment with the offered field being empty and vice versa

If `dietician_additional_appointment_date_offered` is answered No, but `dietician_additional_appointment_date` is provided, validation will fail. This is the only validation now that is retained
