### PR TITLE
Fix duplicate org employer re-running user import

### DIFF
--- a/project/npda/management/commands/import_users.py
+++ b/project/npda/management/commands/import_users.py
@@ -50,7 +50,10 @@ class Command(BaseCommand):
 
         with open(file_path, "r") as file:
             reader = csv.DictReader(file)
+            
             index = 0
+            unique_emails = set()
+
             for row in reader:
                 first_name = row["first_name"]
                 surname = row["surname"]
@@ -101,15 +104,23 @@ class Command(BaseCommand):
                 # add the user to the group
                 user.groups.add(group)
 
-                # create the organisation employer
-                OrganisationEmployer.objects.create(
+                if not OrganisationEmployer.objects.filter(
                     paediatric_diabetes_unit=pdu,
                     npda_user=user,
-                    is_primary_employer=True,
-                )
+                ).exists():
+                    # create the organisation employer
+                    OrganisationEmployer.objects.create(
+                        paediatric_diabetes_unit=pdu,
+                        npda_user=user,
+                        # primary employer is the first one we see for that user 
+                        is_primary_employer=not email in unique_emails,
+                    )
+                
                 index += 1
+                unique_emails.add(email)
 
                 logger.info(
                     f"User {email} successfully created as {group.name} in {pdu}."
                 )
-        logger.info(f"🔥 {index} users successfully created.")
+        
+        logger.info(f"🔥 {index} rows processed, {len(unique_emails)} users successfully created or updated.")


### PR DESCRIPTION
Fixes a bug where you'd get duplicate `OrganisationEmployer` entries for users if you ran the same import multiple times.

The first PDU seen for a given user becomes the primary. This is not ideal as we don't really know whether the user considers that their primary place of work (where they want to go when they initially log in). But I think on balance it's better to preserve the implicit invariant that each user has one primary org employer to avoid confusion for future developers!

Also fixes the logging message at the end to correctly log the number of affected users.