### PR TITLE
crashing-all-patients-if-no-values

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -36,7 +36,11 @@ from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REAS
 from project.constants.leave_pdu_reasons import LEAVE_PDU_REASONS
 from project.constants.retinal_screening_results import RETINAL_SCREENING_RESULTS
 from project.constants.smoking_status import SMOKING_STATUS
-from project.constants.types.kpi_types import KPICalculationsObject, KPIResult, kpi_registry
+from project.constants.types.kpi_types import (
+    KPICalculationsObject,
+    KPIResult,
+    kpi_registry,
+)
 from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 from project.npda.general_functions import get_audit_period_for_date
 from project.npda.general_functions.audit_period import get_quarters_for_audit_period
@@ -85,9 +89,13 @@ class CalculateKPIS:
         """
 
         # Set various attributes used in calculations
-        self.calculation_date = calculation_date if calculation_date is not None else date.today()
+        self.calculation_date = (
+            calculation_date if calculation_date is not None else date.today()
+        )
         # Set the start and end audit dates
-        self.audit_start_date, self.audit_end_date = self._get_audit_start_and_end_dates()
+        self.audit_start_date, self.audit_end_date = (
+            self._get_audit_start_and_end_dates()
+        )
         self.AUDIT_DATE_RANGE = (self.audit_start_date, self.audit_end_date)
 
         # Set the return_pt_querysets attribute
@@ -226,8 +234,8 @@ class CalculateKPIS:
                 kpi_number = 320 + int(name_split[2])
 
             # Assign the KPI label
-            return_obj["calculated_kpi_values"][kpi_name]["kpi_label"] = self._get_kpi_label(
-                kpi_number
+            return_obj["calculated_kpi_values"][kpi_name]["kpi_label"] = (
+                self._get_kpi_label(kpi_number)
             )
 
         return return_obj
@@ -240,7 +248,9 @@ class CalculateKPIS:
 
         return kpi_registry.get_rendered_label(kpi_number)
 
-    def _run_kpi_calculation_method(self, kpi_method_name: str) -> Union[KPIResult | str]:
+    def _run_kpi_calculation_method(
+        self, kpi_method_name: str
+    ) -> Union[KPIResult | str]:
         """Will find and run kpi calculation method
         (name schema is calculation_KPI_NAME_MAP_VALUE)
         """
@@ -666,7 +676,11 @@ class CalculateKPIS:
                 | Q(total_cholesterol_date__range=(self.AUDIT_DATE_RANGE))
                 | Q(thyroid_function_date__range=(self.AUDIT_DATE_RANGE))
                 | Q(coeliac_screen_date__range=(self.AUDIT_DATE_RANGE))
-                | Q(psychological_screening_assessment_date__range=(self.AUDIT_DATE_RANGE))
+                | Q(
+                    psychological_screening_assessment_date__range=(
+                        self.AUDIT_DATE_RANGE
+                    )
+                )
             ),
             patient=OuterRef("pk"),
             visit_date__range=self.AUDIT_DATE_RANGE,
@@ -677,7 +691,9 @@ class CalculateKPIS:
             valid_kpi_6_visits=Exists(valid_visit_subquery)
         )
 
-        eligible_patients = eligible_pts_annotated_kpi_6_visits.filter(valid_kpi_6_visits__gte=1)
+        eligible_patients = eligible_pts_annotated_kpi_6_visits.filter(
+            valid_kpi_6_visits__gte=1
+        )
 
         # Count eligible patients
         total_eligible = eligible_patients.count()
@@ -744,12 +760,32 @@ class CalculateKPIS:
                     # this requires checking for a date in any of the Visit model's
                     # observation fields (found simply by searching for date fields
                     # with the word 'observation' in the field verbose_name)
-                    Q(visit__height_weight_observation_date__range=(self.AUDIT_DATE_RANGE))
+                    Q(
+                        visit__height_weight_observation_date__range=(
+                            self.AUDIT_DATE_RANGE
+                        )
+                    )
                     | Q(visit__hba1c_date__range=(self.AUDIT_DATE_RANGE))
-                    | Q(visit__blood_pressure_observation_date__range=(self.AUDIT_DATE_RANGE))
-                    | Q(visit__foot_examination_observation_date__range=(self.AUDIT_DATE_RANGE))
-                    | Q(visit__retinal_screening_observation_date__range=(self.AUDIT_DATE_RANGE))
-                    | Q(visit__albumin_creatinine_ratio_date__range=(self.AUDIT_DATE_RANGE))
+                    | Q(
+                        visit__blood_pressure_observation_date__range=(
+                            self.AUDIT_DATE_RANGE
+                        )
+                    )
+                    | Q(
+                        visit__foot_examination_observation_date__range=(
+                            self.AUDIT_DATE_RANGE
+                        )
+                    )
+                    | Q(
+                        visit__retinal_screening_observation_date__range=(
+                            self.AUDIT_DATE_RANGE
+                        )
+                    )
+                    | Q(
+                        visit__albumin_creatinine_ratio_date__range=(
+                            self.AUDIT_DATE_RANGE
+                        )
+                    )
                     | Q(visit__total_cholesterol_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__thyroid_function_date__range=(self.AUDIT_DATE_RANGE))
                     | Q(visit__coeliac_screen_date__range=(self.AUDIT_DATE_RANGE))
@@ -857,7 +893,11 @@ class CalculateKPIS:
 
         eligible_patients = base_eligible_patients.filter(
             # a leaving date in the audit period
-            Q(paediatric_diabetes_units__date_leaving_service__range=(self.AUDIT_DATE_RANGE))
+            Q(
+                paediatric_diabetes_units__date_leaving_service__range=(
+                    self.AUDIT_DATE_RANGE
+                )
+            )
         )
 
         # Count eligible patients
@@ -908,7 +948,11 @@ class CalculateKPIS:
                     current_month_end,
                 )
             ),
-            Q(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[0][0]),
+            Q(
+                paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[0][
+                    0
+                ]
+            ),
         )
 
         return eligible_patients.count()
@@ -934,7 +978,11 @@ class CalculateKPIS:
                     current_month_end,
                 )
             ),
-            Q(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[1][0]),
+            Q(
+                paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[1][
+                    0
+                ]
+            ),
         )
 
         return eligible_patients.count()
@@ -945,7 +993,11 @@ class CalculateKPIS:
         """
         if not hasattr(self, "kpi_9_eligible_pts_base_query_set"):
             self.kpi_9_eligible_pts_base_query_set = self.patients.filter(
-                Q(paediatric_diabetes_units__date_leaving_service__range=(self.AUDIT_DATE_RANGE))
+                Q(
+                    paediatric_diabetes_units__date_leaving_service__range=(
+                        self.AUDIT_DATE_RANGE
+                    )
+                )
             )
         return self.kpi_9_eligible_pts_base_query_set
 
@@ -969,9 +1021,15 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        base_query_set, _ = (
+            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        )
         eligible_patients = base_query_set.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
 
         # Count eligible patients
@@ -1015,15 +1073,23 @@ class CalculateKPIS:
         """
         # Define the subquery to find the latest visit where thyroid_treatment_status__in = 2 or 3
         latest_visit_subquery = (
-            Visit.objects.filter(patient=OuterRef("pk"), thyroid_treatment_status__in=[2, 3])
+            Visit.objects.filter(
+                patient=OuterRef("pk"), thyroid_treatment_status__in=[2, 3]
+            )
             .order_by("-visit_date")
             .values("pk")[:1]
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        base_query_set, _ = (
+            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        )
         eligible_patients = base_query_set.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
 
         # Count eligible patients
@@ -1073,9 +1139,15 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        base_query_set, _ = (
+            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        )
         eligible_patients = base_query_set.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
 
         # Count eligible patients
@@ -1338,7 +1410,9 @@ class CalculateKPIS:
 
         # Define the subquery to find the latest visit
         latest_visit_subquery = (
-            Visit.objects.filter(patient=OuterRef("pk")).order_by("-visit_date").values("pk")[:1]
+            Visit.objects.filter(patient=OuterRef("pk"))
+            .order_by("-visit_date")
+            .values("pk")[:1]
         )
         # Filter the Patient queryset based on the subquery if treatment_regimen = 5
         passed_patients = eligible_patients.filter(
@@ -1540,7 +1614,11 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1582,7 +1660,11 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1625,7 +1707,11 @@ class CalculateKPIS:
         )
         # Filter the Patient queryset based on the subquery
         passed_patients = eligible_patients.filter(
-            Q(id__in=Subquery(Patient.objects.filter(visit__in=latest_visit_subquery).values("id")))
+            Q(
+                id__in=Subquery(
+                    Patient.objects.filter(visit__in=latest_visit_subquery).values("id")
+                )
+            )
         )
         total_passed = passed_patients.count()
         total_failed = total_eligible - total_passed
@@ -1681,9 +1767,9 @@ class CalculateKPIS:
         eligible_patients_kpi_24 = total_kpi_1_eligible_pts_base_query_set.filter(
             Q(
                 id__in=Subquery(
-                    Patient.objects.filter(visit__in=eligible_kpi_24_latest_visit_subquery).values(
-                        "id"
-                    )
+                    Patient.objects.filter(
+                        visit__in=eligible_kpi_24_latest_visit_subquery
+                    ).values("id")
                 )
             )
         )
@@ -1803,7 +1889,11 @@ class CalculateKPIS:
                 "total_passed": total_passed,
                 "total_eligible": total_eligible_kpi_24,
                 "pct": round(
-                    ((total_passed / total_eligible_kpi_24) * 100 if total_eligible_kpi_24 else 0),
+                    (
+                        (total_passed / total_eligible_kpi_24) * 100
+                        if total_eligible_kpi_24
+                        else 0
+                    ),
                     1,
                 ),
             }
@@ -2298,10 +2388,13 @@ class CalculateKPIS:
             ]
         )
 
-        actual_health_checks_overall = total_health_checks_lt_12yo + total_health_checks_gte_12yo
+        actual_health_checks_overall = (
+            total_health_checks_lt_12yo + total_health_checks_gte_12yo
+        )
 
         expected_total_health_checks = (
-            eligible_patients_lt_12yo.count() * 3 + eligible_patients_gte_12yo.count() * 6
+            eligible_patients_lt_12yo.count() * 3
+            + eligible_patients_gte_12yo.count() * 6
         )
 
         # Also set pt querysets to be returned if required
@@ -2839,8 +2932,10 @@ class CalculateKPIS:
                 ),
             )
         )
-        total_passed_query_set = eligible_pts_annotated_dietician_additional_visits.filter(
-            dietician_additional_valid_visits__gte=1
+        total_passed_query_set = (
+            eligible_pts_annotated_dietician_additional_visits.filter(
+                dietician_additional_valid_visits__gte=1
+            )
         )
 
         total_passed = total_passed_query_set.count()
@@ -2880,15 +2975,13 @@ class CalculateKPIS:
 
         # Find patients with at least one entry for Influzena Immunisation
         # Recommended (item 24) within the audit period
-        eligible_pts_annotated_flu_immunisation_recommended_date_visits = (
-            eligible_patients.annotate(
-                flu_immunisation_recommended_date_valid_visits=Count(
-                    "visit",
-                    filter=Q(
-                        visit__visit_date__range=self.AUDIT_DATE_RANGE,
-                        visit__flu_immunisation_recommended_date__range=self.AUDIT_DATE_RANGE,
-                    ),
-                )
+        eligible_pts_annotated_flu_immunisation_recommended_date_visits = eligible_patients.annotate(
+            flu_immunisation_recommended_date_valid_visits=Count(
+                "visit",
+                filter=Q(
+                    visit__visit_date__range=self.AUDIT_DATE_RANGE,
+                    visit__flu_immunisation_recommended_date__range=self.AUDIT_DATE_RANGE,
+                ),
             )
         )
         total_passed_query_set = (
@@ -2991,8 +3084,10 @@ class CalculateKPIS:
                 "visit",
                 # NOTE: relativedelta not supported
                 filter=Q(
-                    visit__coeliac_screen_date__gte=F("diagnosis_date") - timedelta(days=90),
-                    visit__coeliac_screen_date__lte=F("diagnosis_date") + timedelta(days=90),
+                    visit__coeliac_screen_date__gte=F("diagnosis_date")
+                    - timedelta(days=90),
+                    visit__coeliac_screen_date__lte=F("diagnosis_date")
+                    + timedelta(days=90),
                 ),
             )
         )
@@ -3041,8 +3136,10 @@ class CalculateKPIS:
                 "visit",
                 # NOTE: relativedelta not supported
                 filter=Q(
-                    visit__thyroid_function_date__gte=F("diagnosis_date") - timedelta(days=90),
-                    visit__thyroid_function_date__lte=F("diagnosis_date") + timedelta(days=90),
+                    visit__thyroid_function_date__gte=F("diagnosis_date")
+                    - timedelta(days=90),
+                    visit__thyroid_function_date__lte=F("diagnosis_date")
+                    + timedelta(days=90),
                 ),
             )
         )
@@ -3099,9 +3196,13 @@ class CalculateKPIS:
         # Date of Diabetes Diagnosis (item 7)
         valid_visit_subquery = Visit.objects.filter(
             patient=OuterRef("pk"),
-            carbohydrate_counting_level_three_education_date__gte=F("patient__diagnosis_date")
+            carbohydrate_counting_level_three_education_date__gte=F(
+                "patient__diagnosis_date"
+            )
             - timedelta(days=7),
-            carbohydrate_counting_level_three_education_date__lte=F("patient__diagnosis_date")
+            carbohydrate_counting_level_three_education_date__lte=F(
+                "patient__diagnosis_date"
+            )
             + timedelta(days=14),
         )
 
@@ -3153,10 +3254,14 @@ class CalculateKPIS:
         )
         total_ineligible = self.total_patients_count - total_eligible
 
-        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(eligible_patients)
+        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
+            eligible_patients
+        )
 
         # Extract just the median values
-        median_hba1cs = [values["median"] for values in hba1c_values_by_patient.values()]
+        median_hba1cs = [
+            values["median"] for values in hba1c_values_by_patient.values()
+        ]
 
         # Finally calculate the mean of the medians
         mean_of_median_hba1cs = self.calculate_mean(median_hba1cs)
@@ -3209,9 +3314,13 @@ class CalculateKPIS:
         # calculate_median method
         # We're doing this in Python instead of Django ORM because median
         # aggregation gets complicated
-        hba1c_values_by_patient = defaultdict(lambda: {"hb1ac_values": [], "nhs_number": ""})
+        hba1c_values_by_patient = defaultdict(
+            lambda: {"hb1ac_values": [], "nhs_number": ""}
+        )
         for visit in valid_visits:
-            hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(visit["hba1c"])
+            hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(
+                visit["hba1c"]
+            )
             hba1c_values_by_patient[visit["patient__pk"]]["nhs_number"] = visit[
                 "patient__nhs_number"
             ]
@@ -3264,10 +3373,14 @@ class CalculateKPIS:
             hba1c_values_by_patient[visit["patient__pk"]].append(visit["hba1c"])
 
         # For each patient, calculate the median of their HbA1c values
-        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(eligible_patients)
+        hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
+            eligible_patients
+        )
 
         # Extract just the median values
-        median_hba1cs = [values["median"] for values in hba1c_values_by_patient.values()]
+        median_hba1cs = [
+            values["median"] for values in hba1c_values_by_patient.values()
+        ]
 
         # Finally calculate the median of the medians
         median_of_median_hba1cs = self.calculate_median(median_hba1cs)
@@ -3312,8 +3425,12 @@ class CalculateKPIS:
         )
 
         # Filter eligible patients to just relevant diabetes types
-        eligible_patients_t1dm = eligible_patients.filter(diabetes_type=DIABETES_TYPES[0][0])
-        eligible_patients_t2dm = eligible_patients.filter(diabetes_type=DIABETES_TYPES[1][0])
+        eligible_patients_t1dm = eligible_patients.filter(
+            diabetes_type=DIABETES_TYPES[0][0]
+        )
+        eligible_patients_t2dm = eligible_patients.filter(
+            diabetes_type=DIABETES_TYPES[1][0]
+        )
         eligible_patients_other = eligible_patients.exclude(
             diabetes_type__in=[DIABETES_TYPES[0][0], DIABETES_TYPES[1][0]]
         )
@@ -3343,14 +3460,15 @@ class CalculateKPIS:
                     # convert HbA1c % to mmol/mol when necessary
                     hba1c_mmol_mol=Case(
                         When(
-                            hba1c_format=HBA1C_FORMATS[0][0],
+                            Q(hba1c_format=HBA1C_FORMATS[0][0]),
                             then=F("hba1c"),
                         ),
                         When(
-                            hba1c_format=HBA1C_FORMATS[1][0],
-                            then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
+                            Q(hba1c_format=HBA1C_FORMATS[1][0]),
+                            then=(F("hba1c") - Round(Decimal("2.152")))
+                            / Decimal("0.09148"),
                         ),
-                        default=F("hba1c"),
+                        default=None,
                         output_field=DecimalField(
                             max_digits=5,
                             decimal_places=2,
@@ -3358,23 +3476,42 @@ class CalculateKPIS:
                     )
                 )
                 .values("hba1c_mmol_mol", "patient__pk")
+                .filter(hba1c_mmol_mol__isnull=False)
             )
 
             # From these, calculate the mean and median HbA1c values
-            mean_hba1c_mmol_mol = self._calculate_mean_hba1cs(valid_visits, key="hba1c_mmol_mol")
+            mean_hba1c_mmol_mol = self._calculate_mean_hba1cs(
+                valid_visits, key="hba1c_mmol_mol"
+            )
             median_hba1c_mmol_mol = self._calculate_median_hba1cs(
                 valid_visits, key="hba1c_mmol_mol"
             )
 
             # Convert to percent (noting we're using floats not Decimal now)
-            mean_hba1c_percent = (0.09148 * mean_hba1c_mmol_mol) + 2.152
-            median_hba1c_percent = (0.09148 * median_hba1c_mmol_mol) + 2.152
+            mean_hba1c_percent = (
+                (0.09148 * mean_hba1c_mmol_mol) + 2.152
+                if mean_hba1c_mmol_mol > 0 and mean_hba1c_mmol_mol is not None
+                else None
+            )
+            median_hba1c_percent = (
+                (0.09148 * median_hba1c_mmol_mol) + 2.152
+                if median_hba1c_mmol_mol > 0 and median_hba1c_mmol_mol is not None
+                else None
+            )
 
             hba1c_vals[key] = {
-                "mean_mmol_mol": int(mean_hba1c_mmol_mol),
-                "median_mmol_mol": int(median_hba1c_mmol_mol),
-                "mean_percent": round(mean_hba1c_percent, 1),
-                "median_percent": round(median_hba1c_percent, 1),
+                "mean_mmol_mol": (
+                    int(mean_hba1c_mmol_mol) if mean_hba1c_mmol_mol else None
+                ),
+                "median_mmol_mol": (
+                    int(median_hba1c_mmol_mol) if median_hba1c_mmol_mol else None
+                ),
+                "mean_percent": (
+                    round(mean_hba1c_percent, 1) if mean_hba1c_percent else None
+                ),
+                "median_percent": (
+                    round(median_hba1c_percent, 1) if median_hba1c_percent else None
+                ),
             }
 
         return hba1c_vals
@@ -3452,7 +3589,9 @@ class CalculateKPIS:
                 | Q(hospital_discharge_date__range=self.AUDIT_DATE_RANGE)
             ),
             # valid reason for admission
-            hospital_admission_reason__in=[choice[0] for choice in HOSPITAL_ADMISSION_REASONS],
+            hospital_admission_reason__in=[
+                choice[0] for choice in HOSPITAL_ADMISSION_REASONS
+            ],
             patient=OuterRef("pk"),
             visit_date__range=self.AUDIT_DATE_RANGE,
         )
@@ -3503,8 +3642,18 @@ class CalculateKPIS:
         valid_visit_subquery = Visit.objects.filter(
             # admission start date OR discharge date within this month
             Q(
-                Q(hospital_admission_date__range=(current_month_start, current_month_end))
-                | Q(hospital_discharge_date__range=(current_month_start, current_month_end))
+                Q(
+                    hospital_admission_date__range=(
+                        current_month_start,
+                        current_month_end,
+                    )
+                )
+                | Q(
+                    hospital_discharge_date__range=(
+                        current_month_start,
+                        current_month_end,
+                    )
+                )
             ),
         )
 
@@ -3528,7 +3677,9 @@ class CalculateKPIS:
         valid_visit_with_admission_count = Visit.objects.filter(
             Q(hospital_admission_date__range=self.AUDIT_DATE_RANGE)
             | Q(hospital_discharge_date__range=self.AUDIT_DATE_RANGE),
-            hospital_admission_reason__in=[choice[0] for choice in HOSPITAL_ADMISSION_REASONS],
+            hospital_admission_reason__in=[
+                choice[0] for choice in HOSPITAL_ADMISSION_REASONS
+            ],
             patient__pk=pt_pk,
             visit_date__range=self.AUDIT_DATE_RANGE,
         ).count()
@@ -3877,7 +4028,9 @@ class CalculateKPIS:
             )
 
         # First get new T1DM diagnoses pts
-        base_query_set, _ = self._get_total_kpi_7_eligible_pts_base_query_set_and_total_count()
+        base_query_set, _ = (
+            self._get_total_kpi_7_eligible_pts_base_query_set_and_total_count()
+        )
 
         # Filter for those diagnoses at least 90 days before audit end date
         self.t1dm_pts_diagnosed_90D_before_end_base_query_set = base_query_set.filter(

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -384,7 +384,7 @@ def exclude_item(lst, item):
 
 @register.filter
 def hba1c_units(value, is_ifcc=True):
-    if value is None:
+    if value is None or value == "" or value == "0" or value == 0 or value < 0:
         return "-"
     if is_ifcc:
         return f"{value} mmol/mol"

--- a/project/npda/views/dashboard/patient_characteristics.py
+++ b/project/npda/views/dashboard/patient_characteristics.py
@@ -29,8 +29,10 @@ from project.constants.colors import (
 )
 from project.constants import HBA1C_FORMATS
 from project.npda.models import Visit
+from project.npda.views.decorators import login_and_otp_required
 
 
+@login_and_otp_required()
 def patient_ages(request):
     """
     This function is used to generate the patient ages table

--- a/project/npda/views/dashboard/patient_characteristics.py
+++ b/project/npda/views/dashboard/patient_characteristics.py
@@ -100,43 +100,6 @@ def patient_ages(request):
 
     audit_year = request.session.get("selected_audit_year", None)
 
-    audit_start, audit_end = audit_period_for_audit_year(audit_year)
-    all_patients_in_this_submission = (
-        Submission.objects.filter(
-            audit_year__range=(audit_start.year, audit_end.year),
-            submission_active=True,
-            paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-        )
-        .get()
-        .patients.all()
-    )
-
-    # This function might get called on historical cohorts, so we need to check if today's date is within the audit period
-    if audit_start <= date.today() <= audit_end:
-        comparison_date = date.today()
-    else:
-        comparison_date = audit_end
-
-    filter = Q()
-    if request.POST.get("diabetes_type"):
-        if request.POST.get("diabetes_type") != "0":
-            filter &= Q(
-                diabetes_type=int(request.POST.get("diabetes_type"))
-            )  # Filter by diabetes type
-
-    # Get the number of patients of ages 0-2, 2-5, 5-12, 12-16, 16-19, 19-25
-    # Filter these patients by the diabetes type selected or All
-    all_patients_in_this_submission_by_age = all_patients_in_this_submission.filter(
-        filter
-    ).values(
-        "pk",
-        "sex",
-        "date_of_birth",
-        "ethnicity",
-        "index_of_multiple_deprivation_quintile",
-        "diabetes_type",
-    )
-
     # Get the number of patients of ages 0-2, 2-5, 5-12, 12-16, 16-19, 19-25
     age_band_counts = {
         "birth_two": 0,
@@ -156,49 +119,96 @@ def patient_ages(request):
         "not_specified": 0,
     }
 
-    for patient in all_patients_in_this_submission_by_age:
-        patient["age"] = relativedelta(comparison_date, patient["date_of_birth"]).years
+    audit_start, audit_end = audit_period_for_audit_year(audit_year)
 
-        # Enable the diabetes types that exist  in the filter
-        for dmtype in diabetes_types:
-            if patient["diabetes_type"] == dmtype["key"]:
-                dmtype["enabled"] = True
+    number_of_patients = 0
 
-        # Count the number of patients in each age band
-        if 0 <= patient["age"] < 2:
-            age_band_counts["birth_two"] += 1
-        elif 2 <= patient["age"] < 5:
-            age_band_counts["two_five"] += 1
-        elif 5 <= patient["age"] < 12:
-            age_band_counts["five_twelve"] += 1
-        elif 12 <= patient["age"] < 16:
-            age_band_counts["twelve_sixteen"] += 1
-        elif 16 <= patient["age"] < 19:
-            age_band_counts["sixteen_nineteen"] += 1
-        elif 19 <= patient["age"] < 25:
-            age_band_counts["nineteen_twenty_five"] += 1
+    if Submission.objects.filter(
+        audit_year__range=(audit_start.year, audit_end.year),
+        submission_active=True,
+        paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
+    ).exists():
+        all_patients_in_this_submission = (
+            Submission.objects.filter(
+                audit_year__range=(audit_start.year, audit_end.year),
+                submission_active=True,
+                paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
+            )
+            .get()
+            .patients.all()
+        )
 
-        # count the number of <12 and >12
-        if patient["age"] < 12:
-            age_band_counts["under_twelve"] += 1
-        elif patient["age"] >= 12:
-            age_band_counts["over_twelve"] += 1
+        # This function might get called on historical cohorts, so we need to check if today's date is within the audit period
+        if audit_start <= date.today() <= audit_end:
+            comparison_date = date.today()
+        else:
+            comparison_date = audit_end
 
-        # Count the patients by sex
-        if patient["sex"] == 1:
-            sex_counts["male"] += 1
-        elif patient["sex"] == 2:
-            sex_counts["female"] += 1
-        elif patient["sex"] == 0:
-            sex_counts["not_known"] += 1
-        elif patient["sex"] == 9:
-            sex_counts["not_specified"] += 1
+        filter = Q()
+        if request.POST.get("diabetes_type"):
+            if request.POST.get("diabetes_type") != "0":
+                filter &= Q(
+                    diabetes_type=int(request.POST.get("diabetes_type"))
+                )  # Filter by diabetes type
 
-    # create the charts
+        # Get the number of patients of ages 0-2, 2-5, 5-12, 12-16, 16-19, 19-25
+        # Filter these patients by the diabetes type selected or All
+        all_patients_in_this_submission_by_age = all_patients_in_this_submission.filter(
+            filter
+        ).values(
+            "pk",
+            "sex",
+            "date_of_birth",
+            "ethnicity",
+            "index_of_multiple_deprivation_quintile",
+            "diabetes_type",
+        )
+
+        number_of_patients = all_patients_in_this_submission_by_age.count()
+
+        for patient in all_patients_in_this_submission_by_age:
+            patient["age"] = relativedelta(
+                comparison_date, patient["date_of_birth"]
+            ).years
+
+            # Enable the diabetes types that exist  in the filter
+            for dmtype in diabetes_types:
+                if patient["diabetes_type"] == dmtype["key"]:
+                    dmtype["enabled"] = True
+
+            # Count the number of patients in each age band
+            if 0 <= patient["age"] < 2:
+                age_band_counts["birth_two"] += 1
+            elif 2 <= patient["age"] < 5:
+                age_band_counts["two_five"] += 1
+            elif 5 <= patient["age"] < 12:
+                age_band_counts["five_twelve"] += 1
+            elif 12 <= patient["age"] < 16:
+                age_band_counts["twelve_sixteen"] += 1
+            elif 16 <= patient["age"] < 19:
+                age_band_counts["sixteen_nineteen"] += 1
+            elif 19 <= patient["age"] < 25:
+                age_band_counts["nineteen_twenty_five"] += 1
+
+            # count the number of <12 and >12
+            if patient["age"] < 12:
+                age_band_counts["under_twelve"] += 1
+            elif patient["age"] >= 12:
+                age_band_counts["over_twelve"] += 1
+
+            # Count the patients by sex
+            if patient["sex"] == 1:
+                sex_counts["male"] += 1
+            elif patient["sex"] == 2:
+                sex_counts["female"] += 1
+            elif patient["sex"] == 0:
+                sex_counts["not_known"] += 1
+            elif patient["sex"] == 9:
+                sex_counts["not_specified"] += 1
 
     context = {
         "audit_year": (audit_start, audit_end),
-        "number_of_patients": all_patients_in_this_submission_by_age.count(),
+        "number_of_patients": number_of_patients,
         "patients_by_age": age_band_counts,
         "diabetes_types": diabetes_types,
         "patients_by_sex": sex_counts,
@@ -207,6 +217,7 @@ def patient_ages(request):
     return render(request, template, context)
 
 
+@login_and_otp_required()
 def all_patient_charts(request):
     """
     This function is used to generate all the patient characteristics charts
@@ -214,15 +225,6 @@ def all_patient_charts(request):
     audit_year = request.session.get("selected_audit_year", None)
 
     audit_start, audit_end = audit_period_for_audit_year(audit_year)
-    all_patients_in_this_submission = (
-        Submission.objects.filter(
-            audit_year__range=(audit_start.year, audit_end.year),
-            submission_active=True,
-            paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-        )
-        .get()
-        .patients.all()
-    )
 
     imd_counts = {
         "1 (most deprived)": 0,
@@ -240,37 +242,54 @@ def all_patient_charts(request):
         "Other/Not Stated/Unknown": 0,
     }
 
-    for patient in all_patients_in_this_submission.values(
-        "pk",
-        "sex",
-        "ethnicity",
-        "index_of_multiple_deprivation_quintile",
-        "diabetes_type",
-    ):
+    if Submission.objects.filter(
+        audit_year__range=(audit_start.year, audit_end.year),
+        submission_active=True,
+        paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
+    ).exists():
+        all_patients_in_this_submission = (
+            Submission.objects.filter(
+                audit_year__range=(audit_start.year, audit_end.year),
+                submission_active=True,
+                paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
+            )
+            .get()
+            .patients.all()
+        )
 
-        # Count the patients by IMD
-        if patient["index_of_multiple_deprivation_quintile"] == 1:
-            imd_counts["1 (most deprived)"] += 1
-        elif patient["index_of_multiple_deprivation_quintile"] == 2:
-            imd_counts["2"] += 1
-        elif patient["index_of_multiple_deprivation_quintile"] == 3:
-            imd_counts["3"] += 1
-        elif patient["index_of_multiple_deprivation_quintile"] == 4:
-            imd_counts["4"] += 1
-        elif patient["index_of_multiple_deprivation_quintile"] == 5:
-            imd_counts["5 (least deprived)"] += 1
+        for patient in all_patients_in_this_submission.values(
+            "pk",
+            "sex",
+            "ethnicity",
+            "index_of_multiple_deprivation_quintile",
+            "diabetes_type",
+        ):
 
-        # Ethnicity
-        if patient["ethnicity"] in ["A", "B", "C"]:
-            ethnicity_counts["White"] += 1
-        if patient["ethnicity"] in ["D", "E", "F", "G"]:
-            ethnicity_counts["Mixed"] += 1
-        if patient["ethnicity"] in ["H", "J", "K", "L", "R"]:
-            ethnicity_counts["Asian"] += 1
-        if patient["ethnicity"] in ["M", "N", "P"]:
-            ethnicity_counts["Black"] += 1
-        if patient["ethnicity"] in ["S", "Z", "99"]:
-            ethnicity_counts["Other/Not Stated/Unknown"] += 1
+            # Count the patients by IMD
+            if patient["index_of_multiple_deprivation_quintile"] == 1:
+                imd_counts["1 (most deprived)"] += 1
+            elif patient["index_of_multiple_deprivation_quintile"] == 2:
+                imd_counts["2"] += 1
+            elif patient["index_of_multiple_deprivation_quintile"] == 3:
+                imd_counts["3"] += 1
+            elif patient["index_of_multiple_deprivation_quintile"] == 4:
+                imd_counts["4"] += 1
+            elif patient["index_of_multiple_deprivation_quintile"] == 5:
+                imd_counts["5 (least deprived)"] += 1
+
+            # Ethnicity
+            if patient["ethnicity"] in ["A", "B", "C"]:
+                ethnicity_counts["White"] += 1
+            if patient["ethnicity"] in ["D", "E", "F", "G"]:
+                ethnicity_counts["Mixed"] += 1
+            if patient["ethnicity"] in ["H", "J", "K", "L", "R"]:
+                ethnicity_counts["Asian"] += 1
+            if patient["ethnicity"] in ["M", "N", "P"]:
+                ethnicity_counts["Black"] += 1
+            if patient["ethnicity"] in ["S", "Z", "99"]:
+                ethnicity_counts["Other/Not Stated/Unknown"] += 1
+    else:
+        all_patients_in_this_submission = None
 
     # Create the IMD pie chart
     imd_piechart = create_piechart(imd_counts, "index_of_multiple_deprivation_quintile")
@@ -278,8 +297,11 @@ def all_patient_charts(request):
     # Create the Ethnicity pie chart
     ethnicity_piechart = create_piechart(ethnicity_counts, "ethnicity")
 
-    visits = return_eligible_visits(all_patients_in_this_submission, audit_year)
-    # Create a Pandas DataFrame
+    if all_patients_in_this_submission is None:
+        visits = None
+    else:
+        visits = return_eligible_visits(all_patients_in_this_submission, audit_year)
+        # Create a Pandas DataFrame
     df = pd.DataFrame(visits)
 
     # Create the box plot for sex

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -20,7 +20,9 @@ def patient_measurements(request):
     else:
         today = date.today()
         calculation_date = date(selected_audit_year, today.month, today.day)
-    calculate_kpis = CalculateKPIS(calculation_date=calculation_date, return_pt_querysets=True)
+    calculate_kpis = CalculateKPIS(
+        calculation_date=calculation_date, return_pt_querysets=True
+    )
 
     calculate_kpis.calculate_kpis_for_pdus(pz_codes=[pz_code])
 
@@ -54,15 +56,28 @@ def patient_measurements(request):
         calculate_kpis.calculate_kpi_hba1c_vals_stratified_by_diabetes_type()
     )
 
-    current_submission = Submission.objects.get(
+    if Submission.objects.filter(
         audit_year=selected_audit_year,
         paediatric_diabetes_unit__pz_code=pz_code,
         submission_active=True,
-    )
-    visits = Visit.objects.filter(patient__in=current_submission.patients.all())
-    submission_visits_with_errors = visits.filter(errors__isnull=False)
+    ).exists():
+        current_submission = Submission.objects.get(
+            audit_year=selected_audit_year,
+            paediatric_diabetes_unit__pz_code=pz_code,
+            submission_active=True,
+        )
+        visits = Visit.objects.filter(patient__in=current_submission.patients.all())
+        submission_visits_with_errors = visits.filter(errors__isnull=False).count()
+        submission_date = current_submission.submission_date
+        affected_patients = current_submission.patients.count()
+    else:
+        submission_visits_with_errors = 0
+        submission_date = None
+        affected_patients = 0
 
-    template = "dashboard/components/cards/card_partials/patient_measurements_partial.html"
+    template = (
+        "dashboard/components/cards/card_partials/patient_measurements_partial.html"
+    )
 
     return render(
         request,
@@ -71,8 +86,8 @@ def patient_measurements(request):
             "selected_audit_year": selected_audit_year,
             "pz_code": pz_code,
             "hba1c_value_counts_stratified_by_diabetes_type": hba1c_value_counts_stratified_by_diabetes_type,
-            "submission_visit_error_count": submission_visits_with_errors.count(),
-            "submission_date": current_submission.submission_date,
-            "affected_patients": current_submission.patients.count(),
+            "submission_visit_error_count": submission_visits_with_errors,
+            "submission_date": submission_date,
+            "affected_patients": affected_patients,
         },
     )


### PR DESCRIPTION
### Overview
Fixes a bunch of irritating errors
- adds the decorators to the htmx endpoints (`patient_measurements`, `patient_ages` and `all_patient_charts`)
- rewrites all 3 functions slightly not to crash if a PDU does not have a submission
- fixes the kpi class not to calculate HbA1c percent if mmol/mol is negative or None (as this would yield a negative percentage).

🧢 *hat tip* to @mbarton for the spade work on identifying the missing decorators