### PR TITLE
Fix crash on reset password link for deleted user

### DIFF
--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -122,12 +122,14 @@ class NPDAUpdatePasswordForm(SetPasswordForm):
 
     def __init__(self, user, *args, **kwargs):
         self.user = user
-        if (
-            self.user.is_rcpch_audit_team_member
-            or self.user.is_superuser
-            or self.user.is_rcpch_staff
-        ):
-            self.is_admin = True
+
+        if user:
+            self.is_admin = (
+                user.is_rcpch_audit_team_member
+                or user.is_superuser
+                or user.is_rcpch_staff
+            )
+        
         super(SetPasswordForm, self).__init__(*args, **kwargs)
 
     def clean(self) -> dict[str]:


### PR DESCRIPTION
The way Django works is `MjM4` in the reset URL is the base64 encoded user pk. When you decode it it's 238 and that user indeed does not exist in the platform any more.

```Internal Server Error: /account/password-reset-confirm/MjM4/set-password

AttributeError at /account/password-reset-confirm/MjM4/set-password
'NoneType' object has no attribute 'is_rcpch_audit_team_member'

Request Method: GET
Request URL: http://npda.rcpch.ac.uk/account/password-reset-confirm/MjM4/set-password

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/decorators/debug.py", line 143, in sensitive_post_parameters_wrapper
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/decorators.py", line 48, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/decorators/cache.py", line 80, in _view_wrapper
    response = view_func(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/contrib/auth/views.py", line 298, in dispatch
    return self.render_to_response(self.get_context_data())
                                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/contrib/auth/views.py", line 329, in get_context_data
    context = super().get_context_data(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/contrib/auth/views.py", line 207, in get_context_data
    context = super().get_context_data(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/generic/edit.py", line 72, in get_context_data
    kwargs["form"] = self.get_form()
                     ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/views/generic/edit.py", line 37, in get_form
    return form_class(**self.get_form_kwargs())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/project/npda/forms/npda_user_form.py", line 118, in __init__
    self.user.is_rcpch_audit_team_member
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Exception Type: AttributeError at /account/password-reset-confirm/MjM4/set-password
Exception Value: 'NoneType' object has no attribute 'is_rcpch_audit_team_member'
Raised during: django.contrib.auth.views.PasswordResetConfirmView
Request information:
USER: AnonymousUser
```