### PR TITLE
fix current quarter calculation

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -1096,7 +1096,11 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        if self.calculation_date == date.today():
+            current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        else:
+            # This is for a previous audit period: we need to get the quarter for the whole year
+            current_quarter = retrieve_quarter_for_date(self.audit_end_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
 
@@ -2022,7 +2026,10 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        if self.calculation_date == date.today():
+            current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        else:
+            current_quarter = retrieve_quarter_for_date(self.audit_end_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
         for q, q_end_date in enumerate(quarter_end_dates, start=1):
@@ -3849,7 +3856,10 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        if self.calculation_date == date.today():
+            current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        else:
+            current_quarter = retrieve_quarter_for_date(self.audit_end_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
         result = {}
 

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -454,8 +454,14 @@ class CalculateKPIS:
             )
         ]
         # Only up to current quarter
-        current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        if self.calculation_date == date.today():
+            # Get the current quarter
+            current_quarter = retrieve_quarter_for_date(self.calculation_date)
+        else:
+            # This is for a previous audit period: we need to get the quarter for the whole year
+            current_quarter = retrieve_quarter_for_date(self.audit_end_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
+        
         result = {}
         eligible_patients_kpi_2 = total_kpi_1_eligible_pts_base_query_set.filter(
             diagnosis_date__range=(self.AUDIT_DATE_RANGE)


### PR DESCRIPTION
### Overview
The scatter plots per quarter rely on knowing the current quarter. If the user has selected a previous  audit year, the current quarter relates to the final quarter of that year. This fix in the KPI quarterly calculations uses the end date of the audit year if a previous audit year has been selected
