### PR TITLE
buttons are disabled for readers

### DIFF
--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -15,7 +15,7 @@
               {% jersify pz_code field as viewable %}
               {% if viewable %}
                 <label for="{{ field.id_for_label }}"
-                       class="block text-gray-700 font-bold md:text-right mb-1 md:mb-0 pr-4 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}pointer-events-none{% endif %}">
+                       class="block text-gray-700 font-bold md:text-right mb-1 md:mb-0 pr-4 {% if not perms.npda.change_patient or not can_use_questionnaire %}pointer-events-none{% endif %}">
                   <small>{{ field.label }}</small>
                 </label>
               {% endif %}
@@ -24,7 +24,7 @@
               {% if field.field.widget|is_select and field.id_for_label != 'id_reason_leaving_service' %}
                 <select id="{{ field.id_for_label }}"
                         name="{{ field.html_name }}"
-                        class="select rcpch-select {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
+                        class="select rcpch-select {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
                   {% for choice in field.field.choices %}
                     <option value="{{ choice.0 }}"
                             {% if field.value|stringformat:'s' == choice.0|stringformat:'s' %} selected="true" {% endif %}>
@@ -41,7 +41,7 @@
                   {% endif %}
                   <input id="{{ field.id_for_label }}"
                          name="{{ field.html_name }}"
-                         class="input rcpch-input-text {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}"
+                         class="input rcpch-input-text {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}"
                          {% if field.field.widget|is_dateinput %} type="date" {% else %} type="text" {% endif %}
                          {% if field.value %}value="{{ field.value|stringformat:'s' }}"{% endif %}>
                 {% endif %}
@@ -68,7 +68,7 @@
         <div class="collapse-content">
           <select id="{{ form.reason_leaving_service.id_for_label }}"
                   name="{{ form.reason_leaving_service.html_name }}"
-                  class="select rcpch-select mb-2 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
+                  class="select rcpch-select mb-2 {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
             <option value="">Select a reason</option>
             {% for choice in form.reason_leaving_service.field.choices %}
               <option value={{ choice.0 }} {% if form.reason_leaving_service.value == choice.0 %} selected="true" {% endif %}>
@@ -89,7 +89,7 @@
           {% endfor %}
           <input id="{{ form.date_leaving_service.id_for_label }}"
                  name="{{ form.date_leaving_service.html_name }}"
-                 class="input rcpch-input-text mb-2 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}"
+                 class="input rcpch-input-text mb-2 {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}"
                  type="date"
                  {% if form.date_leaving_service.value %}value="{{ form.date_leaving_service.value|stringformat:'s' }}"{% endif %}>
           {% for error in form.date_leaving_service.errors %}
@@ -112,14 +112,14 @@
         <button type="submit"
                 value="submit"
                 name="action"
-                class="btn rcpch-light-blue-btn {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
+                class="btn rcpch-light-blue-btn {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
           {{ button_title }}
         </button>
         {% if form_method == 'update' and perms.npda.delete_patient %}
           <button type="submit"
                   value="delete"
                   name="delete"
-                  class="btn rcpch-danger-btn {% if not can_alter_this_audit_year_submission or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
+                  class="btn rcpch-danger-btn {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
             Delete
           </button>
         {% endif %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -21,7 +21,7 @@
             <div class="md:flex md:items-center mb-6 mt-2 {% if background_colour %}bg-{{ background_colour }}{% endif %}">
               <div class="md:w-1/3">
                 <label for="{{ field.id_for_label }}"
-                       class="block text-gray-700 {% if field.errors %}text-rcpch_red{% endif %} font-bold md:text-right mb-1 md:mb-0 pr-4 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} pointer-events-none {% endif %}">
+                       class="block text-gray-700 {% if field.errors %}text-rcpch_red{% endif %} font-bold md:text-right mb-1 md:mb-0 pr-4 {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} pointer-events-none {% endif %}">
                   {% if field.errors %}
                     <span class="fa-stack text-rcpch_red">
                       <i class="fa-circle fa-stack-1x fas"></i>
@@ -36,10 +36,10 @@
                   <div class="indicator">
                     <span class="indicator-item badge badge-lg bg-rcpch_pink text-white ">Required</span>
                   </div>
-                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} opacity-40 pointer-events-none {% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
+                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} opacity-40 pointer-events-none {% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
                   <button type='button'
                           _="on click set #{{ field.id_for_label }}'s value to '{% today_date %}'"
-                          class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not can_alter_this_audit_year_submission or not can_use_questionnaire  or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
+                          class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire  or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
                     Today
                   </button>
                 {% endif %}
@@ -62,13 +62,13 @@
         <div class="flex justify-end">
           <button type="submit"
                   value="Submit"
-                  class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
+                  class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
             {{ button_title }}
           </button>
           <a class="btn rcpch-btn bg-rcpch_yellow_light_tint1 border border-rcpch_yellow_light_tint1 hover:bg-rcpch_yellow hover:border-rcpch_yellow"
              href="{% url 'patient_visits' patient_id=patient_id %}">Cancel</a>
           {% if form_method == 'update' and perms.npda.delete_visit %}
-            <a class="btn rcpch-btn bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}"
+            <a class="btn rcpch-btn bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}"
                href="{% url 'visit-delete' patient_id visit.pk %}">Delete</a>
           {% endif %}
         </div>

--- a/project/npda/templates/partials/page_elements/patient_table_actions.html
+++ b/project/npda/templates/partials/page_elements/patient_table_actions.html
@@ -43,7 +43,7 @@
     {% if user.view_preference != 2 %}
         {% if can_complete_questionnaire %}
             <a href="{% url 'patient-add' %}"
-               class="btn btn-info h-auto w-full md:w-auto {% if not can_alter_this_audit_year_submission %}btn-disabled{% endif %}">
+               class="btn btn-info h-auto w-full md:w-auto {% if not perms.npda.add_patient %}btn-disabled{% endif %}">
                 <i class="fa-solid fa-person-circle-plus"></i>
                 Add patient
             </a>

--- a/project/npda/templates/partials/patient_table.html
+++ b/project/npda/templates/partials/patient_table.html
@@ -234,7 +234,7 @@
         {% endif %}
       </h1>
       <i class="fa-solid fa-hand-sparkles text-5xl text-rcpch_light_blue opacity-0 animate-sparkle mt-2"></i>
-      {% if can_alter_this_audit_year_submission %}
+      {% if perms.npda.add_patient %}
         <div class="py-6">
           {% if request.session.can_complete_questionnaire %}
             <a href="{% url 'patient-add' %}"

--- a/project/npda/templates/partials/visit_form_tab.html
+++ b/project/npda/templates/partials/visit_form_tab.html
@@ -40,7 +40,7 @@
                 {% if field.id_for_label != 'id_bmi' or field.id_for_label == 'id_bmi' and field.value is not None %}
                   <!-- Hide BMI label if no value -->
                   <label for="{{ field.id_for_label }}"
-                         class="block {% if errors %} text-rcpch_red {% else %} text-gray-700 {% endif %} font-bold mb-1 md:mb-0 pr-4 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} pointer-events-none {% endif %}">
+                         class="block {% if errors %} text-rcpch_red {% else %} text-gray-700 {% endif %} font-bold mb-1 md:mb-0 pr-4 {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} pointer-events-none {% endif %}">
                     <small>
                       {% if errors %}
                         <span class="fa-stack text-rcpch_red">
@@ -68,7 +68,7 @@
                 {% if field.field.widget|is_select %}
                   <select id="{{ field.id_for_label }}"
                           name="{{ field.html_name }}"
-                          class="select rcpch-select rounded-none {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
+                          class="select rcpch-select rounded-none {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
                     {% for choice in field.field.choices %}
                       <option value="{{ choice.0 }}"
                               {% if field.value|stringformat:'s' == choice.0|stringformat:'s' %} selected="{{ field.value }}" {% endif %}
@@ -78,28 +78,28 @@
                     {% endfor %}
                   </select>
                 {% elif field.field.widget|is_dateinput %}
-                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text flex-grow basis-2/3 {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
+                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text flex-grow basis-2/3 {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
                   <div class="basis-1/3 flex">
                     <button type='button'
                             _="on click set #{{ field.id_for_label }}'s value to '{% today_date %}'"
-                            class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
+                            class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
                       Today
                     </button>
                     <button type='button'
                             _="on click set #{{ field.id_for_label }}'s value to #id_visit_date.value"
-                            class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
+                            class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">
                       Fill with Visit Date
                     </button>
                   </div>
                 {% elif field.field.widget|is_textarea %}
                   <textarea id="{{ field.id_for_label }}"
                             name="{{ field.html_name }}"
-                            class="input rcpch-input-text rounded-none {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}"
+                            class="input rcpch-input-text rounded-none {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}"
                             {% if field.field.required %}placeholder="Required"{% endif %}>{{ field.value }}</textarea>
                 {% else %}
                   {% if field.id_for_label != 'id_bmi' or field.id_for_label == 'id_bmi' and field.value is not None %}
                     <!-- Hide BMI label if no value -->
-                    <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none {% if not can_alter_this_audit_year_submission or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year or field.id_for_label == 'id_bmi' %}opacity-40 pointer-events-none{% endif %}" {% if field.field.required %}placeholder="Required"{% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
+                    <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year or field.id_for_label == 'id_bmi' %}opacity-40 pointer-events-none{% endif %}" {% if field.field.required %}placeholder="Required"{% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
                     {% if field.value is not None %}
                       {% with field|centile_for_field:'centile' as centile %}
                         {% if centile %}

--- a/project/npda/templates/patients.html
+++ b/project/npda/templates/patients.html
@@ -33,7 +33,8 @@
                 We recommend this method if you already have a system that can export in that format or are building one.
               </p>
               <div class="card-actions justify-end">
-                <a href="{% url 'upload_csv' %}"  class="btn btn-info">Select</a>
+                <a href="{% url 'upload_csv' %}"
+                   class="btn btn-info {% if not perms.npda.can_submit_csv %}btn-disabled{% endif %}">Select</a>
               </div>
             </div>
           </div>
@@ -46,7 +47,8 @@
                 Use this method if you don't have an electronic patient record or you can't export from it in our CSV format.
               </p>
               <div class="card-actions justify-end">
-                <a href="{% url 'patient-add' %}" class="btn btn-info">Select</a>
+                <a href="{% url 'patient-add' %}"
+                   class="btn btn-info {% if not perms.npda.can_submit_csv %}btn-disabled{% endif %}">Select</a>
               </div>
             </div>
           </div>

--- a/project/npda/templates/visits.html
+++ b/project/npda/templates/visits.html
@@ -98,11 +98,11 @@
                       {% nhs_number_vs_urn pz_code patient %} (NPDA ID {{ patient.pk }}) has no visits yet...
                     </h1>
                     <i class="fa-solid fa-hand-sparkles text-5xl text-rcpch_light_blue opacity-0 animate-sparkle mt-2"></i>
-                    {% if can_alter_this_audit_year_submission %}
+                    {% if perms.npda.add_visit %}
                       <div class="py-6">
                         {% if request.session.can_complete_questionnaire %}
                           <a href="{% url 'visit-create' patient_id=patient.pk %}"
-                             class="btn btn-info h-auto w-full md:w-auto">
+                             class="btn btn-info h-auto w-full md:w-auto {% if not perms.npda.add_visit %}btn-disabled{% endif %}">
                             <i class="fa-solid fa-person-circle-plus"></i>
                             Add visit
                           </a>
@@ -118,19 +118,19 @@
             {% endif %}
             <div>
               {% if perms.npda.add_visit %}
-                  {% if can_use_questionnaire %}
-                    <a href="{% url 'visit-create' patient_id=patient.pk %}{% if data_upload_rules_overridden %}?unlock=true{% endif %}"
-                      class="bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 font-semibold text-white border hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white">
-                      Create New Visit
-                    </a>
-                  {% else %}
-                    <span class="bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 font-semibold text-white border opacity-40 pointer-events-none hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white">
-                      Create New Visit
-                    </span>
-                  {% endif %}
+                {% if can_use_questionnaire %}
+                  <a href="{% url 'visit-create' patient_id=patient.pk %}{% if data_upload_rules_overridden %}?unlock=true{% endif %}"
+                     class="btn bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 font-semibold text-white border hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white {% if not perms.npda.add_visit %}btn-disabled{% endif %}">
+                    Create New Visit
+                  </a>
+                {% else %}
+                  <span class="btn bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 font-semibold text-white border opacity-40 pointer-events-none hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white {% if not perms.npda.add_visit %}btn-disabled{% endif %}">
+                    Create New Visit
+                  </span>
+                {% endif %}
               {% endif %}
               <a href="{% url 'patients' %}"
-                class="bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 ml-3 font-semibold text-white border hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white">Back to Patient List</a>
+                 class="bg-rcpch_light_blue border-rcpch_light_blue px-3 py-2.5 mt-40 ml-3 font-semibold text-white border hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue hover:text-white]">Back to Patient List</a>
             </div>
             <div class="py-20">
               {% include 'partials/visit_list_tips.html' with pz_code=pz_code patient=patient %}


### PR DESCRIPTION
Fixes #897

### Overview
The permissions to add or change visit or patient records were not properly applied in the templates, exposing buttons to users without permissions. This was not a serious problem, since they could not access the endpoints, but there was an unfriendly 403. By applying the permissions in the templates, now the buttons are disabled for readers.
