### PR TITLE
Import data from CSV for multiple PDUs

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -86,7 +86,12 @@ async def tidy_up_old_submissions(pdu, new_submission):
 
 
 async def csv_upload(
-    dataframe, errors_to_return, csv_file_name, submission
+    dataframe,
+    errors_to_return,
+    csv_file_name,
+    submission,
+    allow_empty_visits=False,
+    save_errors_on_submission=True
 ):
     """
     Processes standardised NPDA csv file and persists results in NPDA tables
@@ -293,8 +298,8 @@ async def csv_upload(
 
             visit_forms = []
             for _, row in rows.iterrows():
-                if pd.isnull(row["Visit/Appointment Date"]):
-                    logger.warning(f"Missing visit date for {pdu.pz_code} from {csv_file_name}[{row["row_index"]}]. Skipping creating visit.")
+                if allow_empty_visits and pd.isnull(row["Visit/Appointment Date"]):
+                    logger.info(f"Missing visit date for {pdu.pz_code} from {csv_file_name}[{row["row_index"]}]. Skipping creating visit.")
                     continue
 
                 visit_form = await validate_visit_using_form(
@@ -349,7 +354,7 @@ async def csv_upload(
                 tg.create_task(task(rows))
 
     # Store the errors to report back to the user in the Data Quality Report
-    if errors_to_return:
+    if errors_to_return and save_errors_on_submission:
         submission.errors = json.dumps(errors_to_return)
         await submission.asave()
 

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -40,7 +40,7 @@ from project.npda.models import (
     VisitActivity
 )
 
-async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, user, ip_address):
+async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, user=None, ip_address=None):
     old_submission = await Submission.objects.filter(
         paediatric_diabetes_unit=pdu,
         audit_year=audit_year,
@@ -61,11 +61,12 @@ async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, 
         submission_active=True
     )
     
-    await VisitActivity.objects.acreate(
-        activity=8,
-        ip_address=ip_address,
-        npdauser=user,
-    )  # uploaded csv - activity 8
+    if user:
+        await VisitActivity.objects.acreate(
+            activity=8,
+            ip_address=ip_address,
+            npdauser=user,
+        )  # uploaded csv - activity 8
 
     return submission
 

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -297,6 +297,10 @@ async def csv_upload(
 
             visit_forms = []
             for _, row in rows.iterrows():
+                if pd.isnull(row["Visit/Appointment Date"]):
+                    logger.warning(f"Missing visit date for {pdu.pz_code} from {csv_file_name}[{row["row_index"]}]. Skipping creating visit.")
+                    continue
+
                 visit_form = await validate_visit_using_form(
                     patient_form, row, async_client
                 )

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -140,7 +140,9 @@ class Command(BaseCommand):
                 errors_to_return=parsed_csv.errors_to_return,
                 # Just used for logging
                 csv_file_name="MANUAL IMPORT",
-                submission=submission
+                submission=submission,
+                allow_empty_visits=True,
+                save_errors_on_submission=False
             )
 
             if errors:

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -130,6 +130,22 @@ class Command(BaseCommand):
             )
 
             submissions_by_pz_code[pz_code] = submission
+        
+        for pz_code, submission in submissions_by_pz_code.items():
+            df = parsed_csv.df
+            df = df[df["PDU Number"] == pz_code]
+
+            errors = async_to_sync(csv_upload)(
+                dataframe=df,
+                errors_to_return=parsed_csv.errors_to_return,
+                # Just used for logging
+                csv_file_name="MANUAL IMPORT",
+                submission=submission
+            )
+
+            if errors:
+                print(f"Errors found during import for {pz_code}:")
+                print(json.dumps(errors))
 
 
     def handle(self, *args, **options):

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -147,7 +147,11 @@ class Command(BaseCommand):
 
             if errors:
                 print(f"Errors found during import for {pz_code}:")
-                print(json.dumps(errors))
+                
+                for row, errors_by_field in errors.items():
+                    print(f"\tRow {row}:")
+                    for field, error in errors_by_field.items():
+                        print(f"\t\t{field}: {error}")
 
 
     def handle(self, *args, **options):

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -4,8 +4,17 @@ from asgiref.sync import async_to_sync
 
 from django.core.management.base import BaseCommand
 
-from project.npda.models import NPDAUser
-from project.npda.general_functions.csv import csv_upload, csv_parse, csv_header
+from project.npda.models import (
+    NPDAUser,
+    PaediatricDiabetesUnit,
+)
+from project.npda.general_functions import get_current_audit_year
+from project.npda.general_functions.csv import (
+    csv_upload,
+    csv_parse,
+    csv_header,
+    create_csv_submission
+)
 
 
 class Command(BaseCommand):
@@ -14,10 +23,18 @@ class Command(BaseCommand):
     )
 
     def add_arguments(self, parser):
-        parser.add_argument("--file", type=str, required=True, help="File to upload")
+        parser.add_argument(
+            "--file",
+            type=str,
+            required=True,
+            help="File to upload"
+        )
 
         parser.add_argument(
-            "--user", type=int, default=1, help="PK of the user uploading the file"
+            "--user",
+            type=int,
+            required=True,
+            help="NPDA ID (primary key) of the user uploading the file"
         )
 
         parser.add_argument(
@@ -27,29 +44,74 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--use-pz-code-from-file",
+            "--audit-year",
+            type=str,
+            required=True,
+            help="Audit year for the upload",
+        )
+
+        parser.add_argument(
+            "--use-pz-codes-from-file",
             action="store_true",
             help="Use the PZ number column from the file. Allows importing data for multiple PDUs at once",
         )
+
+    def upload_csv_to_single_pdu(self, audit_year, pdu_pz_code, user, parsed_csv, csv_file_bytes, csv_file_name):
+        pdu = PaediatricDiabetesUnit.objects.get(pz_code=pdu_pz_code)
+
+        submission = async_to_sync(create_csv_submission)(
+            pdu=pdu,
+            audit_year=audit_year,
+            csv_file_bytes=csv_file_bytes,
+            csv_file_name=csv_file_name,
+            user=user
+        )   
+    
+        errors = async_to_sync(csv_upload)(
+            dataframe=parsed_csv.df,
+            errors_to_return=parsed_csv.errors_to_return,
+            csv_file_name=csv_file_name,
+            submission=submission
+        )
+
+        return errors   
+
 
     def handle(self, *args, **options):
         user_pk = options["user"]
         user = NPDAUser.objects.get(pk=user_pk)
 
-        if options["use_pz_code_from_file"] and options["pz_code"]:
-            raise ValueError("Cannot specify both --pz-code and --use-pz-code-from-file")
+        if options["audit_year"]:
+            audit_year = int(options["audit_year"])
+        else:
+            # TODO MRB: replace this with AuditPeriod before merging https://github.com/rcpch/national-paediatric-diabetes-audit/pull/865
+            audit_year = get_current_audit_year()
 
-        if options["use_pz_code_from_file"]:
+        if options["use_pz_codes_from_file"] and options["pz_code"]:
+            raise ValueError("Cannot specify both --pz-code and --use-pz-codes-from-file")
+
+        if not options["use_pz_codes_from_file"] and not options["pz_code"]:
+            raise ValueError("Must specify either --pz-code or --use-pz-codes-from-file")
+
+        if options["use_pz_codes_from_file"]:
             pdu_pz_code = None
         else:
             pdu_pz_code = options["pz_code"]
 
         is_jersey = pdu_pz_code == "PZ248"
 
-        df = csv_parse(options["file"], is_jersey=is_jersey).df
+        with open(options["file"], "rb") as f:
+            csv_file_name = f.name
+            csv_file_bytes = f.read()
 
-        with open(options["file"], "r") as f:
-            errors = async_to_sync(csv_upload)(user, df, f, pdu_pz_code)
+        parsed_csv = csv_parse(options["file"], is_jersey=is_jersey)
+
+        if pdu_pz_code:
+            errors = self.upload_csv_to_single_pdu(
+                audit_year, pdu_pz_code, user, parsed_csv, csv_file_bytes, csv_file_name
+            )
+        else:
+            errors = None
 
         if errors:
             print(json.dumps(errors))

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -13,7 +13,8 @@ from project.npda.general_functions.csv import (
     csv_upload,
     csv_parse,
     csv_header,
-    create_csv_submission
+    create_csv_submission,
+    tidy_up_old_submissions
 )
 
 
@@ -51,9 +52,9 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--use-pz-codes-from-file",
+            "--import-as-questionnaire-entries",
             action="store_true",
-            help="Use the PZ number column from the file. Allows importing data for multiple PDUs at once",
+            help="Import data from the file as if it were submitted using the questionnaire. Assign each row to a PDU using the 'PDU Number' column",
         )
 
     def upload_csv_to_single_pdu(self, audit_year, pdu_pz_code, user, parsed_csv, csv_file_bytes, csv_file_name):
@@ -74,6 +75,11 @@ class Command(BaseCommand):
             submission=submission
         )
 
+        async_to_sync(tidy_up_old_submissions)(
+            pdu=pdu,
+            new_submission=submission
+        )
+
         return errors   
 
 
@@ -87,13 +93,13 @@ class Command(BaseCommand):
             # TODO MRB: replace this with AuditPeriod before merging https://github.com/rcpch/national-paediatric-diabetes-audit/pull/865
             audit_year = get_current_audit_year()
 
-        if options["use_pz_codes_from_file"] and options["pz_code"]:
+        if options["import_as_questionnaire_entries"] and options["pz_code"]:
             raise ValueError("Cannot specify both --pz-code and --use-pz-codes-from-file")
 
-        if not options["use_pz_codes_from_file"] and not options["pz_code"]:
+        if not options["import_as_questionnaire_entries"] and not options["pz_code"]:
             raise ValueError("Must specify either --pz-code or --use-pz-codes-from-file")
 
-        if options["use_pz_codes_from_file"]:
+        if options["import_as_questionnaire_entries"]:
             pdu_pz_code = None
         else:
             pdu_pz_code = options["pz_code"]

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -3,10 +3,12 @@ import json
 from asgiref.sync import async_to_sync
 
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from project.npda.models import (
     NPDAUser,
     PaediatricDiabetesUnit,
+    Submission
 )
 from project.npda.general_functions import get_current_audit_year
 from project.npda.general_functions.csv import (
@@ -54,7 +56,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--import-as-questionnaire-entries",
             action="store_true",
-            help="Import data from the file as if it were submitted using the questionnaire. Assign each row to a PDU using the 'PDU Number' column",
+            help="""Import data from the file as if it were submitted using the questionnaire.
+                    Assign each row to a PDU using the 'PDU Number' column".
+                    Will create a questionnaire submission for each PDU in the file.
+                    If any submissions already exist no data will be imported.
+                    Designed for bulk import patient data from the old platform."""
         )
 
     def upload_csv_to_single_pdu(self, audit_year, pdu_pz_code, user, parsed_csv, csv_file_bytes, csv_file_name):
@@ -80,7 +86,50 @@ class Command(BaseCommand):
             new_submission=submission
         )
 
-        return errors   
+        return errors
+    
+    def upload_as_questionnaire_entries(self, audit_year, pdu_pz_code, user, parsed_csv):
+        df = parsed_csv.df
+
+        pz_codes_that_need_submissions = set()
+        pz_codes_that_already_have_submissions = set()
+
+        for pz_code in df["PDU Number"].unique():
+            try:
+                pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+            except PaediatricDiabetesUnit.DoesNotExist:
+                raise ValueError(f"Invalid PDU Number: {pz_code}")
+            
+            has_existing_submission = Submission.objects.filter(
+                paediatric_diabetes_unit=pdu,
+                audit_year=audit_year,
+                submission_active=True
+            ).exists()
+
+            if(has_existing_submission):
+                pz_codes_that_already_have_submissions.add(pz_code)
+            else:
+                pz_codes_that_need_submissions.add(pz_code)
+        
+        if len(pz_codes_that_already_have_submissions) > 0:
+            raise ValueError(
+                f"Submissions already exist for the following PDUs: {pz_codes_that_already_have_submissions}"
+            )
+        
+        submissions_by_pz_code = {}
+
+        for pz_code in pz_codes_that_need_submissions:
+            pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+
+            submission = Submission.objects.create(
+                audit_year=audit_year,
+                paediatric_diabetes_unit=pdu,
+                submission_active=True,
+                submission_by=user,
+                submission_date=timezone.now()
+            )
+
+            submissions_by_pz_code[pz_code] = submission
 
 
     def handle(self, *args, **options):
@@ -117,7 +166,9 @@ class Command(BaseCommand):
                 audit_year, pdu_pz_code, user, parsed_csv, csv_file_bytes, csv_file_name
             )
         else:
-            errors = None
+            errors = self.upload_as_questionnaire_entries(
+                audit_year, pdu_pz_code, user, parsed_csv
+            )
 
         if errors:
             print(json.dumps(errors))

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -23,15 +23,26 @@ class Command(BaseCommand):
         parser.add_argument(
             "--pz-code",
             type=str,
-            default="PZ999",
             help="PZ code of the PDU for the upload",
+        )
+
+        parser.add_argument(
+            "--use-pz-code-from-file",
+            action="store_true",
+            help="Use the PZ number column from the file. Allows importing data for multiple PDUs at once",
         )
 
     def handle(self, *args, **options):
         user_pk = options["user"]
         user = NPDAUser.objects.get(pk=user_pk)
 
-        pdu_pz_code = options["pz_code"]
+        if options["use_pz_code_from_file"] and options["pz_code"]:
+            raise ValueError("Cannot specify both --pz-code and --use-pz-code-from-file")
+
+        if options["use_pz_code_from_file"]:
+            pdu_pz_code = None
+        else:
+            pdu_pz_code = options["pz_code"]
 
         is_jersey = pdu_pz_code == "PZ248"
 


### PR DESCRIPTION
Part of #919 

Adds `--import-as-questionnaire-entries` to the `upload_csv` command. This allows us to import data exported from the old platform as if they had been entered using the questionnaire on the new platform, saving a whole bunch of typing for users.

It creates a new submission for each PDU based on the `PDU Number` column in the CSV. If any PDU already has a submission, no data is uploaded.

This PR also fixes the `upload_csv` command, which I broke in #954.