### PR TITLE
Celery flavoured refactor of the CSV upload code

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -32,24 +32,69 @@ from project.npda.forms.visit_form import VisitForm
 from project.npda.forms.external_patient_validators import validate_patient_async
 from project.npda.forms.external_visit_validators import validate_visit_async
 from project.npda.general_functions.csv.csv_clean import csv_clean
+from project.npda.models import (
+    Patient, 
+    Transfer,
+    Visit,
+    Submission,
+    VisitActivity
+)
+
+async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, user, ip_address):
+    old_submission = await Submission.objects.filter(
+        paediatric_diabetes_unit=pdu,
+        audit_year=audit_year,
+        submission_active=True,
+    ).afirst()
+
+    if old_submission:
+        old_submission.submission_active = False
+        await old_submission.asave()
+    
+    submission = await Submission.objects.acreate(
+        submission_date=timezone.now(),
+        submission_by=user,
+        paediatric_diabetes_unit=pdu,
+        audit_year=audit_year,
+        csv_file=csv_file_bytes,
+        csv_file_name=csv_file_name,
+        submission_active=True
+    )
+    
+    await VisitActivity.objects.acreate(
+        activity=8,
+        ip_address=ip_address,
+        npdauser=user,
+    )  # uploaded csv - activity 8
+
+    return submission
+
+
+async def tidy_up_old_submissions(pdu, new_submission):
+    all_submissions = Submission.objects.filter(
+        paediatric_diabetes_unit=pdu,
+        audit_year=new_submission.audit_year,
+    )
+
+    async for submission in all_submissions:
+        if submission.id != new_submission.id:
+            await Patient.objects.filter(submissions=submission).adelete()
+
+            submission.submission_active = False
+            await submission.asave()
 
 
 async def csv_upload(
-    user, dataframe, errors_to_return, csv_file_name, csv_file_bytes, pdu_pz_code, audit_year
+    user, dataframe, errors_to_return, csv_file_name, submission
 ):
     """
     Processes standardised NPDA csv file and persists results in NPDA tables
     Returns the empty dict if successful, otherwise ValidationErrors indexed by the row they occurred at
     """
+    pdu = submission.paediatric_diabetes_unit
+    is_jersey = pdu.pz_code == "PZ248"
 
-    # Get the models
-    Patient = apps.get_model("npda", "Patient")
-    Transfer = apps.get_model("npda", "Transfer")
-    Visit = apps.get_model("npda", "Visit")
-    Submission = apps.get_model("npda", "Submission")
-    PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
-
-    if pdu_pz_code == "PZ248":
+    if is_jersey:
         CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
     else:
         CSV_HEADINGS = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
@@ -90,7 +135,7 @@ async def csv_upload(
         form = PatientForm(
             fields,
             paediatric_diabetes_unit=pdu,
-            audit_year=audit_year,
+            audit_year=submission.audit_year,
         )
         form.async_validation_results = await validate_patient_async(
             postcode=fields["postcode"],
@@ -175,81 +220,6 @@ async def csv_upload(
 
         return transfer_fields
 
-    """"
-    Create the submission and save the csv file
-    """
-
-    # get the PDU object
-    # TODO #249 MRB: handle case where PDU does not exist
-    pdu = await PaediatricDiabetesUnit.objects.aget(pz_code=pdu_pz_code, active=True)
-
-    # Set previous submission to inactive
-    if await Submission.objects.filter(
-        paediatric_diabetes_unit__pz_code=pdu.pz_code,
-        paediatric_diabetes_unit__active=True,
-        audit_year=audit_year,
-        submission_active=True,
-    ).aexists():
-        original_submission = await Submission.objects.filter(
-            submission_active=True,
-            paediatric_diabetes_unit__pz_code=pdu.pz_code,
-            paediatric_diabetes_unit__active=True,
-            audit_year=audit_year,
-        ).aget()  # there can be only one of these - store it in a variable in case we need to revert
-    else:
-        original_submission = None
-
-    # Create new submission for the audit year
-    # It is not possble to create submissions in years other than the current year
-    try:
-        new_submission = await Submission.objects.acreate(
-            paediatric_diabetes_unit=pdu,
-            audit_year=audit_year,
-            submission_date=timezone.now(),
-            submission_by=user,  # user is the user who is logged in. Passed in as a parameter
-            submission_active=True,
-            csv_file=csv_file_bytes,
-            csv_file_name=csv_file_name,
-        )
-
-        await new_submission.asave()
-
-    except Exception as e:
-        logger.error(f"Error creating new submission: {e}")
-        # the new submission was not created  - no action required as the previous submission is still active
-        raise ValidationError(
-            {
-                "csv_upload": "Error creating new submission. The old submission has been restored."
-            }
-        )
-
-    # now can delete all patients and visits from the previous active submission
-    if original_submission:
-        try:
-            original_submission_patient_count = await Patient.objects.filter(
-                submissions=original_submission
-            ).acount()
-            logger.debug(
-                f"Deleting patients from previous submission: {original_submission_patient_count}"
-            )
-            await Patient.objects.filter(submissions=original_submission).adelete()
-        except Exception as e:
-            raise ValidationError(
-                {"csv_upload": "Error deleting patients from previous submission"}
-            )
-
-    # now can delete the any previous active submission's csv file (if it exists)
-    # and remove the path from the field by setting it to None
-    # the rest of the submission will be retained
-    if original_submission:
-        original_submission.submission_active = False
-        try:
-            await original_submission.asave()  # this action will delete the csv file also as per the save method in the model
-        except Exception as e:
-            raise ValidationError(
-                {"csv_upload": "Error deactivating previous submission"}
-            )
-
     """
     Process the csv file and validate and save the data in the tables, parsing any errors
     """
@@ -259,7 +229,7 @@ async def csv_upload(
     dataframe = dataframe.assign(row_index=np.arange(dataframe.shape[0]))
 
     # We only one to create one patient per NHS number (or URN if in Jersey) and we can't create their visits if we fail to save the patient model
-    if new_submission.paediatric_diabetes_unit.pz_code == "PZ248":
+    if is_jersey:
         visits_by_patient = dataframe.groupby(
             "Unique Reference Number", sort=False, dropna=False
         )
@@ -288,12 +258,12 @@ async def csv_upload(
                 transfer_fields["patient"] = patient
                 await Transfer.objects.acreate(**transfer_fields)
 
-                await new_submission.patients.aadd(patient)
+                await submission.patients.aadd(patient)
 
             return patient
         except Exception as error:
             logger.exception(
-                f"Error saving patient for {pdu_pz_code} from {csv_file_name}[{patient_row_index}]: {error}"
+                f"Error saving patient for {pdu.pz_code} from {csv_file_name}[{patient_row_index}]: {error}"
             )
 
             # We don't know what field caused the error so add to __all__
@@ -308,7 +278,7 @@ async def csv_upload(
                 await sync_to_async(lambda: visit_form.save())()
             except Exception as error:
                 logger.exception(
-                    f"Error saving visit for {pdu_pz_code} from {csv_file_name}[{visit_row_index}]: {error}"
+                    f"Error saving visit for {pdu.pz_code} from {csv_file_name}[{visit_row_index}]: {error}"
                 )
                 errors_to_return[visit_row_index]["__all__"].append(str(error))
 
@@ -379,7 +349,7 @@ async def csv_upload(
 
     # Store the errors to report back to the user in the Data Quality Report
     if errors_to_return:
-        new_submission.errors = json.dumps(errors_to_return)
-        await new_submission.asave()
+        submission.errors = json.dumps(errors_to_return)
+        await submission.asave()
 
     return errors_to_return

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -18,9 +18,19 @@ from django.core.exceptions import ValidationError
 from django.contrib.gis.geos import Point
 from httpx import HTTPError
 
-from project.npda.general_functions.csv import csv_upload, csv_parse
+from project.npda.general_functions.csv import (
+    csv_upload,
+    csv_parse,
+    create_csv_submission,
+    tidy_up_old_submissions
+)
 from project.constants import csv_definition_for, ALL_DATES
-from project.npda.models import NPDAUser, Patient, Visit
+from project.npda.models import (
+    NPDAUser,
+    Patient,
+    Visit,
+    PaediatricDiabetesUnit
+)
 from project.npda.tests.factories.patient_factory import (
     INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
     TODAY,
@@ -141,8 +151,20 @@ def test_user(seed_groups_fixture, seed_users_fixture):
 # https://github.com/pytest-dev/pytest-asyncio/issues/226
 @async_to_sync
 async def csv_upload_sync(
-    user, dataframe, pdu_pz_code=ALDER_HEY_PZ_CODE, errors_to_return=None
+    user, dataframe, pdu=None, errors_to_return=None
 ):
+    if not pdu:
+        pdu = await PaediatricDiabetesUnit.objects.aget(pz_code=ALDER_HEY_PZ_CODE)
+
+    new_submission = await create_csv_submission(
+        pdu=pdu,
+        audit_year=2024,
+        csv_file_bytes=None,
+        csv_file_name=None,
+        user=user,
+        ip_address=None
+    )
+
     return await csv_upload(
         user,
         dataframe,
@@ -152,9 +174,7 @@ async def csv_upload_sync(
             else errors_to_return
         ),
         csv_file_name=None,
-        csv_file_bytes=None,
-        pdu_pz_code=pdu_pz_code,
-        audit_year=2024,
+        submission=new_submission
     )
 
 
@@ -331,7 +351,8 @@ def test_missing_unique_reference_number(
         Patient.objects.count() == 0
     ), "There should be no patients in the database before the test"
 
-    errors = csv_upload_sync(test_user, df, "PZ248")
+    jersey = PaediatricDiabetesUnit.objects.get(pz_code="PZ248")
+    errors = csv_upload_sync(test_user, df, pdu=jersey)
 
     assert "unique_reference_number" in errors[0]
 
@@ -3166,6 +3187,8 @@ def test_bad_data_for_positive_small_integer_fields(
     column = headings["heading"]
     model = apps.get_model("npda", headings["model"])
 
+    pdu = PaediatricDiabetesUnit.objects.get(pz_code=ALDER_HEY_PZ_CODE)
+
     for [value, expected, assertion_message] in [
         [94, None, f"Failed to handle {model_field} with incorrect choice (94)"],
         [-1, None, f"Failed to handle {model_field} with -1 (negative number)"],
@@ -3181,6 +3204,9 @@ def test_bad_data_for_positive_small_integer_fields(
         ],
         ["STRING", None, f"Failed to handle unexpected string for {model_field}"],
     ]:
+        # Clear out patients created by previous iterations of the loop
+        Patient.objects.all().delete()
+
         one_row_csv = modify_raw_csv(
             dummy_sheet_csv,
             end=2,  # exclusive
@@ -3189,7 +3215,7 @@ def test_bad_data_for_positive_small_integer_fields(
 
         df = read_csv_from_str(one_row_csv).df
 
-        errors = csv_upload_sync(test_user, df)
+        errors = csv_upload_sync(test_user, df, pdu=pdu)
 
         assert len(errors) > 0, assertion_message
         assert model.objects.count() == 1, assertion_message
@@ -3201,6 +3227,7 @@ def test_bad_data_for_positive_small_integer_fields(
         # No errors field in Transfer
         if hasattr(instance, "errors"):
             assert model_field in instance.errors
+
 
 
 @pytest.mark.parametrize(

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -16,15 +16,23 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.http import HttpResponse
 from django.conf import settings
+from django.utils import timezone
 
 
 # HTMX imports
 from django_htmx.http import trigger_client_event
 
-from project.npda.general_functions.csv import csv_upload, csv_parse, csv_header
+from project.npda.general_functions.csv import (
+    csv_upload,
+    csv_parse,
+    csv_header,
+    create_csv_submission,
+    tidy_up_old_submissions
+)
 from ..forms.upload import UploadFileForm
 from ..general_functions.session import refresh_session_filters
 from ..general_functions.view_preference import get_or_update_view_preference
+from ..models import PaediatricDiabetesUnit
 
 # RCPCH imports
 from .decorators import login_and_otp_required
@@ -58,6 +66,10 @@ async def home(request):
 
         pz_code = request.session.get("pz_code")
         is_jersey = pz_code == "PZ248"
+
+        # TODO MRB: check pdu is active and I'm not a superuser?
+        pdu = await PaediatricDiabetesUnit.objects.aget(pz_code=pz_code)
+
         if request.session.get("can_upload_csv") is True:
             # check to see if the CSV is valid - cannot accept CSVs with no header. All other header errors are non-lethal but are reported back to the user
             try:
@@ -91,26 +103,25 @@ async def home(request):
 
             audit_year = request.session.get("selected_audit_year")
 
+            new_submission = await create_csv_submission(
+                pdu=pdu,
+                audit_year=audit_year,
+                csv_file_bytes=user_csv_bytes,
+                csv_file_name=user_csv_filename,
+                user=request.user,
+                ip_address=request.META.get("REMOTE_ADDR"),
+            )
+
             # CSV is valid, parse any errors and store the data in the tables.
             errors_by_row_index = await csv_upload(
                 user=request.user,
                 dataframe=parsed_csv.df,
                 errors_to_return=parsed_csv.errors_to_return,
                 csv_file_name=user_csv_filename,
-                csv_file_bytes=user_csv_bytes,
-                pdu_pz_code=pz_code,
-                audit_year=audit_year,
+                submission=new_submission,
             )
-            # log user activity
-            VisitActivity = apps.get_model("npda", "VisitActivity")
-            try:
-                await VisitActivity.objects.acreate(
-                    activity=8,
-                    ip_address=request.META.get("REMOTE_ADDR"),
-                    npdauser=request.user,
-                )  # uploaded csv - activity 8
-            except Exception as e:
-                logger.error(f"Failed to log user activity: {e}")
+
+            await tidy_up_old_submissions(pdu, new_submission)
 
             # update the session fields - this stores that the user has uploaded a csv and disables the ability to use the questionnaire
             await sync_to_async(refresh_session_filters)(request)


### PR DESCRIPTION
Split creating the submission, processing the file and tidying up old submissions into separate methods so they can be called in different places in the future (http route and Celery tasks).

Add the VisitActivity entry as soon as we've created the submission so we still have a record of the upload even if it crashes.

Delete patients from old submissions after we have successfully processed the new one to make it easier to revert back in case of a crash processing the new file. (Fixes #336).

Import models directly rather than using `apps.get_model`.