### PR TITLE
Redis/Celery settings for Azure

### DIFF
--- a/project/celery.py
+++ b/project/celery.py
@@ -6,6 +6,8 @@ from celery import Task
 from django.conf import settings
 import django
 
+from azure.identity import DefaultAzureCredential
+
 # Logging setup
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,22 @@ app.conf.update(
         "global_keyprefix": "{rest}:"
     }
 )
+
+def get_redis_token():
+    credential = DefaultAzureCredential()
+    redis_resource_id = "https://redis.azure.com"
+    token_object = credential.get_token(redis_resource_id)
+    return token_object.token
+
+broker_host = os.environ.get("REDIS_HOST")
+broker_port = os.environ.get("REDIS_PORT", 6379)
+broker_password = get_redis_token()
+broker_username = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
+
+broker_url = f"redis://{broker_username}:{broker_password}@{broker_host}:{broker_port}/0"
+
+CELERY_BROKER_URL = broker_url
+CELERY_RESULT_BACKEND = broker_url # If using Redis as result backend
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/project/celery.py
+++ b/project/celery.py
@@ -22,30 +22,26 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 broker_url = os.environ.get('CELERY_BROKER_URL')
 result_backend = os.environ.get('CELERY_RESULT_BACKEND')
 
-
-REDIS_HOST = os.environ.get('REDIS_HOST')  # Your Redis hostname (e.g., <your-cache>.redis.cache.windows.net)
-REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
-REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')  # Your Redis password
 # Local development Redis configuration
-# Default Redis configuration for local development
+REDIS_HOSTNAME = os.environ.get('REDIS_HOSTNAME')  
+REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
+REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')  
 
-broker_url = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/0"
-result_backend = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/1"
+broker_url = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOSTNAME}:{REDIS_PORT}/0"
+result_backend = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOSTNAME}:{REDIS_PORT}/1"
 
-# Conditional configuration for Azure environment
+
 # Conditional configuration for Azure environment
 if "AZURE_CONTAINER_ENVIRONMENT" in os.environ:
-    REDIS_HOST_AZURE = os.environ.get('REDIS_HOST_AZURE')  # Azure-specific host
-    REDIS_PORT_AZURE = os.environ.get('REDIS_PORT_AZURE', '6379') # Azure-specific port
-    REDIS_PASSWORD_AZURE = None
+    REDIS_PASSWORD = None # Set to None as we will use Azure AD token
 
     credential = DefaultAzureCredential()
 
     try:
         token = credential.get_token("https://redis.azure.com/.default")
-        REDIS_PASSWORD_AZURE = token.secret
-        broker_url = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/0"
-        result_backend = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/1"
+        REDIS_PASSWORD = token.secret
+        broker_url = f"redis://:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/0"
+        result_backend = f"redis://:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/1"
         app.conf.update(
             broker_transport_options={
                 "global_keyprefix": "{queue}:"

--- a/project/celery.py
+++ b/project/celery.py
@@ -18,51 +18,51 @@ app = Celery("project")
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-# app.conf.update(
-#     # Hacks to work around the lack of built in support for Redis cluster.
-#     # We don't use a cluster directly but Azure Managed Redis acts like one.
-#     # https://github.com/celery/celery/issues/8276#issuecomment-2082176893
-#     broker_transport_options={
-#         "global_keyprefix": "{queue}:"
-#     },
-#     result_backend_transport_options={
-#         "global_keyprefix": "{rest}:"
-#     }
-# )
+# Default Redis configuration for local development
+broker_url = os.environ.get('CELERY_BROKER_URL')
+result_backend = os.environ.get('CELERY_RESULT_BACKEND')
 
-# def get_redis_token():
-#     credential = DefaultAzureCredential()
-#     redis_resource_id = "https://redis.azure.com"
-#     token_object = credential.get_token(redis_resource_id)
-#     return token_object.token
-
-# broker_host = os.environ.get("REDIS_HOST")
-# broker_port = os.environ.get("REDIS_PORT", 6379)
-# broker_password = get_redis_token()
-# broker_username = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
-
-# broker_url = f"redis://{broker_username}:{broker_password}@{broker_host}:{broker_port}/0"
-
-# CELERY_BROKER_URL = broker_url
-# CELERY_RESULT_BACKEND = broker_url # If using Redis as result backend
 
 REDIS_HOST = os.environ.get('REDIS_HOST')  # Your Redis hostname (e.g., <your-cache>.redis.cache.windows.net)
 REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
-REDIS_PASSWORD = None  # We will obtain this dynamically
+REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')  # Your Redis password
+# Local development Redis configuration
+# Default Redis configuration for local development
 
-credential = DefaultAzureCredential()
+broker_url = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/0"
+result_backend = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/1"
 
-try:
-    token = credential.get_token("https://redis.azure.com/.default")
-    REDIS_PASSWORD = token.secret
-except Exception as e:
-    print(f"Error getting Azure AD token for Redis: {e}")
-    # Handle the error appropriately, maybe fall back to a different configuration
-    pass
+# Conditional configuration for Azure environment
+# Conditional configuration for Azure environment
+if "AZURE_CONTAINER_ENVIRONMENT" in os.environ:
+    REDIS_HOST_AZURE = os.environ.get('REDIS_HOST_AZURE')  # Azure-specific host
+    REDIS_PORT_AZURE = os.environ.get('REDIS_PORT_AZURE', '6379') # Azure-specific port
+    REDIS_PASSWORD_AZURE = None
 
-broker_url = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/0"
-result_backend = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"
+    credential = DefaultAzureCredential()
 
+    try:
+        token = credential.get_token("https://redis.azure.com/.default")
+        REDIS_PASSWORD_AZURE = token.secret
+        broker_url = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/0"
+        result_backend = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/1"
+        app.conf.update(
+            broker_transport_options={
+                "global_keyprefix": "{queue}:"
+            },
+            result_backend_transport_options={
+                "global_keyprefix": "{rest}:"
+            }
+        )
+    except Exception as e:
+        print(f"Error getting Azure AD token for Redis: {e}")
+        # Consider a fallback mechanism or raising an exception
+        pass
+
+app.conf.broker_url = broker_url
+app.conf.result_backend = result_backend
+
+# Tasks start here
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/project/celery.py
+++ b/project/celery.py
@@ -18,33 +18,51 @@ app = Celery("project")
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
-app.conf.update(
-    # Hacks to work around the lack of built in support for Redis cluster.
-    # We don't use a cluster directly but Azure Managed Redis acts like one.
-    # https://github.com/celery/celery/issues/8276#issuecomment-2082176893
-    broker_transport_options={
-        "global_keyprefix": "{queue}:"
-    },
-    result_backend_transport_options={
-        "global_keyprefix": "{rest}:"
-    }
-)
+# app.conf.update(
+#     # Hacks to work around the lack of built in support for Redis cluster.
+#     # We don't use a cluster directly but Azure Managed Redis acts like one.
+#     # https://github.com/celery/celery/issues/8276#issuecomment-2082176893
+#     broker_transport_options={
+#         "global_keyprefix": "{queue}:"
+#     },
+#     result_backend_transport_options={
+#         "global_keyprefix": "{rest}:"
+#     }
+# )
 
-def get_redis_token():
-    credential = DefaultAzureCredential()
-    redis_resource_id = "https://redis.azure.com"
-    token_object = credential.get_token(redis_resource_id)
-    return token_object.token
+# def get_redis_token():
+#     credential = DefaultAzureCredential()
+#     redis_resource_id = "https://redis.azure.com"
+#     token_object = credential.get_token(redis_resource_id)
+#     return token_object.token
 
-broker_host = os.environ.get("REDIS_HOST")
-broker_port = os.environ.get("REDIS_PORT", 6379)
-broker_password = get_redis_token()
-broker_username = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
+# broker_host = os.environ.get("REDIS_HOST")
+# broker_port = os.environ.get("REDIS_PORT", 6379)
+# broker_password = get_redis_token()
+# broker_username = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
 
-broker_url = f"redis://{broker_username}:{broker_password}@{broker_host}:{broker_port}/0"
+# broker_url = f"redis://{broker_username}:{broker_password}@{broker_host}:{broker_port}/0"
 
-CELERY_BROKER_URL = broker_url
-CELERY_RESULT_BACKEND = broker_url # If using Redis as result backend
+# CELERY_BROKER_URL = broker_url
+# CELERY_RESULT_BACKEND = broker_url # If using Redis as result backend
+
+REDIS_HOST = os.environ.get('REDIS_HOST')  # Your Redis hostname (e.g., <your-cache>.redis.cache.windows.net)
+REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
+REDIS_PASSWORD = None  # We will obtain this dynamically
+
+credential = DefaultAzureCredential()
+
+try:
+    token = credential.get_token("https://redis.azure.com/.default")
+    REDIS_PASSWORD = token.secret
+except Exception as e:
+    print(f"Error getting Azure AD token for Redis: {e}")
+    # Handle the error appropriately, maybe fall back to a different configuration
+    pass
+
+broker_url = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/0"
+result_backend = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"
+
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -16,6 +16,7 @@ import os
 import logging
 
 from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
 
 #  django imports
 from django.core.management.utils import get_random_secret_key
@@ -358,3 +359,15 @@ redis_params = f"?ssl_cert_reqs=required" if REDIS_USE_SSL else ""
 CELERY_BROKER_URL = f"{redis_protocol}://{redis_auth}{REDIS_HOSTNAME}:{REDIS_PORT}/{REDIS_DATABASE_NUMBER}{redis_params}"
 
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+
+def get_redis_token():
+    credential = DefaultAzureCredential()
+    redis_resource_id = os.environ.get("MANAGED_IDENTITY_OBJECT_ID")  # The resource ID for Azure Redis
+    token_object = credential.get_token(redis_resource_id)
+    return token_object.token
+
+if DEBUG is False:
+    REDIS_PASSWORD = get_redis_token()
+    REDIS_USERNAME = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
+
+    REDIS_URL = f"redis://{REDIS_USERNAME}:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/0"

--- a/project/settings.py
+++ b/project/settings.py
@@ -346,35 +346,33 @@ USE_I18N = True
 USE_TZ = True
 
 # Default Redis configuration (for local development)
-REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+REDIS_HOSTNAME = os.environ.get('REDIS_HOSTNAME', 'localhost')
 REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
 REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')
 
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/2",
+        "LOCATION": f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOSTNAME}:{REDIS_PORT}/2",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }
     }
 }
 
-CELERY_RESULT_BACKEND = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/1"
+CELERY_RESULT_BACKEND = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOSTNAME}:{REDIS_PORT}/1"
 
 # Conditional configuration for Azure environment
 if "AZURE_CONTAINER_ENVIRONMENT" in os.environ:
-    REDIS_HOST_AZURE = os.environ.get('REDIS_HOST_AZURE') 
-    REDIS_PORT_AZURE = os.environ.get('REDIS_PORT_AZURE', '6379')
-    REDIS_PASSWORD_AZURE = None
+    REDIS_PASSWORD = None # set to None as we will get it from Azure AD
 
     credential = DefaultAzureCredential()
 
     try:
         token = credential.get_token("https://redis.azure.com/.default")
-        REDIS_PASSWORD_AZURE = token.secret
-        CACHES["default"]["LOCATION"] = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/2"
-        CELERY_RESULT_BACKEND = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/1"
+        REDIS_PASSWORD = token.secret
+        CACHES["default"]["LOCATION"] = f"redis://:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/2"
+        CELERY_RESULT_BACKEND = f"redis://:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/1"
     except Exception as e:
         logger.error(f"Error getting Azure AD token for Redis in Django: {e}")
         pass

--- a/project/settings.py
+++ b/project/settings.py
@@ -345,28 +345,36 @@ USE_I18N = True
 
 USE_TZ = True
 
-REDIS_HOST = os.environ.get('REDIS_HOST')
+# Default Redis configuration (for local development)
+REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
 REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
-REDIS_PASSWORD = None
-
-credential = DefaultAzureCredential()
-
-try:
-    token = credential.get_token("https://redis.azure.com/.default")
-    REDIS_PASSWORD = token.secret
-except Exception as e:
-    print(f"Error getting Azure AD token for Redis in Django: {e}")
-    # Handle the error appropriately
-    pass
+REDIS_PASSWORD = os.environ.get('REDIS_PASSWORD')
 
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/2",
+        "LOCATION": f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/2",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }
     }
 }
 
-CELERY_RESULT_BACKEND = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"
+CELERY_RESULT_BACKEND = f"redis://{':' + REDIS_PASSWORD + '@' if REDIS_PASSWORD else ''}{REDIS_HOST}:{REDIS_PORT}/1"
+
+# Conditional configuration for Azure environment
+if "AZURE_CONTAINER_ENVIRONMENT" in os.environ:
+    REDIS_HOST_AZURE = os.environ.get('REDIS_HOST_AZURE') 
+    REDIS_PORT_AZURE = os.environ.get('REDIS_PORT_AZURE', '6379')
+    REDIS_PASSWORD_AZURE = None
+
+    credential = DefaultAzureCredential()
+
+    try:
+        token = credential.get_token("https://redis.azure.com/.default")
+        REDIS_PASSWORD_AZURE = token.secret
+        CACHES["default"]["LOCATION"] = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/2"
+        CELERY_RESULT_BACKEND = f"redis://:{REDIS_PASSWORD_AZURE}@{REDIS_HOST_AZURE}:{REDIS_PORT_AZURE}/1"
+    except Exception as e:
+        logger.error(f"Error getting Azure AD token for Redis in Django: {e}")
+        pass

--- a/project/settings.py
+++ b/project/settings.py
@@ -345,29 +345,28 @@ USE_I18N = True
 
 USE_TZ = True
 
-REDIS_HOSTNAME = os.getenv("REDIS_HOSTNAME")
-REDIS_PORT = os.getenv("REDIS_PORT")
-REDIS_DATABASE_NUMBER = os.getenv("REDIS_DATABASE_NUMBER")
-REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
+REDIS_HOST = os.environ.get('REDIS_HOST')
+REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
+REDIS_PASSWORD = None
 
-REDIS_USE_SSL = os.environ.get("REDIS_USE_SSL")
+credential = DefaultAzureCredential()
 
-redis_protocol = 'rediss' if REDIS_USE_SSL else 'redis'
-redis_auth = f":{REDIS_PASSWORD}@" if REDIS_PASSWORD else ""
-redis_params = f"?ssl_cert_reqs=required" if REDIS_USE_SSL else ""
+try:
+    token = credential.get_token("https://redis.azure.com/.default")
+    REDIS_PASSWORD = token.secret
+except Exception as e:
+    print(f"Error getting Azure AD token for Redis in Django: {e}")
+    # Handle the error appropriately
+    pass
 
-CELERY_BROKER_URL = f"{redis_protocol}://{redis_auth}{REDIS_HOSTNAME}:{REDIS_PORT}/{REDIS_DATABASE_NUMBER}{redis_params}"
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/2",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    }
+}
 
-CELERY_RESULT_BACKEND = CELERY_BROKER_URL
-
-def get_redis_token():
-    credential = DefaultAzureCredential()
-    redis_resource_id = os.environ.get("MANAGED_IDENTITY_OBJECT_ID")  # The resource ID for Azure Redis
-    token_object = credential.get_token(redis_resource_id)
-    return token_object.token
-
-if DEBUG is False:
-    REDIS_PASSWORD = get_redis_token()
-    REDIS_USERNAME = os.environ.get("MANAGED_IDENTITY_OBJECT_ID") # Set this as an environment variable
-
-    REDIS_URL = f"redis://{REDIS_USERNAME}:{REDIS_PASSWORD}@{REDIS_HOSTNAME}:{REDIS_PORT}/0"
+CELERY_RESULT_BACKEND = f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/1"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,8 @@ openpyxl==3.1.5
 psycopg2-binary==2.9.9
 whitenoise==6.6.0
 python-dotenv==1.0.1
-azure-identity==1.17.1
+# Azure identify
+azure-identity==1.21.0
 
 # We don't use this but django-two-factor-auth requires it
 # They are working to make it optional https://github.com/jazzband/django-two-factor-auth/issues/469

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -42,6 +42,7 @@ gunicorn>=22.0.0
 celery==5.4.0
 flower==2.0.1
 redis==5.2.1
+django-redis==5.4.0
 
 # Automatically reloading Celery on file changes
 watchdog==6.0.0


### PR DESCRIPTION
### Overview
This adds function for the django app and the celery instance to authenticate (and communicate) with azure redis

changes:
1. Adds a `CACHES` redis backend to `settings.py`
2. pulls `REDIS_HOSTNAME`, `REDIS_PORT` from `.env` locally if running locally. If `AZURE_CONTAINER_ENVIRONMENT` is present in the environment (as is default in Azure), instead the variables are set from the azure config. The password is pulled from the azure credential library
3. A similar set up in `celery.py` but includes a workaround as redis instances in azure often work like clusters (for internal sharding and so on) and setting a global key prefix allows celery redis broker operations to be handled together within azure.
4. adds django-redis to `requirements.txt` as a dependency to handle serialization/deserialization from celery to redis and back

For this to work
1. make sure that your local .env has `REDIS_HOSTNAME`, `REDIS_PASSWORD` and `REDIS_PORT` are present. Note the this has changed from `REDIS_HOST`
2. On deployment this will deploy presumably to staging and live? Possibly needs a conditional to make sure this currently only happens on staging?