### PR TITLE
Fix crash when NHS number column missing

### DIFF
--- a/project/constants/csv_headings.py
+++ b/project/constants/csv_headings.py
@@ -268,8 +268,6 @@ CSV_HEADING_OBJECTS = (
     },
 )
 
-# HEADINGS_LIST = [item["heading"] for item in CSV_HEADINGS]
-
 ALL_DATES = [
     "Date of Birth",
     "Date of Diabetes Diagnosis",

--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -152,6 +152,8 @@ def csv_parse(csv_file, is_jersey=False):
 
     # Rows where the unique identifier is missing will be removed - count the number of rows before and after: placed here to ensure all columns have been processed
     total_row_count = df.shape[0]
+    discrepancy = 0
+
     if is_jersey:
         unique_reference_number_nonnull_row_count = df[
             "Unique Reference Number"
@@ -161,13 +163,14 @@ def csv_parse(csv_file, is_jersey=False):
                 "No Unique Reference Numbers found in the file. Please ensure all rows have a unique identifier and upload the file again."
             )
         discrepancy = total_row_count - unique_reference_number_nonnull_row_count
-    else:
+    elif "NHS Number" in df.columns:
         nhs_number_nonnull_row_count = df["NHS Number"].count()
         if nhs_number_nonnull_row_count == 0:
             raise ValueError(
                 "No NHS Numbers found in the file. Please ensure all rows have a unique identifier and upload the file again."
             )
         discrepancy = total_row_count - nhs_number_nonnull_row_count
+    
     if discrepancy > 0:
         if discrepancy == 1:
             raise ValueError(

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -862,6 +862,15 @@ def test_mixed_case_column_headers(test_user, dummy_sheet_csv):
 
 
 @pytest.mark.django_db
+def test_invalid_nhs_number_column_name(test_user, dummy_sheet_csv):
+    csv = dummy_sheet_csv.replace("NHS Number", "NHSNumberXYZWoo")
+    results = read_csv_from_str(csv)
+
+    assert results.missing_columns == ["NHS Number"]
+    assert results.additional_columns == ["NHSNumberXYZWoo"]
+
+
+@pytest.mark.django_db
 def test_first_row_with_extra_cell_at_the_start(test_user, single_row_valid_df):
     csv = single_row_valid_df.to_csv(index=False, date_format="%d/%m/%Y")
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -846,11 +846,12 @@ def test_case_insensitive_column_headers(test_user, dummy_sheet_csv):
     lines[0] = lines[0].lower()
     csv = "\n".join(lines)
 
-    df = read_csv_from_str(csv).df
+    parsed_csv = read_csv_from_str(csv)
+    assert len(parsed_csv.additional_columns) == 0
 
-    errors = csv_upload_sync(test_user, df)
+    errors = csv_upload_sync(test_user, parsed_csv.df)
 
-    assert len(errors) == 0  #
+    assert len(errors) == 0
 
 
 @pytest.mark.django_db
@@ -868,6 +869,16 @@ def test_invalid_nhs_number_column_name(test_user, dummy_sheet_csv):
 
     assert results.missing_columns == ["NHS Number"]
     assert results.additional_columns == ["NHSNumberXYZWoo"]
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/741
+@pytest.mark.django_db
+def test_invalid_date_of_birth_column_name_with_mixed_case_column_headers(test_user, dummy_sheet_csv):
+    csv = dummy_sheet_csv.replace("Date of Birth", "DOB").replace("HbA1c result format", "HB1AC Result Format")
+    results = read_csv_from_str(csv)
+
+    assert results.missing_columns == ["Date of Birth"]
+    assert results.additional_columns == ["DOB"]
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -874,7 +874,7 @@ def test_invalid_nhs_number_column_name(test_user, dummy_sheet_csv):
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/741
 @pytest.mark.django_db
 def test_invalid_date_of_birth_column_name_with_mixed_case_column_headers(test_user, dummy_sheet_csv):
-    csv = dummy_sheet_csv.replace("Date of Birth", "DOB").replace("HbA1c result format", "HB1AC Result Format")
+    csv = dummy_sheet_csv.replace("Date of Birth", "DOB").replace("HbA1c result format", "HBA1C Result Format")
     results = read_csv_from_str(csv)
 
     assert results.missing_columns == ["Date of Birth"]


### PR DESCRIPTION
In #741 the user was using an old template where the `NHS Number` column was `NHSNumber` instead. This led to a crash, now fixed.

I wrote a few more unit tests while I was trying to understand the problem so have committed them here too. 