### PR TITLE
Try to workaround lack of Celery support for Redis cluster

### DIFF
--- a/project/celery.py
+++ b/project/celery.py
@@ -16,6 +16,18 @@ app = Celery("project")
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
+app.conf.update(
+    # Hacks to work around the lack of built in support for Redis cluster.
+    # We don't use a cluster directly but Azure Managed Redis acts like one.
+    # https://github.com/celery/celery/issues/8276#issuecomment-2082176893
+    broker_transport_options={
+        "global_keyprefix": "{queue}:"
+    },
+    result_backend_transport_options={
+        "global_keyprefix": "{rest}:"
+    }
+)
+
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 class NPDATask(Task):

--- a/project/settings.py
+++ b/project/settings.py
@@ -356,7 +356,4 @@ redis_params = f"?ssl_cert_reqs=required" if REDIS_USE_SSL else ""
 
 CELERY_BROKER_URL = f"{redis_protocol}://{redis_auth}{REDIS_HOSTNAME}:{REDIS_PORT}/{REDIS_DATABASE_NUMBER}{redis_params}"
 
-# Temporary debugging until it works in Azure
-print(f"!! CELERY_BROKER_URL={CELERY_BROKER_URL.replace(REDIS_PASSWORD, "*") if REDIS_PASSWORD else CELERY_BROKER_URL}")
-
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL


### PR DESCRIPTION
Celery doesn't support Redis cluster directly. You get a very opaque `CROSSSLOT` error: https://github.com/celery/celery/issues/9436. Azure Managed Redis acts like a cluster, so we're getting that error too.

In fairness this is described in the documentation: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/managed-redis/managed-redis-architecture#multi-key-commands.

There is a suggestion on the Celery GitHub that you can workaround this problem with some config: https://github.com/celery/celery/issues/8276#issuecomment-2082176893. I'm a little scared about whether the hack will survive internal Redis Cluster leadership elections in Azure Managed Redis but hopefully this at least gets it working to unblock further work on #650 