### PR TITLE
quarter-from-calculation-date

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -26,8 +26,6 @@ from django.db.models import (
     Sum,
     When,
     DecimalField,
-    ExpressionWrapper,
-    DateField,
 )
 
 # NPDA Imports

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -456,7 +456,7 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(date.today())
+        current_quarter = retrieve_quarter_for_date(self.calculation_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
         eligible_patients_kpi_2 = total_kpi_1_eligible_pts_base_query_set.filter(

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -1092,7 +1092,7 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(date.today())
+        current_quarter = retrieve_quarter_for_date(self.calculation_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
 
@@ -2018,7 +2018,7 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(date.today())
+        current_quarter = retrieve_quarter_for_date(self.calculation_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
         for q, q_end_date in enumerate(quarter_end_dates, start=1):
@@ -3845,7 +3845,7 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(date.today())
+        current_quarter = retrieve_quarter_for_date(self.calculation_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
 

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -110,18 +110,18 @@ def dashboard(request):
     )
 
     # Gather other context vars
-    current_date = date.today()
+    
     days_remaining_until_audit_end_date = (
-        kpi_calculations_object["audit_end_date"] - current_date
+        kpi_calculations_object["audit_end_date"] - calculation_date
     ).days
-    current_quarter = retrieve_quarter_for_date(current_date)
+    current_quarter = retrieve_quarter_for_date(calculation_date)
 
     context = {
         "scatter_plot_select_list": _scatter_plot_select_list("new_diagnoses"),
         "pdu_object": pdu,
         # "pdu_lead_organisation": pdu_lead_organisation,
         "kpi_calculations_object": kpi_calculations_object,
-        "current_date": current_date,
+        "current_date": calculation_date,
         "current_quarter": current_quarter,
         "days_remaining_until_audit_end_date": days_remaining_until_audit_end_date,
         "charts": {

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.shortcuts import render
 
 from project import constants
+from project.npda.general_functions.audit_period import audit_period_for_audit_year
 from project.npda.general_functions.quarter_for_date import retrieve_quarter_for_date
 from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.models.paediatric_diabetes_unit import (
@@ -87,12 +88,13 @@ def dashboard(request):
 
     selected_audit_year = int(request.session.get("selected_audit_year"))
 
-    if selected_audit_year <= 2024:
-        # The day after the audit year end date
-        calculation_date = date(selected_audit_year, 4, 1)
+    # This function might get called on historical cohorts, so we need to check if today's date is within the audit period
+    audit_start, audit_end = audit_period_for_audit_year(selected_audit_year)
+    if audit_start <= date.today() <= audit_end:
+        calculation_date = date.today()
     else:
-        today = date.today()
-        calculation_date = date(selected_audit_year, today.month, today.day)
+        calculation_date = audit_end # audit_start
+
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -93,7 +93,7 @@ def dashboard(request):
     if audit_start <= date.today() <= audit_end:
         calculation_date = date.today()
     else:
-        calculation_date = audit_end # audit_start
+        calculation_date = audit_start
 
 
     calculate_kpis = CalculateKPIS(

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -520,6 +520,7 @@ def submission_and_calculation_date(request):
             audit_year=selected_audit_year,
             submission_active=True,
         )
+        
     else:
         submission = None
 
@@ -528,6 +529,6 @@ def submission_and_calculation_date(request):
     if audit_start <= date.today() <= audit_end:
         calculation_date = date.today()
     else:
-        calculation_date = audit_end # audit_start
+        calculation_date = audit_start
 
     return submission, calculation_date

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -14,6 +14,7 @@ from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 
 import project.constants.colors as colors
+from project.npda.general_functions.audit_period import audit_period_for_audit_year
 from project.npda.general_functions.map import (
     generate_dataframe_and_aggregated_distance_data_from_cases,
     generate_distance_from_organisation_scatterplot_figure,
@@ -522,11 +523,11 @@ def submission_and_calculation_date(request):
     else:
         submission = None
 
-    if selected_audit_year <= date.today().year:
-        # The day after the audit year end date
-        calculation_date = date(selected_audit_year, 4, 1)
+    # This function might get called on historical cohorts, so we need to check if today's date is within the audit period
+    audit_start, audit_end = audit_period_for_audit_year(selected_audit_year)
+    if audit_start <= date.today() <= audit_end:
+        calculation_date = date.today()
     else:
-        today = date.today()
-        calculation_date = date(selected_audit_year, today.month, today.day)
+        calculation_date = audit_end # audit_start
 
     return submission, calculation_date

--- a/project/npda/views/dashboard/patient_characteristics.py
+++ b/project/npda/views/dashboard/patient_characteristics.py
@@ -124,14 +124,14 @@ def patient_ages(request):
     number_of_patients = 0
 
     if Submission.objects.filter(
-        audit_year__range=(audit_start.year, audit_end.year),
+        audit_year=audit_start.year,
         submission_active=True,
         paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
         paediatric_diabetes_unit__active=True,
     ).exists():
         all_patients_in_this_submission = (
             Submission.objects.filter(
-                audit_year__range=(audit_start.year, audit_end.year),
+                audit_year=audit_start.year,
                 submission_active=True,
                 paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
                 paediatric_diabetes_unit__active=True,
@@ -256,14 +256,14 @@ def all_patient_charts(request):
     }
 
     if Submission.objects.filter(
-        audit_year__range=(audit_start.year, audit_end.year),
+        audit_year=audit_start.year,
         submission_active=True,
         paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
         paediatric_diabetes_unit__active=True,
     ).exists():
         all_patients_in_this_submission = (
             Submission.objects.filter(
-                audit_year__range=(audit_start.year, audit_end.year),
+                audit_year=audit_start.year,
                 submission_active=True,
                 paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
                 paediatric_diabetes_unit__active=True,

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -1,5 +1,6 @@
 from datetime import date
 from django.shortcuts import render
+from project.npda.general_functions.audit_period import audit_period_for_audit_year
 from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.views.dashboard import helpers as hp
 from project.npda.views.decorators import login_and_otp_required
@@ -13,12 +14,13 @@ def patient_measurements(request):
     pz_code = request.session.get("pz_code")
 
     selected_audit_year = int(request.session.get("selected_audit_year"))
-    if selected_audit_year <= 2024:
-        # The day after the audit year end date
-        calculation_date = date(selected_audit_year, 4, 1)
+    # This function might get called on historical cohorts, so we need to check if today's date is within the audit period
+    audit_start, audit_end = audit_period_for_audit_year(selected_audit_year)
+    if audit_start <= date.today() <= audit_end:
+        calculation_date = date.today()
     else:
-        today = date.today()
-        calculation_date = date(selected_audit_year, today.month, today.day)
+        calculation_date = audit_start
+
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
     )


### PR DESCRIPTION
### Overview
In the total diagnoses KPI2 total the date used is today. As we have moved to a new audit year this means everything defaults to quarter 1 which transfers to even historical data.

This fixes this and how calculation_date is arrived at if previous audit years are requested