### PR TITLE
Issue980-multiple-employer-logs

### DIFF
--- a/project/npda/models/npda_user.py
+++ b/project/npda/models/npda_user.py
@@ -221,6 +221,9 @@ class NPDAUser(AbstractUser, PermissionsMixin):
 
     def get_short_name(self):
         return self.first_name
+    
+    def number_of_pdu_memberships(self):
+        return self.organisation_employers.count()
 
     def get_all_employer_organisations(self):
         return self.organisation_employers.all()

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -106,8 +106,8 @@
             Resend Confirmation Email
           </button>
         {% endif %}
-        <a class="bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint {% if not perms.npda.change_npdauser %}btn-disabled opacity-50 cursor-not-allowed pointer-events-none {% endif %}"
-           href="{% url 'npdauser-delete' npdauser.pk %}{% if not perms.npda.change_npdauser %}disabled{% endif %}">Delete</a>
+        <a class="bg-rcpch_red text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint {% if not perms.npda.delete_npdauser or form.instance.pk == request.user.pk %}btn-disabled opacity-50 cursor-not-allowed pointer-events-none {% endif %}"
+           href="{% url 'npdauser-delete' npdauser.pk %}">Delete</a>
       {% endif %}
     </form>
   </div>

--- a/project/npda/templates/partials/npda_user_table.html
+++ b/project/npda/templates/partials/npda_user_table.html
@@ -51,7 +51,7 @@
                   </a>
                 </span>
               {% else %}
-                <span class="flex flex-row text-left hover:text-rcpch_pink px-2 text-rcpch_dark_blue btn btn-wide flex p-1 h-full tooltip tooltip-right"
+                <span class="flex flex-row text-left hover:text-rcpch_pink px-2 text-rcpch_dark_blue btn btn-wide flex p-1 h-full opacity-50 cursor-not-allowed tooltip tooltip-right"
                       data-tip="Member of {{ npda_user.number_of_pdu_memberships }} PDUs at least one of which differs from yours. Please contact NPDA to make changes to {{ npda_user }}'s account'.">
                   <strong>{{ npda_user.pk }} <i class="fa-solid fa-hospital fa-xl"></i></strong>
                 </span>

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -37,7 +37,8 @@ from project.constants.user import (
 from project.npda.general_functions.audit_period import get_audit_period_for_date
 from project.npda.general_functions.csv import csv_parse
 from project.npda.models import NPDAUser, Submission
-from project.npda.models.visitactivity import VisitActivity
+from project.npda.models.organisation_employer import OrganisationEmployer
+from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
 from project.npda.tests.UserDataClasses import (
@@ -1019,3 +1020,141 @@ def test_editors_and_readers_can_only_view_their_own_logs(
             assert response.status_code == HTTPStatus.OK, (
                 f"User {user_should_see_all_logs.first_name} ({user_should_see_all_logs.organisation_employers.first().pz_code}) should be able to see logs for user {other_user.first_name} ({other_user.organisation_employers.first().pz_code})"
             )
+    
+@pytest.mark.django_db
+def test_coordinators_can_see_users_with_multiple_employers_if_in_same_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators can see users with multiple employers if they are in the same PDU."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Create a test user with multiple employers in the same PDU
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-logs", kwargs={"npdauser_id": test_user_multiple_employers.pk})
+    response = client.get(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.OK
+
+@pytest.mark.django_db
+def test_coordinators_can_edit_users_with_multiple_employers_even_if_in_same_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators can see users with multiple employers if they are in the same PDU."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Create a test user with multiple employers in the same PDU
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-update", kwargs={"pk": test_user_multiple_employers.pk})
+    response = client.get(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.OK
+
+@pytest.mark.django_db
+def test_coordinators_cannot_delete_users_with_multiple_employers_even_if_in_same_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators can see users with multiple employers if they are in the same PDU."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Create a test user with multiple employers in the same PDU
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-delete", kwargs={"pk": test_user_multiple_employers.pk})
+    response = client.post(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+@pytest.mark.django_db
+def test_coordinators_cannot_delete_themselves(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators cannot delete themselves."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-delete", kwargs={"pk": test_coordinator.pk})
+    response = client.post(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.FORBIDDEN

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -1103,7 +1103,7 @@ def test_coordinators_cannot_delete_users_with_multiple_employers_even_if_in_sam
     seed_groups_fixture,
     seed_users_fixture,
 ):
-    """Test that coordinators can see users with multiple employers if they are in the same PDU."""
+    """Test that coordinators cannot delete users with multiple employers even if they are in the same PDU."""
 
     # Create a test user
     test_coordinator = NPDAUser.objects.filter(
@@ -1158,3 +1158,41 @@ def test_coordinators_cannot_delete_themselves(
 
     # Check that the response is successful
     assert response.status_code == HTTPStatus.FORBIDDEN
+
+@pytest.mark.django_db
+def test_coordinators_can_view_user_logs_with_multiple_employers_if_in_the_same_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators can see user logs with multiple employers if they are in the same PDU."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Create a test user with multiple employers in the same PDU
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-logs", kwargs={"npdauser_id": test_user_multiple_employers.pk})
+    response = client.get(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.OK

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -129,13 +129,13 @@ class CheckPDUInstanceMixin(AccessMixin):
 
         # get PDUs assigned to user who is trying to access a view
         user_pdus = [org.pz_code for org in request.user.organisation_employers.all()]
+        print(f"User PDUs: {user_pdus}")
 
         # get pdu that user is requesting access of
         requested_pdu = ""
 
         if model == "NPDAUser":
-            requested_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
-            requested_pdu = requested_user.organisation_employers.first().pz_code
+            requested_pdu = request.session.get("pz_code") # get the pdu from the session. This will not cover national view users, but they can access all PDUs anyway
 
         elif model == "Patient":
             requested_patient = Patient.objects.get(pk=self.kwargs["pk"])

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -129,13 +129,20 @@ class CheckPDUInstanceMixin(AccessMixin):
 
         # get PDUs assigned to user who is trying to access a view
         user_pdus = [org.pz_code for org in request.user.organisation_employers.all()]
-        print(f"User PDUs: {user_pdus}")
-
-        # get pdu that user is requesting access of
-        requested_pdu = ""
 
         if model == "NPDAUser":
-            requested_pdu = request.session.get("pz_code") # get the pdu from the session. This will not cover national view users, but they can access all PDUs anyway
+            requested_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
+            if requested_user.organisation_employers.filter(pz_code=request.session.get('pz_code')).exists():
+                if requested_user.number_of_pdu_memberships() == 1:
+                    # if the user is a member of the requested pdu and there is only one, then we can use that
+                    requested_pdu = requested_user.organisation_employers.all().filter(pz_code=request.session.get('pz_code')).first().pz_code
+                else:
+                    # if the user is a member of multiple PDUs, then we need to check which one they are trying to access
+                    requested_pdu = requested_user.organisation_employers.all().filter(pz_code=request.session.get('pz_code')).first().pz_code
+            else:
+                # the user is not a member of the requested pdu so we just return the pz code of the users primary pdu
+                requested_pdu = requested_user.paediatric_diabetes_units.filter(is_primary_employer=True).first().paediatric_diabetes_unit.pz_code
+
 
         elif model == "Patient":
             requested_patient = Patient.objects.get(pk=self.kwargs["pk"])

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -389,27 +389,28 @@ class NPDAUserUpdateView(
                     "employer_choices": organisation_choices,
                 },
             )
-        if "resend_email" in request.POST:
-            npda_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
-            subject = "Password Reset Requested"
-            email = construct_confirm_email(request=request, user=npda_user)
-
-            send_email_to_recipients(
-                recipients=[npda_user.email],
-                subject=subject,
-                message=email,
-            )
-
-            messages.success(
-                request,
-                f"Confirmation and password reset request resent to {npda_user.email}.",
-            )
-            redirect_url = reverse(
-                "npda_users",
-            )
-            return redirect(redirect_url)
         else:
-            return super().post(request, *args, **kwargs)
+            if "resend_email" in request.POST:
+                npda_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
+                subject = "Password Reset Requested"
+                email = construct_confirm_email(request=request, user=npda_user)
+
+                send_email_to_recipients(
+                    recipients=[npda_user.email],
+                    subject=subject,
+                    message=email,
+                )
+
+                messages.success(
+                    request,
+                    f"Confirmation and password reset request resent to {npda_user.email}.",
+                )
+                redirect_url = reverse(
+                    "npda_users",
+                )
+                return redirect(redirect_url)
+            else:
+                return super().post(request, *args, **kwargs)
 
         
 
@@ -431,6 +432,26 @@ class NPDAUserDeleteView(
     model = NPDAUser
     success_message = "NPDA User removed from database"
     success_url = reverse_lazy("npda_users")
+
+    def post(self, request, *args, **kwargs):
+        """
+        Coordinators and RCPCH Audit Team can delete users, but only RCPCH Audit Team can delete those with multiple employers
+        Coordinators should not be able to delete themselves
+        """
+        requested_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
+        if requested_user.number_of_pdu_memberships() > 1:
+            if not (
+                self.request.user.is_superuser
+                or self.request.user.is_rcpch_audit_team_member
+            ):
+                raise PermissionDenied(
+                    "You do not have permission to delete this user as they are members of more than one PDU. Contact the NPDA for assistance."
+                )
+        if requested_user.pk == self.request.user.pk:
+            raise PermissionDenied(
+                "You cannot delete your own account. Contact the NPDA for assistance."
+            )
+        return super().post(request, *args, **kwargs)
 
 
 class NPDAUserLogsListView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, ListView):

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -78,22 +78,11 @@ class NPDAUserListView(
     context_object_name = "npdauser_list"
 
     def get_queryset(self):
-        # scope the queryset to filter only those users in organisations in the same PDU. This is to prevent users from seeing all users in the system
-        pz_code = self.request.session.get("pz_code")
-        flag_field = Count("organisation_employers")
-
-        if self.request.user.viewing_data_nationally():
-            return (
-                NPDAUser.objects.all()
-                .annotate(number_of_pdu_memberships=flag_field)
-                .order_by("surname")
-            )
-
-        return (
-            NPDAUser.objects.filter(organisation_employers__pz_code=pz_code)
-            .annotate(number_of_pdu_memberships=flag_field)
-            .order_by("surname", "organisation_employers__pz_code")
-        )
+        """
+        Apply ordering
+        """
+        queryset = super().get_queryset()
+        return queryset.order_by("surname")
 
     def get_context_data(self, **kwargs):
         context = super(NPDAUserListView, self).get_context_data(**kwargs)
@@ -376,8 +365,6 @@ class NPDAUserUpdateView(
             organisation_choices = organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
                 requesting_user=self.request.user, user_instance=user_instance
             )
-
-            print('choices ',organisation_choices)
 
             return render(
                 request=request,

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -82,7 +82,17 @@ class NPDAUserListView(
         Apply ordering
         """
         queryset = super().get_queryset()
-        return queryset.order_by("surname")
+        pz_code = self.request.session.get("pz_code")
+
+        if self.request.user.viewing_data_nationally():
+            return (
+                queryset.order_by("surname")
+            )
+
+        return (
+            queryset.filter(organisation_employers__pz_code=pz_code)
+            .order_by("surname")
+        )
 
     def get_context_data(self, **kwargs):
         context = super(NPDAUserListView, self).get_context_data(**kwargs)

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -490,7 +490,10 @@ class NPDAUserLogsListView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, Li
                 )
                 return False
 
-            if requested_pdu != npda_user.organisation_employers.first():
+            # if requested_pdu != npda_user.organisation_employers.first():
+            if not npda_user.organisation_employers.filter(
+                pz_code=requested_pdu.pz_code
+            ).exists():
                 logger.warning(
                     f"Coordinator user {logged_in_user.email} tried to view logs for another user {npda_user.email} in a different PDU {requested_pdu.pz_code}"
                 )


### PR DESCRIPTION
### Overview
This PR fixes the unfriendly 403 that results from a coordinator trying to view the user logs of another user who has more than one employer. It adds a few more things to the user model


Changes
1. This adds changes to the `CheckPDUInstanceMixin` to check the requested user employers against that in session and the `request.user` employer and permissions.
2. Adds check for multiple PDUs in the NPDAUser model and uses this in the NPDAUser list and in the user table as this had got lost.
3. Prevents users deleting themselves in the template and in the decorators
4. Adds tests for all these things

closes #980