### PR TITLE
Issue980-multiple-employers

### DIFF
--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -66,7 +66,7 @@ def create_session_object(user):
     
     primary_organisation = OrganisationEmployer.objects.filter(
         npda_user=user, is_primary_employer=True
-    ).get()
+    ).first() # There should only be one primary organisation but if there are multiple, just take the first one
     pz_code = primary_organisation.paediatric_diabetes_unit.pz_code
     pdu_choices = (
         organisations_adapter.paediatric_diabetes_units_to_populate_select_field(

--- a/project/npda/templates/partials/npda_user_table.html
+++ b/project/npda/templates/partials/npda_user_table.html
@@ -135,24 +135,27 @@
           {% endif %}
           <td class="px-6 text-left">{{ npda_user.get_role_display }}</td>
           <td class="w-80 px-2 text-right">
-            <div class="tooltip tooltip-left"
-                 data-tip="View user logs for {{ npda_user }}">
-              <a href="{% url 'npdauser-logs' npda_user.pk %}"
-                 class="text-rcpch_pink flex justify-center items-center px-2">
-                <svg class="text-rcpch_pink w-8 h-8"
-                     width="24"
-                     height="24"
-                     viewBox="0 0 24 24"
-                     stroke-width="2"
-                     stroke="currentColor"
-                     fill="none"
-                     stroke-linecap="round"
-                     stroke-linejoin="round">
-                  <path stroke="none" d="M0 0h24v24H0z" />
-                  <polyline points="9 6 15 12 9 18" />
-                </svg>
-              </a>
-            </div>
+            {% if request.user.role != 3 and request.user.role != 2 %}
+              <!--readers/editors cannot view logs-->
+              <div class="tooltip tooltip-left"
+                   data-tip="View user logs for {{ npda_user }}">
+                <a href="{% url 'npdauser-logs' npda_user.pk %}"
+                   class="text-rcpch_pink flex justify-center items-center px-2">
+                  <svg class="text-rcpch_pink w-8 h-8"
+                       width="24"
+                       height="24"
+                       viewBox="0 0 24 24"
+                       stroke-width="2"
+                       stroke="currentColor"
+                       fill="none"
+                       stroke-linecap="round"
+                       stroke-linejoin="round">
+                    <path stroke="none" d="M0 0h24v24H0z" />
+                    <polyline points="9 6 15 12 9 18" />
+                  </svg>
+                </a>
+              </div>
+            {% endif %}
           </td>
         </tr>
       {% endfor %}

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -41,6 +41,7 @@ from project.npda.models.organisation_employer import OrganisationEmployer
 from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
+from project.npda.tests.factories.npda_user_factory import NPDAUserFactory
 from project.npda.tests.UserDataClasses import (
     test_user_audit_centre_coordinator_data,
     test_user_audit_centre_editor_data,
@@ -1180,6 +1181,7 @@ def test_coordinators_can_view_user_logs_with_multiple_employers_if_in_the_same_
     ).first()
 
     GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    
     # Add multiple employers to the test user
     OrganisationEmployer.objects.create(
         npda_user=test_user_multiple_employers,
@@ -1240,3 +1242,48 @@ def test_coordinators_with_multiple_employers_can_view_user_logs_with_multiple_e
 
     # Check that the response is successful
     assert response.status_code == HTTPStatus.OK
+
+@pytest.mark.django_db
+def test_coordinators_with_multiple_employers_cannot_view_user_logs_with_multiple_employers_if_no_common_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators with multiple employers cannot see user logs with multiple employers if they are in different PDUs."""
+
+    KINGS_COLLEGE = "PZ215"
+    BCH_PZ_CODE = "PZ108"
+
+    # Create a test coordinator with multiple employers in different PDUs from the user
+    test_coordinator = NPDAUserFactory(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers=[KINGS_COLLEGE, BCH_PZ_CODE],
+    )
+    OrganisationEmployer.objects.filter(
+        npda_user=test_coordinator,
+        paediatric_diabetes_unit__pz_code=KINGS_COLLEGE,
+    ).update(is_primary_employer=False) # can't have 2 primary employers
+
+    # Create a test user with multiple employers
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-logs", kwargs={"npdauser_id": test_user_multiple_employers.pk})
+    response = client.get(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.FORBIDDEN

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -1196,3 +1196,47 @@ def test_coordinators_can_view_user_logs_with_multiple_employers_if_in_the_same_
 
     # Check that the response is successful
     assert response.status_code == HTTPStatus.OK
+
+@pytest.mark.django_db
+def test_coordinators_with_multiple_employers_can_view_user_logs_with_multiple_employers_if_in_the_same_pdu(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    """Test that coordinators with multiple employers can see user logs with multiple employers if they are in the same PDU."""
+
+    # Create a test user
+    test_coordinator = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Create a test user with multiple employers in the same PDU
+    test_user_multiple_employers = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    # Add multiple employers to the test user
+    OrganisationEmployer.objects.create(
+        npda_user=test_user_multiple_employers,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+    
+    OrganisationEmployer.objects.create(
+        npda_user=test_coordinator,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    # Login user
+    client = login_and_verify_user(client, test_coordinator)
+
+    # Make a GET request to the user logs page
+    url = reverse("npdauser-logs", kwargs={"npdauser_id": test_user_multiple_employers.pk})
+    response = client.get(url)
+
+    # Check that the response is successful
+    assert response.status_code == HTTPStatus.OK

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -490,14 +490,15 @@ class NPDAUserLogsListView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, Li
                 f"Reader or Editor user {logged_in_user.email} tried to view logs for another user {npda_user.email}"
             )
             return False
+        
 
         # Coordinators can view logs for any user in their PDU
         if logged_in_user.role == AUDIT_CENTRE_COORDINATOR:
             try:
-                requested_pdu = npda_user.organisation_employers.get(
+                npda_users_pdu_list = npda_user.organisation_employers.filter(
                     pz_code__in=logged_in_user.organisation_employers.all().values_list(
                         "pz_code", flat=True
-                    ),
+                    ), 
                 )
             except PaediatricDiabetesUnit.DoesNotExist:
                 logger.warning(f"Requested PDU for user {npda_user.email} not found")
@@ -508,12 +509,10 @@ class NPDAUserLogsListView(LoginAndOTPRequiredMixin, PermissionRequiredMixin, Li
                 )
                 return False
 
-            # if requested_pdu != npda_user.organisation_employers.first():
-            if not npda_user.organisation_employers.filter(
-                pz_code=requested_pdu.pz_code
-            ).exists():
+            if not set(npda_user.organisation_employers.all()) & set(npda_users_pdu_list):
+                # if any of the user's employers are not in the logged in user's PDU list, deny access
                 logger.warning(
-                    f"Coordinator user {logged_in_user.email} tried to view logs for another user {npda_user.email} in a different PDU {requested_pdu.pz_code}"
+                    f"Coordinator user {logged_in_user.email} tried to view logs for another user {npda_user.email} in a different PDU {npda_users_pdu_list}"
                 )
                 return False
 


### PR DESCRIPTION
### Overview
What I had not appreciated last time I tried to fix this was that while the npda user being viewed might have multiple employers, the coordinator viewing their record may also have multiple employers and this is what was happening here.

So in the workflow:
1. create a coordinator with multiple employers
2. create a reader or editor with multiple employers (with at least one the same
3. the coordinator logs in and tries to view the reader's logs
This should now work

I have added some tests for this
I have removed the opportunity in the template for readers and editors to view logs