### PR TITLE
upload-different-pdu

### DIFF
--- a/project/npda/templates/partials/npda_user_table.html
+++ b/project/npda/templates/partials/npda_user_table.html
@@ -19,10 +19,14 @@
         <tr class="text-rcpch_light_blue bg-white border-b border-gray-100 hover:bg-r hover:bg-rcpch_light_blue hover:text-white">
           <td class="text-left">
             <div class="tooltip tooltip-right" data-tip="NPDA User Unique ID">
-              <a href="{% url 'npdauser-update' npda_user.pk %}"
-                 class="text-rcpch_pink px-2 hover:text-rcpch_dark_blue">
+              {% if perms.npda.change_npdauser %}
+                <a href="{% url 'npdauser-update' npda_user.pk %}"
+                   class="text-rcpch_pink px-2 hover:text-rcpch_dark_blue">
+                  <strong>{{ npda_user.pk }}</strong>
+                </a>
+              {% else %}
                 <strong>{{ npda_user.pk }}</strong>
-              </a>
+              {% endif %}
             </div>
           </td>
           <td class="text-left">{{ npda_user.get_full_name }}</td>
@@ -156,7 +160,8 @@
           </td>
           <td class="px-6 text-left">{{ npda_user.get_role_display }}</td>
           <td class="w-80 px-2 text-right">
-            <div class="tooltip tooltip-left" data-tip="View user logs for {{ npda_user }}">
+            <div class="tooltip tooltip-left"
+                 data-tip="View user logs for {{ npda_user }}">
               <a href="{% url 'npdauser-logs' npda_user.pk %}"
                  class="text-rcpch_pink flex justify-center items-center px-2">
                 <svg class="text-rcpch_pink w-8 h-8"

--- a/project/npda/templates/partials/submission_employer_selector.html
+++ b/project/npda/templates/partials/submission_employer_selector.html
@@ -1,0 +1,35 @@
+{% csrf_token %}
+<div role="alert" class="alert border-t-1 border-blue-400 shadow-lg mt-5">
+  <i class="fa-2xl fa-info-circle fa-solid"></i>
+  <div>
+    <h3 class="font-bold">Important Information</h3>
+    <div class="text-xs">
+      You are about to upload data to the NPDA for <strong>{{ request.session.pz_code }} ({{ request.session.lead_organisation }})</strong>.
+      {% if employers|length > 1 %}
+        <p class="text-xs mt-2 mb-2">
+          If this is incorrect, please select the correct employer below.
+        </p>
+        <form class="filter">
+          {% for employer in employers %}
+            <input class="btn filter-reset"
+                   {% if employer.paediatric_diabetes_unit.pz_code == request.session.pz_code %}checked{% endif %}
+                   hx-post="{% url 'switch_paediatric_diabetes_unit' %}"
+                   hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                   hx-trigger="click"
+                   hx-target="#employer-selector"
+                   hx-swap="innerHTML"
+                   type="radio"
+                   name="employers"
+                   value="{{ employer.paediatric_diabetes_unit.pz_code }}"
+                   aria-label="{{ employer.paediatric_diabetes_unit.lead_organisation_name }} ({{ employer.paediatric_diabetes_unit.pz_code }})" />
+          {% endfor %}
+        </form>
+      {% endif %}
+      {% if request.user.is_rcpch_audit_team_member or request.user.is_rcpch_staff or request.user.is_superuser %}
+        <p class="text-xs mt-2 mb-2">
+          If you are an RCPCH staff member or part of the audit team, you can upload data for any employer. To change the selected paediatric diabetes unit user the filter button in the top right-hand corner.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/project/npda/templates/upload_csv/file_upload.html
+++ b/project/npda/templates/upload_csv/file_upload.html
@@ -21,6 +21,11 @@
         <a href="{% url 'download_template' 'england_wales' %}"
            download="npda_base.csv"
            class="bg-rcpch_light_blue border-rcpch_light_blue btn w-full text-lg text-white focus:bg-rcpch_pink hover:bg-rcpch_dark_blue"><i class="fa-file-arrow-down fa-solid"></i> Download NPDA CSV template</a>
+        {% comment %} PZ code and employer alert {% endcomment %}
+        <div id="employer-selector">
+          {% include 'partials/submission_employer_selector.html' with employers=employers %}
+        </div>
+        {% comment %} end of employer alert {% endcomment %}
       </div>
       <form method="post"
             enctype="multipart/form-data"

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -34,6 +34,11 @@ urlpatterns = [
     path("view_preference", view=view_preference, name="view_preference"),
     path("audit-year", view=audit_year, name="audit-year"),
     path("upload_csv", view=upload_csv, name="upload_csv"),
+    path(
+        "switch_paediatric_diabetes_unit",
+        view=switch_paediatric_diabetes_unit,
+        name="switch_paediatric_diabetes_unit",
+    ),
     # Submission views
     path(
         "submissions",

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -16,12 +16,13 @@ from project.npda.views.decorators import login_and_otp_required
 
 # RCPCH imports
 from .mixins import CheckCurrentAuditYearMixin, LoginAndOTPRequiredMixin
-from ..models import Submission
+from ..models import Submission, OrganisationEmployer, PaediatricDiabetesUnit
 from ..general_functions.csv import (
     download_csv,
     download_xlsx,
     csv_parse,
 )
+from ..general_functions.session import refresh_session_filters
 
 
 class SubmissionsListView(
@@ -192,4 +193,33 @@ class SubmissionsListView(
 
 @login_and_otp_required()
 def upload_csv(request):
-    return render(request, "upload_csv/file_upload.html")
+    context = {"employers": OrganisationEmployer.objects.filter(npda_user=request.user)}
+    return render(request, "upload_csv/file_upload.html", context=context)
+
+
+@login_and_otp_required()
+def switch_paediatric_diabetes_unit(request):
+    """
+    Switch the Paediatric Diabetes Unit in the session.
+    This is an HTMX view.
+    """
+    template = "partials/submission_employer_selector.html"
+    error_message = None
+
+    selected_pz_code = request.POST.get("employers")
+    if selected_pz_code == request.session.get("pz_code"):
+        return HttpResponse(status=200)
+
+    try:
+        pdu = PaediatricDiabetesUnit.objects.get(pz_code=selected_pz_code)
+    except PaediatricDiabetesUnit.DoesNotExist as error:
+        error_message = f"Error: {error}. Please contact the NPDA team."
+
+    context = {
+        "employers": OrganisationEmployer.objects.filter(npda_user=request.user),
+        "error_message": error_message,
+    }
+    # update the session with the new PDU
+    refresh_session_filters(request, selected_pz_code)
+
+    return render(request, template, context=context)


### PR DESCRIPTION
### Overview
Some users have access to more than one PDU. It is not clear which context they are uploading in and could easily overwrite data in the wrong unit

This PR introduces a new alert on the upload CSV alert. If the user has more than one organisation employer, the alert reminds them which PDU they are submitting to, and offers a toggle to change if they wish. This updates the pz code in the session and changes the context to that PDU. If the user is a superuser or RCPCH staff, the alert advises them to change the context in the view preference selector as before.

Other items fixed
1. editor users should not be able to edit themselves. The decorators currently prevent this but there is no check in the template for this so the misadventuring editor gets an unfriendly 403 for trying. The anchor link for those without permission is now disabled.