### PR TITLE
truncated-tooltips

### DIFF
--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -5,7 +5,7 @@
   <div class="flex justify-center bg-white py-8">
     <div class="max-w-full lg:max-w-[75%] px-2 bg-white font-montserrat">
       <strong>
-        {{ title }} - {% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %}
+        {{ title }} - NPDA ID {{ patient.pk }} ({% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %}) at {{ paediatric_diabetes_unit.lead_organisation_name }} ({{ paediatric_diabetes_unit.pz_code }})
       </strong>
       <form id="update-form"
             method="post"

--- a/project/npda/templates/partials/page_elements/patient_table_page_controls.html
+++ b/project/npda/templates/partials/page_elements/patient_table_page_controls.html
@@ -3,7 +3,7 @@
         <span class="tooltip tooltip-bottom"
               data-tip="All patients in this submission for April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}. Note this includes patients who have been discharged or transferred out of the unit in the audit year and those that have no visits.">
             <strong>
-            {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ paginator.count }} patients in audit year April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}</strong>
+            {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ paginator.count }} patients in audit year April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }} at {{ pdu.lead_organisation_name }} ({{ pdu.pz_code }})</strong>
             <i class="fa-solid fa-info-circle"></i>
         </span>
     </th>

--- a/project/npda/templates/visits.html
+++ b/project/npda/templates/visits.html
@@ -6,7 +6,7 @@
     <div class="overflow-x-auto">
       <div class="min-w-full inline-block px-10 py-2">
         <div class="w-full overflow-x-auto relative">
-          <strong>All Visits (April {{ submission.audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}) for {% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %} (NPDA ID-{{ patient.pk }})</strong>
+          <strong>All {{ paediatric_diabetes_unit.lead_organisation_name }} ({{ paediatric_diabetes_unit.pz_code }}) Visits (April {{ submission.audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}) for {% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %} (NPDA ID-{{ patient.pk }})</strong>
           {% if visits %}
             <table class="font-montserrat table-md w-full table mb-5 text-sm text-left text-gray-400 text-gray-500 rtl:text-right">
               <thead class="bg-rcpch_dark_blue text-xs text-white text-gray-700 uppercase bg-gray-50">

--- a/project/npda/templates/visits.html
+++ b/project/npda/templates/visits.html
@@ -30,8 +30,10 @@
                           {% if item.present %}
                             <span class="bg-{{ item.colour }} px-1 py-0.25 mx-1 my-1 text-sm font-semibold text-white">
                               <small>
-                                <div class="tooltip tooltip-top visible text-center text-white hover:text-white"
-                                     {% if item.errors %} data-tip='{{ item.errors.values|flatten|join:", " }}' {% endif %}>
+                                <div class="tooltip tooltip-bottom visible text-center text-white hover:text-white"
+                                     {% if item.errors %} data-tip='{% for error in item.errors.values|flatten %}{{ error|safe }}{% endfor %}
+                                     '
+                                     {% endif %}>
                                   {% if item.errors %}
                                     <span class="fa-stack text-rcpch_red">
                                       <i class="fa-circle fa-stack-1x fas"></i>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -1,9 +1,12 @@
-import re
+from datetime import date
 import itertools
 import logging
+import re
 
 from django import template, forms
 from django.conf import settings
+from django.contrib.gis.measure import D
+from django.utils.html import conditional_escape, mark_safe
 
 from ...constants import (
     # VisitCategories,
@@ -11,9 +14,6 @@ from ...constants import (
     UNIQUE_IDENTIFIER_ENGLAND,
     UNIQUE_IDENTIFIER_JERSEY,
 )
-
-from django.contrib.gis.measure import D
-from datetime import date
 
 
 register = template.Library()
@@ -128,13 +128,11 @@ def error_for_field(errors_by_field, field):
     if errors_by_field is None:
         return ""
 
-    concatenated_fields = ""
-
     errors = errors_by_field[field] if field in errors_by_field else []
 
-    error_messages = [error["message"] for error in errors]
+    error_messages = [conditional_escape(error["message"]) for error in errors]
 
-    return "\n".join(error_messages)
+    return mark_safe("\n".join(error_messages))
 
 
 @register.simple_tag
@@ -211,14 +209,6 @@ def docs_url():
 
 
 @register.filter
-def format_nhs_number(nhs_number):
-    if nhs_number and len(nhs_number) >= 10:
-        return f"{nhs_number[:3]} {nhs_number[3:6]} {nhs_number[6:]}"
-
-    return nhs_number
-
-
-@register.filter
 def get_key_where_true(dictionary: dict) -> str:
     """Get the first key where the value is True.
 
@@ -270,10 +260,9 @@ def nhs_number_vs_urn(pz_code, patient=None):
         # Jersey
         return "Unique Reference Number"
     else:
+        print(patient)
         if patient and patient.nhs_number:
-            if len(patient.nhs_number) >= 10:
-                return f"{patient.nhs_number[:3]} {patient.nhs_number[3:6]} {patient.nhs_number[6:]}"
-            return patient.nhs_number
+            return f"{patient.nhs_number[:3]} {patient.nhs_number[3:6]} {patient.nhs_number[6:]}"
         return "NHS Number"
 
 

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -260,7 +260,6 @@ def nhs_number_vs_urn(pz_code, patient=None):
         # Jersey
         return "Unique Reference Number"
     else:
-        print(patient)
         if patient and patient.nhs_number:
             return f"{patient.nhs_number[:3]} {patient.nhs_number[3:6]} {patient.nhs_number[6:]}"
         return "NHS Number"

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -84,7 +84,9 @@ class PatientVisitsListView(
         context["submission"] = submission
 
         # If the patient has left the PDU, they may appear in another one but we record that as a separate Patient instance
-        pdu = Transfer.objects.get(patient=patient).paediatric_diabetes_unit
+        paediatric_diabetes_unit = Transfer.objects.get(
+            patient=patient
+        ).paediatric_diabetes_unit
 
         calculate_kpis = CalculateKPIS(
             calculation_date=datetime.date.today(), return_pt_querysets=False
@@ -93,10 +95,11 @@ class PatientVisitsListView(
         # for a single patient's calculation
         kpi_calculations_object = calculate_kpis.calculate_kpis_for_single_patient(
             patient,
-            pdu,
+            paediatric_diabetes_unit,
         )
 
         context["kpi_calculations_object"] = kpi_calculations_object
+        context["paediatric_diabetes_unit"] = paediatric_diabetes_unit
 
         return context
 
@@ -123,6 +126,9 @@ class VisitCreateView(
         context["form_method"] = "create"
         context["button_title"] = "Add"
         context["visit_tabs"] = get_visit_tabs(form=None)
+        Transfer = apps.get_model("npda", "Transfer")
+        transfer = Transfer.objects.get(patient=patient, date_leaving_service=None)
+        context["paediatric_diabetes_unit"] = transfer.paediatric_diabetes_unit
         return context
 
     def get_success_url(self):
@@ -173,6 +179,13 @@ class VisitUpdateView(
         context["button_title"] = "Save"
         context["form_method"] = "update"
         context["visit_tabs"] = get_visit_tabs(form=context["form"])
+        visit = Visit.objects.get(pk=self.kwargs["pk"])
+        Transfer = apps.get_model("npda", "Transfer")
+        transfer = Transfer.objects.get(
+            patient=visit.patient, date_leaving_service=None
+        )
+        context["paediatric_diabetes_unit"] = transfer.paediatric_diabetes_unit
+        context["patient"] = visit.patient
 
         return context
 
@@ -191,7 +204,6 @@ class VisitUpdateView(
         return initial
 
     def form_valid(self, form: BaseModelForm) -> HttpResponse:
-        print("form_valid is called int he view")
         if "delete" in self.request.POST:
             return redirect(reverse("visit-delete", kwargs={"pk": self.kwargs["pk"]}))
         visit = form.save(commit=True)


### PR DESCRIPTION
### Overview

This PR makes safe all tool tips so that any html codes for quotes etc are rendered as intended. There was a tendancy in the lists for tooltips to be truncated at the top of the list and by making them show below this problem is overcome.

In the process I realized as a superuser it is not clear which organisation's patients you are looking at so I have added the PDU lead organisation name and PZ code to all headers of all tables and all forms