### PR TITLE
Fix privilege escalation by coordinators vulnerabilities

### DIFF
--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -221,7 +221,39 @@ def test_coordinators_cannot_change_their_role(
 
 
 @pytest.mark.django_db
-def test_coordinators_cannot_change_their_employer(
+def test_coordinators_cannot_change_their_employer_htmx(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    url = reverse("npdauser-update", kwargs={ "pk": user.pk })
+
+    response = client.post(url, data={
+        "email": user.email,
+        "first_name": user.first_name,
+        "surname": user.surname,
+        "add_employer": GOSH_PZ_CODE
+    }, **{
+        # Gated on request.htmx
+        "HTTP_HX-Request": "true",
+    })
+
+    user.refresh_from_db()
+    employers = [e.pz_code for e in user.organisation_employers.all()]
+
+    assert employers == [ALDER_HEY_PZ_CODE]
+
+
+# Not actually used in the UI but possible to construct manually
+@pytest.mark.django_db
+def test_coordinators_cannot_change_their_employer_post(
     seed_groups_fixture,
     seed_users_fixture,
     client,
@@ -237,15 +269,13 @@ def test_coordinators_cannot_change_their_employer(
 
     response = client.post(url, data={
         "add_employer": GOSH_PZ_CODE
-    }, **{
-        # Gated on request.htmx
-        "HTTP_HX-Request": "true",
     })
 
     user.refresh_from_db()
     employers = [e.pz_code for e in user.organisation_employers.all()]
 
     assert employers == [ALDER_HEY_PZ_CODE]
+
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -22,7 +22,7 @@ import pytest
 # 3rd party imports
 from django.urls import reverse
 
-from project.constants.user import RCPCH_AUDIT_TEAM
+from project.constants.user import RCPCH_AUDIT_TEAM, AUDIT_CENTRE_COORDINATOR
 # E12 imports
 from project.npda.models import NPDAUser
 from project.npda.tests.utils import login_and_verify_user
@@ -192,3 +192,82 @@ def test_npda_user_list_view_users_cannot_set_their_view_preference_to_organisat
 
     users = response.context_data["object_list"]
     check_all_users_in_pdu(ah_user, users, ALDER_HEY_PZ_CODE)
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/906
+@pytest.mark.django_db
+def test_coordinators_cannot_change_their_role(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    user = NPDAUser.objects.filter(role=AUDIT_CENTRE_COORDINATOR).first()
+    client = login_and_verify_user(client, user)
+
+    url = reverse("npdauser-update", kwargs={ "pk": user.pk })
+
+    response = client.post(url, {
+        "role": RCPCH_AUDIT_TEAM
+    })
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+    user = user.refresh_from_db()
+    assert user.role == AUDIT_CENTRE_COORDINATOR
+
+
+@pytest.mark.django_db
+def test_coordinators_cannot_change_their_employer(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, ah_user)
+
+    url = reverse("npdauser-update", kwargs={ "pk": ah_user.pk })
+
+    response = client.post(url, {
+        "add_employer": GOSH_PZ_CODE
+    })
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+    ah_user = user.refresh_from_db()
+    employers = [e.pz_code for e in ah_user.organisation_employers.all()]
+
+    assert employers == [ALDER_HEY_PZ_CODE]
+
+
+@pytest.mark.django_db
+def test_coordinators_cannot_create_users_outside_of_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    user_count_before = NPDAUser.objects.count()
+
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, ah_user)
+
+    url = reverse("npdauser-update", kwargs={ "pk": ah_user.pk })
+
+    response = client.post(url, {
+        "first_name": "Bob",
+        "last_name": "Bobertson",
+        "role": AUDIT_CENTRE_COORDINATOR,
+        "add_employer": GOSH_PZ_CODE
+    })
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+    user_count_after = NPDAUser.objects.count()
+    assert user_count_after == user_count_before

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -22,7 +22,7 @@ import pytest
 # 3rd party imports
 from django.urls import reverse
 
-from project.constants.user import RCPCH_AUDIT_TEAM, AUDIT_CENTRE_COORDINATOR
+from project.constants.user import RCPCH_AUDIT_TEAM, AUDIT_CENTRE_COORDINATOR, TRUST_AUDIT_TEAM_COORDINATOR_ACCESS
 # E12 imports
 from project.npda.models import NPDAUser
 from project.npda.tests.utils import login_and_verify_user
@@ -207,13 +207,17 @@ def test_coordinators_cannot_change_their_role(
     url = reverse("npdauser-update", kwargs={ "pk": user.pk })
 
     response = client.post(url, {
+        "email": user.email,
+        "first_name": user.first_name,
+        "surname": user.surname,
         "role": RCPCH_AUDIT_TEAM
     })
 
-    assert response.status_code == HTTPStatus.FORBIDDEN
-
-    user = user.refresh_from_db()
+    user.refresh_from_db()
     assert user.role == AUDIT_CENTRE_COORDINATOR
+    
+    assert user.groups.count() == 1
+    assert user.groups.first().name == TRUST_AUDIT_TEAM_COORDINATOR_ACCESS
 
 
 @pytest.mark.django_db
@@ -222,23 +226,27 @@ def test_coordinators_cannot_change_their_employer(
     seed_users_fixture,
     client,
 ):
-    ah_user = NPDAUser.objects.filter(
+    user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=AUDIT_CENTRE_COORDINATOR
     ).first()
 
-    client = login_and_verify_user(client, ah_user)
+    client = login_and_verify_user(client, user)
 
-    url = reverse("npdauser-update", kwargs={ "pk": ah_user.pk })
+    url = reverse("npdauser-update", kwargs={ "pk": user.pk })
 
-    response = client.post(url, {
+    response = client.post(url, data={
+        "email": user.email,
+        "first_name": user.first_name,
+        "surname": user.surname,
         "add_employer": GOSH_PZ_CODE
+    }, **{
+        # Gated on request.htmx
+        "HTTP_HX-Request": "true",
     })
 
-    assert response.status_code == HTTPStatus.FORBIDDEN
-
-    ah_user = user.refresh_from_db()
-    employers = [e.pz_code for e in ah_user.organisation_employers.all()]
+    user.refresh_from_db()
+    employers = [e.pz_code for e in user.organisation_employers.all()]
 
     assert employers == [ALDER_HEY_PZ_CODE]
 
@@ -258,16 +266,43 @@ def test_coordinators_cannot_create_users_outside_of_their_pdu(
 
     client = login_and_verify_user(client, ah_user)
 
-    url = reverse("npdauser-update", kwargs={ "pk": ah_user.pk })
+    url = reverse("npdauser-create")
 
     response = client.post(url, {
         "first_name": "Bob",
-        "last_name": "Bobertson",
+        "surname": "Bobertson",
+        "email": "bob@bobertson.com",
         "role": AUDIT_CENTRE_COORDINATOR,
         "add_employer": GOSH_PZ_CODE
     })
 
-    assert response.status_code == HTTPStatus.FORBIDDEN
+    user_count_after = NPDAUser.objects.count()
+    assert user_count_after == user_count_before
+
+
+@pytest.mark.django_db
+def test_coordinators_cannot_create_audit_team_members(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    user_count_before = NPDAUser.objects.count()
+
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, ah_user)
+
+    url = reverse("npdauser-create")
+
+    response = client.post(url, {
+        "first_name": "Bob",
+        "surname": "Bobertson",
+        "email": "bob@bobertson.com",
+        "role": RCPCH_AUDIT_TEAM,
+    })
 
     user_count_after = NPDAUser.objects.count()
     assert user_count_after == user_count_before

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -236,9 +236,6 @@ def test_coordinators_cannot_change_their_employer(
     url = reverse("npdauser-update", kwargs={ "pk": user.pk })
 
     response = client.post(url, data={
-        "email": user.email,
-        "first_name": user.first_name,
-        "surname": user.surname,
         "add_employer": GOSH_PZ_CODE
     }, **{
         # Gated on request.htmx
@@ -306,3 +303,66 @@ def test_coordinators_cannot_create_audit_team_members(
 
     user_count_after = NPDAUser.objects.count()
     assert user_count_after == user_count_before
+
+
+# These tests pass already before fixing https://github.com/rcpch/national-paediatric-diabetes-audit/issues/906
+# as handled by CheckPDUInstanceMixin but leaving them in for completeness sake.
+@pytest.mark.django_db
+def test_coordinators_cannot_delete_users_outside_of_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    user_count_before = NPDAUser.objects.count()
+
+    ah_coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    gosh_coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, ah_coordinator)
+
+    url = reverse("npdauser-delete", kwargs={ "pk": gosh_coordinator.pk })
+
+    response = client.post(url)
+
+    user_count_after = NPDAUser.objects.count()
+    assert user_count_after == user_count_before
+
+
+@pytest.mark.django_db
+def test_coordinators_cannot_add_employers_outside_of_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    client,
+):
+    ah_coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    gosh_coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, ah_coordinator)
+
+    url = reverse("npdauser-update", kwargs={ "pk": gosh_coordinator.pk })
+
+    response = client.post(url, data={
+        "add_employer": ALDER_HEY_PZ_CODE
+    }, **{
+        # Gated on request.htmx
+        "HTTP_HX-Request": "true",
+    })
+
+    gosh_coordinator.refresh_from_db()
+    employers = [e.pz_code for e in gosh_coordinator.organisation_employers.all()]
+
+    assert employers == [GOSH_PZ_CODE]

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -159,6 +159,22 @@ class NPDAUserCreateView(
     def form_valid(self, form):
         PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
 
+        new_user_pz_code = form.cleaned_data["add_employer"] or self.request.session.get("pz_code")
+
+        my_pz_codes = self.request.user.organisation_employers.values_list("pz_code", flat=True)
+
+        if new_user_pz_code not in my_pz_codes:
+            raise PermissionDenied(
+                f"You do not have permission to add users to {new_user_pz_code}. Contact the NPDA for assistance."
+            )
+        
+        new_user_pdu = PaediatricDiabetesUnit.objects.get(pz_code=new_user_pz_code)
+
+        if not new_user_pdu.active and not (self.request.user.is_rcpch_audit_team_member or self.request.user.is_superuser):
+            raise PermissionDenied(
+                f"{new_user_pz_code} is inactive. Contact the NPDA for assistance."
+            )
+
         new_user = form.save(commit=False)
         new_user.set_unusable_password()
         new_user.is_active = True
@@ -166,49 +182,15 @@ class NPDAUserCreateView(
         new_user.view_preference = 1  # PDU level view preference
         new_user.save()
 
-        # add the user to the appropriate organisation
-        new_employer_pz_code = form.cleaned_data["add_employer"]
-        if new_employer_pz_code:
-            # a new employer has been added
-            pdu = PaediatricDiabetesUnit.objects.get(pz_code=new_employer_pz_code, active=True)
-            OrganisationEmployer.objects.create(
-                paediatric_diabetes_unit=pdu,
-                npda_user=new_user,
-                is_primary_employer=True,
-            )
-            new_user.refresh_from_db()
-        else:
-            # create the new users using the pz_code stored in the session
-            OrganisationEmployer.objects.create(
-                paediatric_diabetes_unit=PaediatricDiabetesUnit.objects.get(
-                    pz_code=self.request.session.get("pz_code")
-                ),
-                npda_user=new_user,
-                is_primary_employer=True,
-            )
-        try:
-            new_user.save()
-        except Exception as error:
-            messages.error(
-                self.request,
-                f"Error: {error}. Account not created. Please contact the NPDA team if this issue persists.",
-            )
-            return redirect(
-                "npda_users",
-            )
+        OrganisationEmployer.objects.create(
+            paediatric_diabetes_unit=new_user_pdu,
+            npda_user=new_user,
+            is_primary_employer=True,
+        )
 
         # add the user to the appropriate group
         new_group = group_for_role(new_user.role)
-        try:
-            new_user.groups.add(new_group)
-        except Exception as error:
-            messages.error(
-                self.request,
-                f"Error: {error}. Account not created. Please contact NPDA team if this issue persists.",
-            )
-            return redirect(
-                "npda_users",
-            )
+        new_user.groups.add(new_group)
 
         # user created - send email with reset link to new user
         subject = "Password Reset Requested"
@@ -282,7 +264,7 @@ class NPDAUserUpdateView(
             .order_by("-is_primary_employer")
         )
         return context
-    
+
     def form_valid(self, form):
         if not self.request.user.has_perm("npda.change_npdauser"):
                 raise PermissionDenied(
@@ -340,11 +322,23 @@ class NPDAUserUpdateView(
                 # add the user to the appropriate organisation
                 new_employer_pz_code = request.POST.get("add_employer")
                 if new_employer_pz_code:
+                    my_pz_codes = self.request.user.organisation_employers.values_list("pz_code", flat=True)
+
+                    if new_employer_pz_code not in my_pz_codes:
+                        raise PermissionDenied(
+                            f"You do not have permission to add users to {new_employer_pz_code}. Contact the NPDA for assistance."
+                        )
+
                     # a new employer has been added
-                    # fetch the object from the API using the PZ code
                     selected_pdu = PaediatricDiabetesUnit.objects.get(
                         pz_code=new_employer_pz_code
                     )
+
+                    if not selected_pdu.active and not (self.request.user.is_rcpch_audit_team_member or self.request.user.is_superuser):
+                        raise PermissionDenied(
+                            f"{new_user_pz_code} is inactive. Contact the NPDA for assistance."
+                        )
+
                     OrganisationEmployer.objects.update_or_create(
                         paediatric_diabetes_unit=selected_pdu,
                         npda_user=selected_npda_user,

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -38,6 +38,7 @@ from ..general_functions import (
 )
 from .mixins import CheckPDUInstanceMixin, CheckPDUListMixin, LoginAndOTPRequiredMixin
 from .mixins import LoginAndOTPRequiredMixin
+from ...constants import RCPCH_AUDIT_TEAM
 
 # from ..signals import password_reset_sent
 
@@ -174,6 +175,11 @@ class NPDAUserCreateView(
             raise PermissionDenied(
                 f"{new_user_pz_code} is inactive. Contact the NPDA for assistance."
             )
+        
+        if form.cleaned_data["role"] == RCPCH_AUDIT_TEAM and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+            raise PermissionDenied(
+                "You do not have permission to add a user with RCPCH Audit Team role."
+            )
 
         new_user = form.save(commit=False)
         new_user.set_unusable_password()
@@ -267,9 +273,15 @@ class NPDAUserUpdateView(
 
     def form_valid(self, form):
         if not self.request.user.has_perm("npda.change_npdauser"):
-                raise PermissionDenied(
-                    "You do not have permission to edit this user. Contact the NPDA for assistance."
-                )
+            raise PermissionDenied(
+                "You do not have permission to edit this user. Contact the NPDA for assistance."
+            )
+        
+        if form.cleaned_data["role"] == RCPCH_AUDIT_TEAM and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+            raise PermissionDenied(
+                "You do not have permission to add a user with RCPCH Audit Team role."
+            )
+        
         user = form.save(commit=True)
         # remove all groups and add the user to the right group
         user.groups.clear()


### PR DESCRIPTION
Fixes #906 

By constructing a malicious POST request using a logged in Coordinator session, an attacker could privilege escalate and grant themselves audit team access (role=4) or create new users with audit team access. A similar attack could be done per employer.

This PR fixes this by checking the PDUs a coordinator is attached to before updating users.