### PR TITLE
Fix KPI 24 calculations for patients who no longer use HCL in their most recent visit

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -1756,12 +1756,9 @@ class CalculateKPIS:
 
         # Eligible kpi24 patients are those who are either on an insulin pump or insulin pump therapy
         eligible_kpi_24_latest_visit_subquery = (
-            Visit.objects.filter(patient=OuterRef("pk"))
-            .filter(
-                # Either:
-                # 3 = insulin pump
-                # or 6 = Insulin pump therapy plus other blood glucose lowering medication
-                Q(treatment__in=[3, 6])
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                treatment__isnull=False
             )
             .order_by("-visit_date")
             .values("pk")[:1]
@@ -1770,7 +1767,8 @@ class CalculateKPIS:
             Q(
                 id__in=Subquery(
                     Patient.objects.filter(
-                        visit__in=eligible_kpi_24_latest_visit_subquery
+                        visit__in=eligible_kpi_24_latest_visit_subquery,
+                        visit__treatment__in=[3, 6]
                     ).values("id")
                 )
             )

--- a/project/npda/tests/kpi_calculations/test_kpis_24.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_24.py
@@ -7,6 +7,7 @@ from project.npda.kpi_class.kpis import CalculateKPIS, KPIResult
 from project.npda.models import Patient
 from project.npda.tests import utils
 from project.npda.tests.factories.patient_factory import PatientFactory
+from project.npda.tests.factories.visit_factory import VisitFactory
 from project.npda.tests.kpi_calculations.test_calculate_kpis import \
     assert_kpi_result_equal
 
@@ -135,3 +136,34 @@ def test_kpi_calculation_24(AUDIT_START_DATE):
         expected=EXPECTED_KPIRESULT,
         actual=calc_kpis.calculate_kpi_24_hybrid_closed_loop_system(),
     )
+
+
+# Edge case found as part of https://github.com/rcpch/national-paediatric-diabetes-audit/issues/797
+@pytest.mark.django_db
+def test_kpi_calculation_24_for_patients_who_have_come_off_hcl(AUDIT_START_DATE):
+    first_visit_date = AUDIT_START_DATE + relativedelta(days=2)
+
+    patient = PatientFactory(
+        visit__visit_date=first_visit_date,
+        date_of_birth=AUDIT_START_DATE - relativedelta(days=365 * 10),
+        visit__treatment=3,
+        visit__closed_loop_system=2,
+    )
+
+    calc_kpis = CalculateKPIS(calculation_date=AUDIT_START_DATE)
+    calc_kpis.set_patients_for_calculation(Patient.objects.filter(pk__in=[patient.pk]))
+
+    first_result = calc_kpis.calculate_kpi_24_hybrid_closed_loop_system()
+    assert first_result.total_passed == 1
+
+    # Add a more recent visit where they are back on injections
+    second_visit_date = first_visit_date + relativedelta(months=3)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=second_visit_date,
+        treatment=1
+    )
+
+    second_result = calc_kpis.calculate_kpi_24_hybrid_closed_loop_system()
+    assert second_result.total_passed == 0


### PR DESCRIPTION
Fixes a bug I saw in the Royal Preston data where the denominator for Closed Loop on the dashboard was not the same as the numerator for Pump.

The bug was caused by a patient who was on an HCL but had gone back to injections in their most recent visit.

The fix is to use the exact same code we already use for KPI 15, which correctly applies the filter on treatment type only when calculating `passed` patients rather than in the subquery to find the most recent visit with a treatment record.