### PR TITLE
Fix invalid gp postcode in questionnaire

### DIFF
--- a/project/npda/forms/external_patient_validators.py
+++ b/project/npda/forms/external_patient_validators.py
@@ -98,6 +98,13 @@ async def _gp_details_from_postcode(
         normalised_postcode = await validate_postcode(
             gp_practice_postcode, async_client
         )
+
+        if not normalised_postcode:
+            raise ValidationError(
+                "Invalid GP practice with postcode %(postcode)s",
+                params={"postcode": gp_practice_postcode},
+            )
+
         ods_code = await gp_ods_code_for_postcode(normalised_postcode, async_client)
 
         if not ods_code:

--- a/project/npda/tests/form_tests/test_external_patient_validators.py
+++ b/project/npda/tests/form_tests/test_external_patient_validators.py
@@ -193,7 +193,7 @@ async def test_normalised_postcode_used_for_call_to_nhs_spine():
             assert(result.gp_practice_postcode == GP_POSTCODE_WITH_SPACES)
 
 
-async def test_invalid_gp_practice_postcode():
+async def test_gp_practice_postcode_does_not_return_result_from_spine():
     with patch("project.npda.forms.external_patient_validators.gp_ods_code_for_postcode", AsyncMock(return_value=None)):
         result = await validate_patient_async(
             postcode=None,
@@ -203,6 +203,23 @@ async def test_invalid_gp_practice_postcode():
         )
 
         assert(type(result.gp_practice_postcode) is ValidationError)
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/931
+async def test_invalid_gp_practice_postcode():
+    with patch("project.npda.forms.external_patient_validators.validate_postcode", AsyncMock(return_value=None)):    
+        with patch("project.npda.forms.external_patient_validators.gp_ods_code_for_postcode") as mock:
+            result = await validate_patient_async(
+                postcode=None,
+                gp_practice_ods_code=None,
+                gp_practice_postcode="INVALID",
+                async_client=async_client
+            )
+
+            # Passing None to the API call returned a 406 Not Acceptable so we want to check we don't call
+            # the spine at all
+            assert not mock.called
+            assert(type(result.gp_practice_postcode) is ValidationError)
 
 
 async def test_http_error_validating_gp_practice_postcode():


### PR DESCRIPTION
Fixes #931.

For a totally invalid GP postcode that didn't even get past postcodes.io, we ended up calling the NHS Spine with `None`. This caused it to return `406 Not Acceptable`, which we treated as an unexpected HTTP error and allowed the postcode to be saved.

The fix is to not call the spine at all if the postcode doesn't validate in the first place.