### PR TITLE
Submissions-summary

### DIFF
--- a/project/npda/management/commands/create_groups.py
+++ b/project/npda/management/commands/create_groups.py
@@ -57,7 +57,8 @@ def groups_seeder(
         {"codename": "change_npdauser", "content_type": npdauserContentType},
         {"codename": "add_npdauser", "content_type": npdauserContentType},
         {"codename": "delete_npdauser", "content_type": npdauserContentType},
-        
+        # submission
+        {"codename": "view_submission", "content_type": submissionContentType},
         
     ]
 
@@ -70,6 +71,8 @@ def groups_seeder(
         {"codename": "view_transfer", "content_type": transferContentType},
         # NPDA-user related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
+        # submission
+        {"codename": "view_submission", "content_type": submissionContentType},
     ]
 
     EDITOR_PERMISSIONS = [
@@ -84,6 +87,8 @@ def groups_seeder(
         # transfer-related permissions = None
         # user-related permissions
         {"codename": "view_npdauser", "content_type": npdauserContentType},
+        # submission
+        {"codename": "view_submission", "content_type": submissionContentType},
     ]
 
     RCPCH_AUDIT_TEAM_PERMISSIONS = [

--- a/project/npda/templates/partials/page_elements/patient_table_actions.html
+++ b/project/npda/templates/partials/page_elements/patient_table_actions.html
@@ -70,7 +70,7 @@
                     </a>
                 </li>
                 <li>
-                    <button class="btn {% if submission_error_count > 0 %} btn-warning {% else %} btn-success {% endif %} text-white {% if not perms.npda.can_download_csv %}btn-disabled{% endif %}"
+                    <button class="btn {% if submission_error_count > 0 %} btn-warning {% else %} btn-success {% endif %} text-white {% if not perms.npda.view_submission %}btn-disabled{% endif %}"
                             type="button"
                             onclick="quality_report_modal.showModal()">
                         <i class="fa-solid fa-file-excel"></i>

--- a/project/npda/templates/partials/page_elements/patient_table_actions.html
+++ b/project/npda/templates/partials/page_elements/patient_table_actions.html
@@ -40,77 +40,88 @@
             </button>
         </label>
     </label>
-    {% if user.view_preference != 2 %}
-        {% if request.session.can_complete_questionnaire %}
-            <a href="{% url 'patient-add' %}"
-               class="btn btn-info h-auto w-full md:w-auto {% if not perms.npda.add_patient %}btn-disabled{% endif %}">
-                <i class="fa-solid fa-person-circle-plus"></i>
-                Add patient
-            </a>
-        {% else %}
-            <div class="pl-1 pr-1">
-                <ul class="menu menu-horizontal">
-                    <li>
-                        <a href="{% url 'upload_csv' %}"
-                           class="btn btn-info text-white {% if not perms.npda.can_submit_csv %}btn-disabled{% endif %}">
-                            <i class="fa-solid fa-upload"></i>
-                            Upload CSV
-                        </a>
-                    </li>
-                    <li>
-                        <button class="btn {% if submission_error_count > 0 %} btn-warning {% else %} btn-success {% endif %} text-white {% if not perms.npda.can_download_csv %}btn-disabled{% endif %}"
-                                type="button"
-                                onclick="quality_report_modal.showModal()">
-                            <i class="fa-solid fa-file-excel"></i>
-                            Data Quality Report
-                            {% if submission_error_count > 0 %}
-                                <span class="badge badge-error">{{ submission_error_count }}</span>
-                            {% endif %}
-                        </button>
-                    </li>
-                    <!-- Pop up which shows data protection guidance for report -->
-                    {% include 'partials/page_elements/quality_report_popup.html' %}
-                    <!-- Pop up which shows data protection guidance for original data download -->
-                    {% include 'partials/page_elements/original_data_popup.html' %}
-                    <div class="dropdown dropdown-bottom dropdown-end">
-                        <div tabindex="0"
-                             role="button"
-                             class="btn btn-info text-white w-12 p-0 flex">
-                            {# Trigger Element #}
-                            <i class="fa-solid fa-chevron-down"></i>
-                        </div>
-                        <ul tabindex="0"
-                            class="dropdown-content menu bg-base-100 text-black font-normal rounded-box z-[1] w-52 p-2 shadow mt-1">
-                            {# Content as Sibling #}
-                            {% if perms.npda.can_download_csv %}
-                                <li>
-                                    <button type="button"
-                                            onclick="original_data_modal.showModal()"
-                                            class="{% if not perms.npda.can_download_csv %}btn-disabled{% endif %}">
-                                        <i class="fa-solid fa-download"></i>
-                                        Download original file
-                                    </button>
-                                    {# Note: Was an <a> tag before, ensure consistency #}
-                                </li>
-                            {% endif %}
+    {% if request.session.can_complete_questionnaire %}
+        <div class="pl-1 pr-1">
+            <ul class="menu menu-horizontal">
+                <li>
+                    <a href="{% url 'patient-add' %}"
+                       class="btn btn-info h-auto w-full md:w-auto {% if not perms.npda.add_patient %}btn-disabled{% endif %}">
+                        <i class="fa-solid fa-person-circle-plus"></i>
+                        Add patient
+                    </a>
+                </li>
+                <li>
+                    <a href="{% url 'submissions' %}"
+                       class="btn btn-info h-auto w-full md:w-auto {% if not perms.npda.view_submission %}btn-disabled{% endif %}">
+                        <i class="fa-solid fa-timeline"></i>
+                        View submission history
+                    </a>
+                </li>
+            </ul>
+        </div>
+    {% else %}
+        <div class="pl-1 pr-1">
+            <ul class="menu menu-horizontal">
+                <li>
+                    <a href="{% url 'upload_csv' %}"
+                       class="btn btn-info text-white {% if not perms.npda.can_submit_csv %}btn-disabled{% endif %}">
+                        <i class="fa-solid fa-upload"></i>
+                        Upload CSV
+                    </a>
+                </li>
+                <li>
+                    <button class="btn {% if submission_error_count > 0 %} btn-warning {% else %} btn-success {% endif %} text-white {% if not perms.npda.can_download_csv %}btn-disabled{% endif %}"
+                            type="button"
+                            onclick="quality_report_modal.showModal()">
+                        <i class="fa-solid fa-file-excel"></i>
+                        Data Quality Report
+                        {% if submission_error_count > 0 %}
+                            <span class="badge badge-error">{{ submission_error_count }}</span>
+                        {% endif %}
+                    </button>
+                </li>
+                <!-- Pop up which shows data protection guidance for report -->
+                {% include 'partials/page_elements/quality_report_popup.html' %}
+                <!-- Pop up which shows data protection guidance for original data download -->
+                {% include 'partials/page_elements/original_data_popup.html' %}
+                <div class="dropdown dropdown-bottom dropdown-end">
+                    <div tabindex="0"
+                         role="button"
+                         class="btn btn-info text-white w-12 p-0 flex">
+                        {# Trigger Element #}
+                        <i class="fa-solid fa-chevron-down"></i>
+                    </div>
+                    <ul tabindex="0"
+                        class="dropdown-content menu bg-base-100 text-black font-normal rounded-box z-[1] w-52 p-2 shadow mt-1">
+                        {# Content as Sibling #}
+                        {% if perms.npda.can_download_csv %}
                             <li>
-                                <a href="{% url 'submissions' %}">
-                                    <i class="fa-solid fa-timeline"></i>
-                                    View upload history
+                                <button type="button"
+                                        onclick="original_data_modal.showModal()"
+                                        class="{% if not perms.npda.can_download_csv %}btn-disabled{% endif %}">
+                                    <i class="fa-solid fa-download"></i>
+                                    Download original file
+                                </button>
+                                {# Note: Was an <a> tag before, ensure consistency #}
+                            </li>
+                        {% endif %}
+                        <li>
+                            <a href="{% url 'submissions' %}">
+                                <i class="fa-solid fa-timeline"></i>
+                                View upload history
+                            </a>
+                        </li>
+                        {% if user.is_superuser or request.user.is_rcpch_audit_team_member %}
+                            <li>
+                                <a href="{% url 'patient-add' %}" class="text-rcpch_red">
+                                    <i class="fa-solid fa-person-circle-plus"></i>
+                                    Add patient manually (Audit Team only)
                                 </a>
                             </li>
-                            {% if user.is_superuser or request.user.is_rcpch_audit_team_member %}
-                                <li>
-                                    <a href="{% url 'patient-add' %}" class="text-rcpch_red">
-                                        <i class="fa-solid fa-person-circle-plus"></i>
-                                        Add patient manually (Audit Team only)
-                                    </a>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </div>
-                </ul>
-            </div>
-        {% endif %}
+                        {% endif %}
+                    </ul>
+                </div>
+            </ul>
+        </div>
     {% endif %}
 </div>

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -3,12 +3,28 @@
 {% load humanize %}
 <div>
   {% if request.user.view_preference == 1 %}
-    <!-- national view -->
-    <h1 class="font-montserrat text-md text-rcpch_dark_blue font-semibold">
-      All Submissions for {{ lead_organisation }} ({{ pz_code }})
-    </h1>
+    <!-- PDU/tTrust/LHB view -->
+    {% if request.user.is_rcpch_audit_team_member or request.user.is_superuser or request.user.is_rcpch_staff %}
+      <div class="alert alert-info mb-2">
+        <i class="fa-solid fa-circle-info"></i>
+        <span class="text-sm text-rcpch_dark_blue font-semibold">
+          You are currently viewing the submissions for {{ lead_organisation }} ({{ pz_code }}) only. If you want a national view of all submissions please remove the PDU filter in the Filters in the menu bar.
+        </span>
+      </div>
+    {% endif %}
+    <div class="flex flex-row items-center">
+      <h1 class="font-montserrat text-md text-rcpch_dark_blue font-semibold">
+        All Submissions for {{ lead_organisation }} ({{ pz_code }})
+      </h1>
+    </div>
   {% elif request.user.view_preference == 2 %}
-    <!-- PDU view   -->
+    <!-- National view   -->
+    <div class="alert alert-info mb-2">
+      <i class="fa-solid fa-circle-info"></i>
+      <span class="text-sm text-rcpch_dark_blue font-semibold">
+        You are currently viewing all submissions Nationally. If you want to view submissions only for {{ lead_organisation }} ({{ pz_code }}) (or any PDU) please apply the PDU filter in the Filters in the menu bar.
+      </span>
+    </div>
     <h1 class="font-montserrat text-md text-rcpch_dark_blue font-semibold">
       All Submissions Nationally
     </h1>

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -405,12 +405,15 @@ def submission_stats(selected_audit_year):
     # Retrieve the latest submission data for the selected audit year
     latest_submission_data = Submission.objects.filter(
         audit_year=selected_audit_year,
-        submission_date__gte=date.today(),
         paediatric_diabetes_unit__active=True,
         submission_active=True
     ).order_by(
         '-submission_date'
-    ).first()
+    )
+    if latest_submission_data.exists():
+        latest_submission_data = latest_submission_data.first()
+    else:
+        latest_submission_data = None
 
     fewest_errors = Submission.objects.filter(
         audit_year = selected_audit_year,
@@ -420,7 +423,11 @@ def submission_stats(selected_audit_year):
         error_count=Count('errors')
     ).order_by(
         'error_count'
-    ).first()
+    )
+    if fewest_errors.exists():
+        fewest_errors = fewest_errors.first()
+    else:
+        fewest_errors = None
 
     most_patients = Submission.objects.filter(
         audit_year = selected_audit_year,
@@ -430,7 +437,11 @@ def submission_stats(selected_audit_year):
         patient_count=Count('patients')
     ).order_by(
         '-patient_count'
-    ).first()
+    )
+    if most_patients.exists():
+        most_patients = most_patients.first()
+    else:
+        most_patients = None
 
     most_visits = Submission.objects.filter(
         audit_year = selected_audit_year,
@@ -441,7 +452,8 @@ def submission_stats(selected_audit_year):
         visits_per_patient=Count('patients')/Count('patients__visit')
     ).order_by(
         '-visits_per_patient'
-    ).first()
+    )
+
 
     latest_submission_paediatric_diabetes_unit, submission_date = getattr(latest_submission_data, "paediatric_diabetes_unit", None), getattr(latest_submission_data,"submission_date", None)
     fewest_errors_paediatric_diabetes_unit, error_number = getattr(fewest_errors, "paediatric_diabetes_unit", None), getattr(fewest_errors,"error_count", None)

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -7,12 +7,14 @@ import logging
 # Django imports
 from django.apps import apps
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Case, When, F, Value, IntegerField, OuterRef, Subquery
 from django.db.models.functions import Concat, ExtractMonth, ExtractYear
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from django.views.generic import ListView
+
 
 # Third party imports
 import pandas as pd
@@ -40,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 class SubmissionsListView(
-    LoginAndOTPRequiredMixin, ListView
+    LoginAndOTPRequiredMixin, ListView, PermissionRequiredMixin
 ):
     """
     The SubmissionsListView class.
@@ -55,6 +57,8 @@ class SubmissionsListView(
     model = apps.get_model(app_label="npda", model_name="Submission")
     template_name = "submissions_list.html"
     context_object_name = "submissions"
+    permission_required = "npda.view_submission"
+    permission_denied_message = "You do not have permission to view submissions."
 
     def get_queryset(self) -> Iterable[Any]:
         """


### PR DESCRIPTION
### Overview
At NPDA sprint 16/5/25 we noticed that the submissions summary view was not accessible from the patient list (as it had been before), and that in national view the stats threw errors if some queries were empty and this threw a 500 error

In the course of fixing this it became clear that although the docs say that readers, editors and coordinators can view submissions, this permission has not been implemented for all in this way.

changes:
1. add a view submissions button to the patient list, even for those that are using the questionnaire
2. fix the stats summaries in the national view of the submissions list
3. add alerts to the national view submissions list to remind Audit Team members to switch context here to national view to get the national stats
4. add view_submission to the seeding of groups for future

Other things that need to happen after closing this PR
1. Add view_submission to all readers / editors and coordinators