### PR TITLE
Handle invalid NHS number better for CSV uploads

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -241,7 +241,12 @@ async def csv_upload(
     ):
         try:
             save_errors_and_retain_valid_fields(patient_row_index, patient_form)
-            patient = await sync_to_async(lambda: patient_form.save())()
+
+            patient = await sync_to_async(lambda: patient_form.save(commit=False))()
+            
+            # Throw database level issues not covered by the form (eg missing both nhs_number and urn)
+            patient.clean()
+            await patient.asave()
 
             if patient:
                 # add the patient to a new Transfer instance

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -241,16 +241,7 @@ async def csv_upload(
     ):
         try:
             save_errors_and_retain_valid_fields(patient_row_index, patient_form)
-
-            nhs_number = patient_form.cleaned_data.get("nhs_number")
-            unique_reference_number = patient_form.cleaned_data.get(
-                "unique_reference_number"
-            )
-
-            patient = None
-
-            if nhs_number or unique_reference_number:
-                patient = await sync_to_async(lambda: patient_form.save())()
+            patient = await sync_to_async(lambda: patient_form.save())()
 
             if patient:
                 # add the patient to a new Transfer instance

--- a/project/npda/general_functions/write_errors_to_xlsx.py
+++ b/project/npda/general_functions/write_errors_to_xlsx.py
@@ -54,7 +54,6 @@ def write_errors_to_xlsx(
         errors=errors,
         original_data=df,
         identifier_field="Unique Reference Number" if is_jersey else "NHS Number",
-        csv_headings=(UNIQUE_IDENTIFIER_JERSEY if is_jersey else UNIQUE_IDENTIFIER_ENGLAND) + CSV_HEADING_OBJECTS
     )
 
     # Add sheet that lists the errors.
@@ -125,8 +124,7 @@ def flatten_errors(
     #  {row_number: {field_name: [error_messages]}}
     errors: dict[int, dict[str, list[str]]],
     original_data: pd.DataFrame,
-    identifier_field: str,
-    csv_headings: List[Dict[str, str]],
+    identifier_field: str
 ) -> pd.DataFrame:
     identifier_column = csv_definition_for(identifier_field)["heading"]
 
@@ -134,11 +132,15 @@ def flatten_errors(
 
     for row_ix, row_errors in errors.items():
         for field, errors in row_errors.items():
+            # __all__ errors should be attached to the first column
+            csv_definition = csv_definition_for(field)
+            column = csv_definition["heading"] if csv_definition else identifier_column
+
             rows.append({
                 # 0 based indexing and the column header. So + 2
                 "Original CSV Row": int(row_ix) + 2,
                 identifier_field: original_data.loc[int(row_ix), identifier_column],
-                "Column": csv_definition_for(field)["heading"],
+                "Column": column,
                 "Errors": "; ".join(errors),
             })
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -507,6 +507,9 @@ def test_invalid_nhs_number(test_user, single_row_valid_df):
     errors = csv_upload_sync(test_user, single_row_valid_df)
     assert "nhs_number" in errors[0]
 
+    patient = Patient.objects.first()
+    assert patient.nhs_number == "123456789"
+
 
 @pytest.mark.django_db
 def test_future_date_of_birth(test_user, single_row_valid_df):

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -325,7 +325,7 @@ def test_missing_nhs_number(
 
     assert "nhs_number" in errors[0]
 
-    # We shouldn't save this patient (invariant enforced in Patient.save not in the database)
+    # We shouldn't save this patient (invariant enforced in Patient.clean not in the database)
     assert Patient.objects.count() == 0
 
 
@@ -355,7 +355,7 @@ def test_missing_unique_reference_number(
 
     assert "unique_reference_number" in errors[0]
 
-    # We shouldn't save this patient (invariant enforced in Patient.save not in the database)
+    # We shouldn't save this patient (invariant enforced in Patient.clean not in the database)
     assert Patient.objects.count() == 0
 
 


### PR DESCRIPTION
Fixes #850

Fix two bugs that happened when you uploaded a CSV file where a row has a full length but invalid NHS number.

- Still save the invalid NHS number with the patient
- Fix crash when rendering the Data Quality Report spreadsheet 