### PR TITLE
Fix import of Jersey questionnaire patients

### DIFF
--- a/project/npda/forms/external_patient_validators.py
+++ b/project/npda/forms/external_patient_validators.py
@@ -54,7 +54,7 @@ async def _validate_postcode(
 async def _imd_for_postcode(
     postcode: str | None, async_client: AsyncClient
 ) -> str | None:
-    if postcode:
+    if postcode and not postcode.lower().startswith("je"):
         try:
             imd = await imd_for_postcode(postcode, async_client)
 

--- a/project/npda/general_functions/csv/csv_download.py
+++ b/project/npda/general_functions/csv/csv_download.py
@@ -36,9 +36,7 @@ def download_xlsx(request, submission_id):
     if submission.errors:
         errors = json.loads(submission.errors)
 
-    is_jersey = submission.paediatric_diabetes_unit.pz_code == "PZ248"
-
-    xlsx_file = write_errors_to_xlsx(errors or {}, submission.csv_file, is_jersey)
+    xlsx_file = write_errors_to_xlsx(errors or {}, submission.csv_file)
 
     response = HttpResponse(xlsx_file, content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{xlsx_file_name}"'

--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ParsedCSVFile:
     df: pd.DataFrame
+    identifier_column: str | None
     missing_columns: list[str]
     additional_columns: list[str]
     duplicate_columns: list[str]
@@ -41,7 +42,7 @@ class ParsedCSVFile:
     errors_to_return: collections.defaultdict[int, collections.defaultdict[str, list[str]]]
 
 
-def csv_parse(csv_file, is_jersey=False):
+def csv_parse(csv_file):
     """
     Read the csv file and return a pandas dataframe
     Assigns the correct data types to the columns
@@ -56,13 +57,7 @@ def csv_parse(csv_file, is_jersey=False):
 
     errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
 
-    # Define the column names to be used in the csv file: the unique identifier in Jersy is different from the one in England
-    if is_jersey:
-        HEADINGS_LIST = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
-    else:
-        HEADINGS_LIST = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
-
-    HEADINGS_LIST = [item["heading"] for item in HEADINGS_LIST]
+    HEADINGS_LIST = [obj["heading"] for obj in (UNIQUE_IDENTIFIER_ENGLAND + UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS)]
 
     # Convert the predefined column names to lowercase
     lowercase_headings_list = [heading.lower() for heading in HEADINGS_LIST]
@@ -85,15 +80,6 @@ def csv_parse(csv_file, is_jersey=False):
     # The template published on the RCPCH website has trailing spaces on 'Observation Date: Thyroid Function '
     df.columns = df.columns.str.strip()
 
-    if df.columns[0].lower() not in lowercase_headings_list:
-        # No header in the source - pass them from our definitions
-        logger.warning(
-            f"CSV file uploaded without column names, using predefined column names"
-        )
-
-        # Have to reset back otherwise we get an empty dataframe
-        csv_file.seek(0)
-
     # Pandas has strange behaviour for the first line in a CSV - additional cells become row labels
     # https://github.com/pandas-dev/pandas/issues/47490
     #
@@ -111,8 +97,25 @@ def csv_parse(csv_file, is_jersey=False):
                 c for c in HEADINGS_LIST if c.lower() == column.lower()
             )
             df = df.rename(columns={column: normalised_column})
+    
+    identifier_england = UNIQUE_IDENTIFIER_ENGLAND[0]["heading"]
+    identifier_jersey = UNIQUE_IDENTIFIER_JERSEY[0]["heading"]
 
-    missing_columns = [column for column in HEADINGS_LIST if not column in df.columns]
+    if identifier_england in df.columns and identifier_jersey in df.columns:
+        raise ValueError(
+            "Both Unique Reference Number and NHS Number columns are present. Please ensure only one of these is present in the file."
+        )
+
+    if identifier_jersey in df.columns:
+        identifier_column = identifier_jersey
+    elif identifier_england in df.columns:
+        identifier_column = identifier_england
+    else:
+        identifier_column = None
+
+    missing_columns = [
+        column for column in HEADINGS_LIST if not column in df.columns and column != identifier_england and column != identifier_jersey
+    ]
 
     additional_columns = [
         column for column in df.columns if not column in HEADINGS_LIST
@@ -142,7 +145,7 @@ def csv_parse(csv_file, is_jersey=False):
             
             df[column] = column_after
 
-    if is_jersey:
+    if identifier_column == identifier_jersey:
         datatypes = JERSEY_CSV_DATA_TYPES | CSV_DATA_TYPES_MINUS_DATES
     else:
         datatypes = ENGLAND_CSV_DATA_TYPES | CSV_DATA_TYPES_MINUS_DATES
@@ -178,34 +181,26 @@ def csv_parse(csv_file, is_jersey=False):
     total_row_count = df.shape[0]
     discrepancy = 0
 
-    if is_jersey:
-        unique_reference_number_nonnull_row_count = df[
-            "Unique Reference Number"
-        ].count()
-        if unique_reference_number_nonnull_row_count == 0:
+    if identifier_column in df:
+        identifier_nonnull_row_count = df[identifier_column].count()
+        if identifier_nonnull_row_count == 0:
             raise ValueError(
-                "No Unique Reference Numbers found in the file. Please ensure all rows have a unique identifier and upload the file again."
+                f"No {identifier_column}s found in the file. Please ensure all rows have a unique identifier and upload the file again."
             )
-        discrepancy = total_row_count - unique_reference_number_nonnull_row_count
-    elif "NHS Number" in df.columns:
-        nhs_number_nonnull_row_count = df["NHS Number"].count()
-        if nhs_number_nonnull_row_count == 0:
+            discrepancy = total_row_count - identifier_nonnull_row_count
+        
+        if discrepancy > 0:
+            if discrepancy == 1:
+                raise ValueError(
+                    f"{discrepancy} row has no unique identifier. Please ensure all rows have a unique identifier and upload the file again."
+                )
             raise ValueError(
-                "No NHS Numbers found in the file. Please ensure all rows have a unique identifier and upload the file again."
+                f"{discrepancy} rows have no unique identifier. Please ensure all rows have a unique identifier and upload the file again."
             )
-        discrepancy = total_row_count - nhs_number_nonnull_row_count
-    
-    if discrepancy > 0:
-        if discrepancy == 1:
-            raise ValueError(
-                f"{discrepancy} row has no unique identifier. Please ensure all rows have a unique identifier and upload the file again."
-            )
-        raise ValueError(
-            f"{discrepancy} rows have no unique identifier. Please ensure all rows have a unique identifier and upload the file again."
-        )
 
     return ParsedCSVFile(
         df,
+        identifier_column,
         missing_columns,
         additional_columns,
         duplicate_columns,

--- a/project/npda/general_functions/write_errors_to_xlsx.py
+++ b/project/npda/general_functions/write_errors_to_xlsx.py
@@ -19,18 +19,12 @@ from openpyxl.styles import PatternFill, Font
 from openpyxl.comments import Comment
 
 # import csv mappings
-from ...constants.csv_headings import (
-    CSV_HEADING_OBJECTS,
-    UNIQUE_IDENTIFIER_ENGLAND,
-    UNIQUE_IDENTIFIER_JERSEY,
-    csv_definition_for
-)
+from ...constants.csv_headings import csv_definition_for
 
 
 def write_errors_to_xlsx(
     errors: dict[str, dict[str, list[str]]],
-    original_csv_file_bytes: bytes,
-    is_jersey: bool,
+    original_csv_file_bytes: bytes
 ) -> bytes:
     """
     Write errors to an Excel file. Highlight invalid cells in the source CSV.
@@ -43,9 +37,12 @@ def write_errors_to_xlsx(
     xlsx_file = io.BytesIO()
 
     # Get original data
-    df = csv_parse(
-        io.BytesIO(initial_bytes=original_csv_file_bytes), is_jersey=is_jersey
-    ).df
+    parsed_csv = csv_parse(
+        io.BytesIO(initial_bytes=original_csv_file_bytes)
+    )
+
+    df = parsed_csv.df
+
     # Write an xlsx of the original data.
     df.to_excel(xlsx_file, sheet_name="Uploaded data (raw)", index=False)
 
@@ -53,7 +50,7 @@ def write_errors_to_xlsx(
     df_errors = flatten_errors(
         errors=errors,
         original_data=df,
-        identifier_field="Unique Reference Number" if is_jersey else "NHS Number",
+        identifier_column=parsed_csv.identifier_column,
     )
 
     # Add sheet that lists the errors.
@@ -124,10 +121,8 @@ def flatten_errors(
     #  {row_number: {field_name: [error_messages]}}
     errors: dict[int, dict[str, list[str]]],
     original_data: pd.DataFrame,
-    identifier_field: str
+    identifier_column: str
 ) -> pd.DataFrame:
-    identifier_column = csv_definition_for(identifier_field)["heading"]
-
     rows = []
 
     for row_ix, row_errors in errors.items():
@@ -139,7 +134,7 @@ def flatten_errors(
             rows.append({
                 # 0 based indexing and the column header. So + 2
                 "Original CSV Row": int(row_ix) + 2,
-                identifier_field: original_data.loc[int(row_ix), identifier_column],
+                identifier_column: original_data.loc[int(row_ix), identifier_column],
                 "Column": column,
                 "Errors": "; ".join(errors),
             })

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -218,13 +218,11 @@ class Command(BaseCommand):
         else:
             pdu_pz_code = options["pz_code"]
 
-        is_jersey = pdu_pz_code == "PZ248"
-
         with open(options["file"], "rb") as f:
             csv_file_name = f.name
             csv_file_bytes = f.read()
 
-        parsed_csv = csv_parse(options["file"], is_jersey=is_jersey)
+        parsed_csv = csv_parse(options["file"])
 
         if pdu_pz_code:
             self.upload_csv_to_single_pdu(

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -30,8 +30,7 @@ def upload_csv_task(submission_id):
 
     # CSV parsing errors are done inline in the route that handles the file upload
     parsed_csv = csv_parse(
-        io.BytesIO(submission.csv_file),
-        is_jersey=submission.paediatric_diabetes_unit.pz_code == "PZ248",
+        io.BytesIO(submission.csv_file)
     )
 
     csv_upload_sync = async_to_sync(csv_upload)

--- a/project/npda/tests/form_tests/test_external_patient_validators.py
+++ b/project/npda/tests/form_tests/test_external_patient_validators.py
@@ -143,6 +143,17 @@ async def test_http_error_calculating_index_of_multiple_deprivation():
             )
 
 
+async def test_we_dont_calculate_index_of_multiple_deprivation_for_jersey():
+    with patch("project.npda.forms.external_patient_validators.imd_for_postcode") as mock:
+        await validate_patient_async(
+                postcode="JE2 3NG",
+                gp_practice_ods_code=None,
+                gp_practice_postcode=None,
+                async_client=async_client
+            )
+            
+        assert not mock.called
+
 async def test_validate_patient_with_gp_practice_ods_code():
     result = await validate_patient_async(
         postcode=None,

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -11,6 +11,7 @@ from asgiref.sync import async_to_sync
 
 import nhs_number
 import pandas as pd
+import numpy as np
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.apps import apps
@@ -324,36 +325,6 @@ def test_missing_nhs_number(
     errors = csv_upload_sync(test_user, single_row_valid_df)
 
     assert "nhs_number" in errors[0]
-
-    # We shouldn't save this patient (invariant enforced in Patient.clean not in the database)
-    assert Patient.objects.count() == 0
-
-
-@pytest.mark.django_db
-def test_missing_unique_reference_number(
-    seed_groups_per_function_fixture,
-    seed_users_per_function_fixture,
-    single_row_valid_df,
-):
-    # As these tests need full transaction support we can't use our session fixtures
-    test_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
-    ).first()
-
-    # Delete all patients to ensure we're starting from a clean slate
-    Patient.objects.all().delete()
-
-    df = single_row_valid_df.rename(columns={"NHS Number": "Unique Reference Number"})
-    df.loc[0, "Unique Reference Number"] = None
-
-    assert (
-        Patient.objects.count() == 0
-    ), "There should be no patients in the database before the test"
-
-    jersey = PaediatricDiabetesUnit.objects.get(pz_code="PZ248")
-    errors = csv_upload_sync(test_user, df, pdu=jersey)
-
-    assert "unique_reference_number" in errors[0]
 
     # We shouldn't save this patient (invariant enforced in Patient.clean not in the database)
     assert Patient.objects.count() == 0
@@ -933,7 +904,8 @@ def test_invalid_nhs_number_column_name(test_user, dummy_sheet_csv):
     csv = dummy_sheet_csv.replace("NHS Number", "NHSNumberXYZWoo")
     results = read_csv_from_str(csv)
 
-    assert results.missing_columns == ["NHS Number"]
+    # Added to missing_columns in the route as there we know if it was supposed to be a Jersey upload or England
+    assert results.identifier_column is None
     assert results.additional_columns == ["NHSNumberXYZWoo"]
 
 
@@ -1023,6 +995,39 @@ def test_upload_without_headers(test_user, one_patient_two_visits):
     # No patients or associated visits should be saved
     assert Patient.objects.count() == 0
     assert Visit.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_jersey_csv(test_user, one_patient_two_visits):
+    df = one_patient_two_visits.rename(columns={"NHS Number": "Unique Reference Number"})
+    csv = df.to_csv(index=False, date_format="%d/%m/%Y")
+
+    parsed_csv = read_csv_from_str(csv)
+    assert parsed_csv.identifier_column == "Unique Reference Number"
+
+
+@pytest.mark.django_db
+def test_missing_identifier_columns(test_user, one_patient_two_visits):
+    df = one_patient_two_visits.drop(["NHS Number"], axis=1)
+    csv = df.to_csv(index=False, date_format="%d/%m/%Y")
+
+    parsed_csv = read_csv_from_str(csv)
+    # Added to missing columns in the route as there we know if it was supposed to be a Jersey upload or England
+    assert parsed_csv.identifier_column is None
+
+
+@pytest.mark.django_db
+def test_both_identifier_columns_causes_an_error(test_user, one_patient_two_visits):
+    df = one_patient_two_visits
+    df = df.assign(**{"Unique Reference Number": np.arange(df.shape[0])})
+    
+    assert "NHS Number" in df.columns
+    assert "Unique Reference Number" in df.columns
+
+    csv = df.to_csv(index=False, date_format="%d/%m/%Y")
+
+    with pytest.raises(ValueError):
+        read_csv_from_str(csv)
 
 
 @pytest.mark.django_db

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -77,7 +77,7 @@ async def home(request):
         if request.session.get("can_upload_csv") is True:
             # check to see if the CSV is valid - cannot accept CSVs with no header. All other header errors are non-lethal but are reported back to the user
             try:
-                parsed_csv = csv_parse(io.BytesIO(user_csv_bytes), is_jersey=is_jersey)
+                parsed_csv = csv_parse(io.BytesIO(user_csv_bytes))
             except ValueError as e:
                 messages.error(
                     request=request,
@@ -85,15 +85,19 @@ async def home(request):
                 )
                 return redirect("home")
 
+            missing_columns = parsed_csv.missing_columns
+            if not parsed_csv.identifier_column:
+                missing_columns.append("Unique Reference Number" if is_jersey else "NHS Number")
+
             if (
-                parsed_csv.missing_columns
+                missing_columns
                 or parsed_csv.additional_columns
                 or parsed_csv.duplicate_columns
             ):
                 message = "Invalid CSV format."
-                if parsed_csv.missing_columns:
+                if missing_columns:
                     message += (
-                        f" Missing columns: [{", ".join(parsed_csv.missing_columns)}]"
+                        f" Missing columns: [{", ".join(missing_columns)}]"
                     )
                 if parsed_csv.additional_columns:
                     message += f" Unexpected columns: [{", ".join(parsed_csv.additional_columns)}]"
@@ -102,6 +106,13 @@ async def home(request):
                 messages.error(
                     request=request,
                     message=message,
+                )
+                return redirect("home")
+            
+            if parsed_csv.identifier_column == "Unique Reference Number" and not is_jersey:
+                messages.error(
+                    request=request,
+                    message="CSV file must use NHS number as the identifier column unless uploading for Jersey"
                 )
                 return redirect("home")
 


### PR DESCRIPTION
Follow on to #959 and #961 

Refactors `csv_parse` to not require `is_jersey` as a parameter. This means we can use it as part of a bulk upload, where we use the `PDU Number` column to determine PDU. It's a bit silly since only Jersey uses CSV data with `Unique Reference Number` but keeps things consistent.

Also skip calculating IMD for Jersey as it's not supported yet.