### PR TITLE
Fix dashboard crash changing audit year

### DIFF
--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -177,6 +177,7 @@ def audit_year(request):
     """
     if request.method == "POST":
         audit_year = request.POST.get("audit_year_select_name", None)
+        audit_year = int(audit_year) if audit_year else None
 
         refresh_session_filters(request, audit_year=audit_year)
 


### PR DESCRIPTION
Fixes crash rendering the dashboard when you switch audit year in the filters menu.

```
Internal Server Error: /all_patient_charts

ValueError at /all_patient_charts
Audit period is only available for the years 2023, 2024, 2025, 2026. Provided audit year: 2023

Request Method: GET
Request URL: http://npda.rcpch.ac.uk/all_patient_charts

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/project/npda/views/decorators.py", line 64, in sync_login_and_otp_required
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/project/npda/views/dashboard/patient_characteristics.py", line 236, in all_patient_charts
    audit_start, audit_end = audit_period_for_audit_year(audit_year)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/project/npda/general_functions/audit_period.py", line 108, in audit_period_for_audit_year
    raise ValueError(
    ^

Exception Type: ValueError at /all_patient_charts
Exception Value: Audit period is only available for the years 2023, 2024, 2025, 2026. Provided audit year: 2023
Raised during: project.npda.views.dashboard.patient_characteristics.all_patient_charts
```