### PR TITLE
Styled password reset email

### DIFF
--- a/project/npda/templates/registration/password_reset_email.html
+++ b/project/npda/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 {% autoescape on %}
 <div class="indent" style="display: relative; width: 80%; margin: auto;">
   <div class="centered" style="width: 50%; margin: auto;">
-    <img alt="RCPCH NPDA Logo" src='{{ protocol}}://{{ domain }}{% static "npda-logo.png" %}'>
+    <img alt="RCPCH NPDA Logo" src='{{ protocol}}://{{ domain }}{% static "images/npda-logo-white.png" %}'>
   </div>
   <p style="font-family: 'Montserrat', sans-serif;">NPDA Password Reset</p>
   <p style="font-family: 'Montserrat', sans-serif;">Dear {{user}},</p>

--- a/project/npda/templates/registration/password_reset_email.html
+++ b/project/npda/templates/registration/password_reset_email.html
@@ -1,0 +1,44 @@
+{% load static %}
+{% load humanize %}
+{% autoescape on %}
+<div class="indent" style="display: relative; width: 80%; margin: auto;">
+  <div class="centered" style="width: 50%; margin: auto;">
+    <img alt="RCPCH NPDA Logo" src='{{ protocol}}://{{ domain }}{% static "npda-logo.png" %}'>
+  </div>
+  <p style="font-family: 'Montserrat', sans-serif;">NPDA Password Reset</p>
+  <p style="font-family: 'Montserrat', sans-serif;">Dear {{user}},</p>
+  <p style="font-family: 'Montserrat', sans-serif;">To reset your password for the NPDA platform, click the link
+    below. Note if you did not confirm your account within 72 hours of creation, you can also use this link to create a new password:</p>
+  <p>
+    <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}" target="_blank">
+      {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+    </a>
+  </p>
+  <p style="font-family: 'Montserrat', sans-serif;">If clicking the link above doesn't work, please copy and paste the
+    URL in a new browser window instead.</p>
+  <p style="font-family: 'Montserrat', sans-serif;">If you did not make this request, please
+    <a href="mailto:npda@rcpch.ac.uk">contact the RCPCH NPDA team.</a>
+  </p>
+  <p style="font-family: 'Montserrat', sans-serif;">Please note that this link will expire in <b>{{ reset_password_link_expires_at|naturaltime }}</b></p>
+  <p>
+    To request a new link, go to 
+    <a href="{{ protocol }}://{{ domain }}{% url 'password_reset'%}">
+      {{ protocol }}://{{ domain }}{% url 'password_reset'%}
+    </a>
+    or get in touch with 
+    <a href="mailto:npda@rcpch.ac.uk">The NPDA Team</a>
+  </p>
+  <br />
+  <p style="font-family: 'Montserrat', sans-serif;">The RCPCH NPDA team</p>
+</div>
+<style>
+  @font-face {
+    font-family: 'Montserrat';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/montserrat/v25/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Hw5aXx-p7K4KLg.woff) format('woff');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+</style>
+{% endautoescape %}

--- a/project/npda/templates/registration/password_reset_subject.txt
+++ b/project/npda/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+RCPCH NPDA Password Reset


### PR DESCRIPTION
Fixes #877 

Copied over the reset password email template from Epilepsy12.

Screenshot pending as the image is broken when sending from localhost