### PR TITLE
aggregates health check categories totals complete vs  eligible

### DIFF
--- a/project/npda/templates/dashboard/components/cards/n_on_hcl_card.html
+++ b/project/npda/templates/dashboard/components/cards/n_on_hcl_card.html
@@ -1,23 +1,20 @@
 {% extends "dashboard/components/bases/base_secondary_card.html" %}
-
 {% block card_title %}
     Closed Loop
     {% include 'common/docs_icon_link_button.html' with rel_url="developer/kpis/hybrid_closed_loop_system" fa_icon_class="fa-solid fa-eye" %}
+    <span class="tooltip" data-tip="See patient report">
+        {% url 'patient_report' as base_url %}
+        <a href="{{ base_url }}?category=treatment&sort=treatment_regimen&order=asc">
+            <i class="fa-solid fa-arrow-up-right-from-square text-rcpch_pink"></i>
+        </a>
+    </span>
 {% endblock %}
-
 {% block card_content %}
-
-<div
-hx-get="{% url 'get_n_on_hcl_partial' %}"
-hx-trigger="load" hx-swap="innerHTML"
-_="on htmx:afterSwap remove #loading-spinner-n-on-hcl-card"></div>
-
-
-
-
-<div id="loading-spinner-n-on-hcl-card"
-class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
-</div>
-
-
+    <div hx-get="{% url 'get_n_on_hcl_partial' %}"
+         hx-trigger="load"
+         hx-swap="innerHTML"
+         _="on htmx:afterSwap remove #loading-spinner-n-on-hcl-card"></div>
+    <div id="loading-spinner-n-on-hcl-card"
+         class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
+    </div>
 {% endblock %}

--- a/project/npda/templates/dashboard/components/cards/pump_card.html
+++ b/project/npda/templates/dashboard/components/cards/pump_card.html
@@ -1,23 +1,19 @@
 {% extends "dashboard/components/bases/base_secondary_card.html" %}
-
 {% block card_title %}
     Pump
     {% include 'common/docs_icon_link_button.html' with rel_url="developer/kpis/treatment_regimen/#15-insulin-pump-including-those-using-a-pump-as-part-of-a-hybrid-closed-loop" fa_icon_class="fa-solid fa-eye" %}
-{% endblock %}
-
-{% block card_content %}
-
-<div
-hx-get="{% url 'get_pump_partial' %}"
-hx-trigger="load" hx-swap="innerHTML"
-_="on htmx:afterSwap remove #loading-spinner-pump-card"></div>
-
-
-
-
-<div id="loading-spinner-pump-card"
-class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
-</div>
-
-
-{% endblock %}
+    <span class="tooltip" data-tip="See patient report">
+        {% url 'patient_report' as base_url %}
+        <a href="{{ base_url }}?category=treatment&sort=treatment_regimen&order=desc">
+            <i class="fa-solid fa-arrow-up-right-from-square text-rcpch_pink"></i>
+        </a>
+    {% endblock %}
+    {% block card_content %}
+        <div hx-get="{% url 'get_pump_partial' %}"
+             hx-trigger="load"
+             hx-swap="innerHTML"
+             _="on htmx:afterSwap remove #loading-spinner-pump-card"></div>
+        <div id="loading-spinner-pump-card"
+             class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center h-full w-1/5 mx-auto bg-center">
+        </div>
+    {% endblock %}

--- a/project/npda/templates/partials/page_elements/copy_button.html
+++ b/project/npda/templates/partials/page_elements/copy_button.html
@@ -9,15 +9,13 @@
   - icon_class: Optional additional CSS classes for the icon
   - size: Optional size (xs, sm, md, lg) - defaults to sm
 {% endcomment %}
-
-<button
-  class="btn btn-circle btn-{{ size|default:'sm' }} btn-primary tooltip tooltip-right {% if button_class %}{{ button_class }}{% endif %}"
-  data-tip="{{ tooltip|default:'Copy to clipboard' }}"
-  onclick="copyToClipboard('{{ value }}', this)"
-  aria-label="Copy {{ value }} to clipboard">
-  <i class="fa-solid fa-clipboard {% if icon_class %}{{ icon_class }}{% endif %}" id="icon-{{ value|slugify }}"></i>
+<button class="btn btn-circle btn-{{ size|default:'sm' }} btn-info tooltip tooltip-right {% if button_class %}{{ button_class }}{% endif %}"
+        data-tip="{{ tooltip|default:'Copy to clipboard' }}"
+        onclick="copyToClipboard('{{ value }}', this)"
+        aria-label="Copy {{ value }} to clipboard">
+  <i class="fa-solid fa-clipboard {% if icon_class %}{{ icon_class }}{% endif %}"
+     id="icon-{{ value|slugify }}"></i>
 </button>
-
 <script>
   function copyToClipboard(text, button) {
     // Copy text to clipboard

--- a/project/npda/templates/patient_report/health_checks_table_partial.html
+++ b/project/npda/templates/patient_report/health_checks_table_partial.html
@@ -1,4 +1,5 @@
 {% extends "patient_report/base_table.html" %}
+{% load npda_tags %}
 {% block description_box %}
   {% include "patient_report/description_box.html" with description="HbA1c, BMI, and thyroid screen must be completed annually for all children and young people <i><b>with Type 1 diabetes</i></b>. Urinary albumin, blood pressure, and foot exam are mandatory for young people aged 12 and above. Eye screening is mandatory every 2 years for young people aged 12 and above, unless retinopathy was observed at a previous screen." proportion="of all children and young people with T1 diabetes." %}
 {% endblock %}
@@ -7,7 +8,7 @@
     {% if is_jersey %}
       Unique Reference Number
     {% else %}
-      NHS Number {{ sort_field }}
+      NHS Number
     {% endif %}
     <div class="block">
       <span hx-get="?category=health_checks&sort=nhs_number&order=asc"
@@ -26,7 +27,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  HBA1c
+  HBA1c ({{ total_passed_hba1c|percentage:total_eligible_hba1c }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_hba1c&order=desc"
           hx-target="#table-area"
@@ -43,7 +44,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  BMI
+  BMI ({{ total_passed_bmi|percentage:total_eligible_bmi }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_bmi&order=desc"
           hx-target="#table-area"
@@ -60,7 +61,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Thyroid Screen
+  Thyroid Screen ({{ total_passed_thyroid_screen|percentage:total_eligible_thyroid_screen }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_thyroid_screen&order=desc"
           hx-target="#table-area"
@@ -77,7 +78,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Blood Pressure
+  Blood Pressure ({{ total_passed_blood_pressure|percentage:total_eligible_blood_pressure }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_blood_pressure&order=desc"
           hx-target="#table-area"
@@ -94,7 +95,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Urinary Albumin
+  Urinary Albumin ({{ total_passed_urinary_albumin|percentage:total_eligible_urinary_albumin }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_urinary_albumin&order=desc"
           hx-target="#table-area"
@@ -111,7 +112,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Foot Exam
+  Foot Exam ({{ total_passed_foot_exam|percentage:total_eligible_foot_exam }} complete)
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_foot_exam&order=desc"
           hx-target="#table-area"
@@ -138,38 +139,38 @@
 {% endblock %}
 {% block table_body %}
   {% for patient in patients %}
-    {% if  patient.is_first_complete_year_of_care %}
+    {% if  patients.0.is_first_complete_year_of_care %}
       <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50">
         <tr>
           <th colspan="9">These patients are completing their first year of care.</th>
         </tr>
       </thead>
     {% endif %}
-    <tr class="{% if not patient.is_complete_year_of_care %}bg-rcpch_orange_light_tint3{% endif %}">
+    <tr class="{% if not patients.0.is_complete_year_of_care %}bg-rcpch_orange_light_tint3{% endif %}">
       <td>
-        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patient.pk is_complete_year_of_care=patient.is_complete_year_of_care patient_identifier=patient.patient_identifier %}
+        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patients.0.pk is_complete_year_of_care=patients.0.is_complete_year_of_care patient_identifier=patients.0.patient_identifier %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_hba1c %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_hba1c %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_bmi %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_bmi %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_thyroid_screen %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_thyroid_screen %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_blood_pressure ineligible_reason=ineligible_reasons.blood_pressure %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_blood_pressure ineligible_reason=ineligible_reasons.blood_pressure %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_urinary_albumin ineligible_reason=ineligible_reasons.urinary_albumin %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_urinary_albumin ineligible_reason=ineligible_reasons.urinary_albumin %}
       </td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_foot_exam ineligible_reason=ineligible_reasons.foot_exam %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_foot_exam ineligible_reason=ineligible_reasons.foot_exam %}
       </td>
-      <td>{{ patient.num_passed }} / {{ patient.num_total }}</td>
+      <td>{{ patients.0.num_passed }} / {{ patients.0.num_total }}</td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_retinal_screening ineligible_reason=ineligible_reasons.retinal_screening %}
+        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patients.0.passed_retinal_screening ineligible_reason=ineligible_reasons.retinal_screening %}
       </td>
     </tr>
   {% empty %}

--- a/project/npda/templates/patient_report/patient_report.html
+++ b/project/npda/templates/patient_report/patient_report.html
@@ -8,7 +8,12 @@
       <h1 class="text-2xl font-bold mb-4">Patient Report</h1>
       <div id="table-area" hx-swap="innerHTML">
         {% comment %} Just the default table, htmx views swap this out {% endcomment %}
-        {% include "patient_report/health_checks_table_partial.html" with sort_field=sort_field sort_order=sort_order %}
+        {% if selected_category == "treatment" %}
+          <!-- slight hack: this is designed for htmx but now we navigate here from the dashboard just for treatment also -->
+          {% include "patient_report/treatment_table_partial.html" with sort_field="treatment" sort_order=sort_order %}
+        {% else %}
+          {% include "patient_report/health_checks_table_partial.html" with sort_field=sort_field sort_order=sort_order %}
+        {% endif %}
       </div>
     </div>
   </div>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -472,3 +472,14 @@ def disable_fields(field, form):
         return True
 
     return False
+
+@register.filter
+def percentage(measure, total):
+    """
+    Returns the percentage of a measure against a total
+    """
+    if measure is None or total is None or measure == "" or total == "":
+        return "-"
+    if total == 0:
+        return "0%"
+    return f"{round(int(measure) / int(total) * 100)}%"

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -314,6 +314,7 @@ class PatientReportView(
             ).values(
                 "pk",
                 "patient_identifier",
+                "is_gte_12yo",
                 "is_complete_year_of_care",
                 "passed_hba1c",
                 "passed_bmi",
@@ -735,6 +736,7 @@ class PatientReportView(
                 "smoking_cessation_referral": "Not required as less than 12 years old",
             }
 
+        # Set the first complete year of care flag
         first_complete_year_of_care = False
         if context["sort_field"] == "":
             patients = context["patients"]
@@ -748,7 +750,55 @@ class PatientReportView(
                 else:
                     patient["is_first_complete_year_of_care"] = False
             context["patients"] = patients
-
+        
+        # Get the totals of each item of the health check data as well as the total
+        # of those eligible for the health check
+        if self.selected_category == TableCategories.HEALTH_CHECKS.value:
+            total_passed_bmi = 0
+            total_eligible_bmi = 0
+            total_passed_hba1c = 0
+            total_eligible_hba1c = 0
+            total_passed_thyroid_screen = 0
+            total_eligible_thyroid_screen = 0
+            total_passed_blood_pressure = 0
+            total_eligible_blood_pressure = 0
+            total_passed_urinary_albumin = 0
+            total_eligible_urinary_albumin = 0
+            total_passed_retinal_screening = 0
+            total_eligible_retinal_screening = 0
+            total_passed_foot_exam = 0
+            total_eligible_foot_exam = 0
+            for patient in context["patients"]:
+               if patient["is_complete_year_of_care"]:
+                    total_passed_bmi += patient["passed_bmi"]
+                    total_eligible_bmi += 1
+                    total_passed_hba1c += patient["passed_hba1c"]
+                    total_eligible_hba1c += 1
+                    total_passed_thyroid_screen += patient["passed_thyroid_screen"]
+                    total_eligible_thyroid_screen += 1
+                    if patient["is_gte_12yo"]:
+                        # total_passed_retinal_screening += (
+                        #     patient["passed_retinal_screening"]
+                        # )
+                        # total_eligible_retinal_screening += 1
+                        total_passed_blood_pressure += patient["passed_blood_pressure"]
+                        total_eligible_blood_pressure += 1
+                        total_passed_urinary_albumin += patient["passed_urinary_albumin"]
+                        total_eligible_urinary_albumin += 1
+                        total_passed_foot_exam += patient["passed_foot_exam"]
+                        total_eligible_foot_exam += 1
+            context["total_passed_bmi"] = total_passed_bmi
+            context["total_eligible_bmi"] = total_eligible_bmi
+            context["total_passed_hba1c"] = total_passed_hba1c
+            context["total_eligible_hba1c"] = total_eligible_hba1c
+            context["total_passed_thyroid_screen"] = total_passed_thyroid_screen
+            context["total_eligible_thyroid_screen"] = total_eligible_thyroid_screen
+            context["total_passed_blood_pressure"] = total_passed_blood_pressure
+            context["total_eligible_blood_pressure"] = total_eligible_blood_pressure
+            context["total_passed_urinary_albumin"] = total_passed_urinary_albumin
+            context["total_eligible_urinary_albumin"] = total_eligible_urinary_albumin
+            context["total_passed_foot_exam"] = total_passed_foot_exam
+            context["total_eligible_foot_exam"] = total_eligible_foot_exam
         return context
 
     def get_template_names(self) -> list[str]:

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -71,7 +71,7 @@ class PatientReportView(
 
     # Context
     model = Patient
-    template_name = "patient_report/new_patient_report.html"
+    template_name = "patient_report/patient_report.html"
     context_object_name = "patients"
     paginate_by = 50
 
@@ -707,7 +707,12 @@ class PatientReportView(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
+        # if self.request.GET.get("category"):
+        #     # Get the selected category from the request if navigating from dashboard
+        #     self.selected_category = self.request.GET.get("category")
+        # else:
+        #     self.selected_category = TableCategories.HEALTH_CHECKS.value
+        #     context["selected_category"] = self.selected_category
         # Jersey
         if self.request.session.get("pz_code") == "PZ248":
             context["is_jersey"] = True
@@ -753,21 +758,21 @@ class PatientReportView(
         
         # Get the totals of each item of the health check data as well as the total
         # of those eligible for the health check
+        total_passed_bmi = 0
+        total_eligible_bmi = 0
+        total_passed_hba1c = 0
+        total_eligible_hba1c = 0
+        total_passed_thyroid_screen = 0
+        total_eligible_thyroid_screen = 0
+        total_passed_blood_pressure = 0
+        total_eligible_blood_pressure = 0
+        total_passed_urinary_albumin = 0
+        total_eligible_urinary_albumin = 0
+        total_passed_retinal_screening = 0
+        total_eligible_retinal_screening = 0
+        total_passed_foot_exam = 0
+        total_eligible_foot_exam = 0
         if self.selected_category == TableCategories.HEALTH_CHECKS.value:
-            total_passed_bmi = 0
-            total_eligible_bmi = 0
-            total_passed_hba1c = 0
-            total_eligible_hba1c = 0
-            total_passed_thyroid_screen = 0
-            total_eligible_thyroid_screen = 0
-            total_passed_blood_pressure = 0
-            total_eligible_blood_pressure = 0
-            total_passed_urinary_albumin = 0
-            total_eligible_urinary_albumin = 0
-            total_passed_retinal_screening = 0
-            total_eligible_retinal_screening = 0
-            total_passed_foot_exam = 0
-            total_eligible_foot_exam = 0
             for patient in context["patients"]:
                if patient["is_complete_year_of_care"]:
                     total_passed_bmi += patient["passed_bmi"]
@@ -821,3 +826,4 @@ class PatientReportView(
                 return ["patient_report/health_checks_table_partial.html"]
 
         return ["patient_report/patient_report.html"]
+    


### PR DESCRIPTION
### Overview
Adds totals for health checks in the patient report 
These are not there by default so the annotated numbers have to be aggregated to generate the totals. Some measures are for the over twelves so this is included in the filter. Note that retinopathy screening eligibility is harder to calculate because the test is needed only every 2 years unless a previous test was positivity - because of this retinopathy totals have been left off.

closes #696