### PR TITLE
Update auto-add-issues-to-project.yml - move new issues into Triage

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yml
+++ b/.github/workflows/auto-add-issues-to-project.yml
@@ -7,10 +7,12 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue or PR to project automatically
+    name: Add issue to project and column
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:
-          project-url: https://github.com/orgs/rcpch/projects/13 #NPDA Project
+          project-url: https://github.com/orgs/rcpch/projects/13
           github-token: ${{ secrets.AUTO_ADD_TO_PROJECT_TOKEN }}
+          fields: |
+            Status: Triage


### PR DESCRIPTION
Move new issues specifically into the Triage lane in the project board