### PR TITLE
Fix div by zero error for patients with zero weight or height

### DIFF
--- a/project/npda/forms/external_visit_validators.py
+++ b/project/npda/forms/external_visit_validators.py
@@ -35,7 +35,7 @@ class VisitExternalValidationResult:
 async def _calculate_centiles_z_scores(
     birth_date: date, observation_date: date, sex: int, measurement_method: str, observation_value: Decimal | None, async_client: AsyncClient
 ) -> CentileAndSDS | None:
-    if observation_value is None:
+    if observation_value is None or observation_value <= 0:
         return None
 
     try:
@@ -87,7 +87,22 @@ async def validate_visit_async(
 
     bmi = None
 
-    if height is not None and weight is not None:
+    valid_height = height is not None
+    valid_weight = weight is not None
+
+    if valid_height and height <= 0:
+        logger.warning(
+            "Height is <=0. Cannot calculate centiles and z-scores."
+        )
+        valid_height = False
+    
+    if valid_weight and weight <= 0:
+        logger.warning(
+            "Weight is <=0. Cannot calculate centiles and z-scores."
+        )
+        valid_weight = False
+
+    if valid_height and valid_weight:
         bmi = calculate_bmi(height, weight)
         ret.bmi = bmi
 

--- a/project/npda/tests/form_tests/test_external_visit_validators.py
+++ b/project/npda/tests/form_tests/test_external_visit_validators.py
@@ -98,6 +98,74 @@ async def test_missing_weight():
         assert(mock.call_count == 1)
 
 
+async def test_zero_height():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"height": 0})
+        )
+
+        assert(result.height_result is None)
+
+        assert(result.weight_result.centile == 1)
+        assert(result.weight_result.sds == 2)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
+async def test_zero_weight():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"weight": 0})
+        )
+
+        assert(result.height_result.centile == 1)
+        assert(result.height_result.sds == 2)
+
+        assert(result.weight_result is None)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
+async def test_negative_height():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"height": -2})
+        )
+
+        assert(result.height_result is None)
+
+        assert(result.weight_result.centile == 1)
+        assert(result.weight_result.sds == 2)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
+async def test_negative_weight():
+    with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))) as mock:
+        result = await validate_visit_async(
+            **(VALID_FIELDS | {"weight": -2})
+        )
+
+        assert(result.height_result.centile == 1)
+        assert(result.height_result.sds == 2)
+
+        assert(result.weight_result is None)
+
+        assert(result.bmi is None)
+        assert(result.bmi_result is None)
+
+        assert(mock.call_count == 1)
+
+
 async def test_invalid_bmi():
     with patch("project.npda.forms.external_visit_validators.calculate_centiles_z_scores", AsyncMock(return_value=(1,2))):
         with patch("project.npda.forms.external_visit_validators.calculate_bmi", Mock(return_value=None)):


### PR DESCRIPTION
Another day another data quality bug! A patient explicitly had `0` as their height in the Luton CSV.

Fixes #738 