### PR TITLE
Edit submission without csv_file_name

### DIFF
--- a/project/npda/models/submission.py
+++ b/project/npda/models/submission.py
@@ -44,6 +44,7 @@ class Submission(models.Model):
         "CSV file name",
         help_text="Name of the uploaded CSV file",
         null=True,
+        blank=True
     )
 
     errors = models.JSONField(


### PR DESCRIPTION
Previously you couldn't edit a submission in the Django admin without setting a `csv_file_name`