### PR TITLE
Fix deploys broken due to AZ CLI upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - live
+      - mbarton/fix-az-cli-snafu
 
 permissions:
   id-token: write
@@ -25,6 +26,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: 'Run CI script'
+        uses: azure/cli@v2
         env:
           AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}
           AZURE_CONFIG_STORAGE_ACCOUNT: ${{ secrets.AZURE_CONFIG_STORAGE_ACCOUNT }}
@@ -32,7 +34,10 @@ jobs:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        run: s/ci
+        with:
+          # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
+          azcliversion: 2.71.0
+          inlineScript: s/ci
       
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - live
+      - mbarton/fix-az-cli-snafu
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Deploy to live
         uses: azure/cli@v2
         env:
-          AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
+          AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
           AZURE_CORE_USE_MSAL_HTTP_CACHE: false
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,21 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
         run: s/ci
       
+      # Workaround https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
+      # TODO MRB: remove the Docker wrapper once https://github.com/Azure/azure-cli/pull/31508 is released
+      - name: Azure CLI script
+        uses: azure/cli@v2
+        env:
+          AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        with:
+          azcliversion: 2.71.0
+          inlineScript: |
+            s/deploy-revision.py \
+              --name ${AZURE_STAGING_APP_NAME} \
+              --resource-group ${AZURE_RESOURCE_GROUP} \
+              --git-hash ${GITHUB_SHA}
+
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,6 @@ jobs:
           # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
           azcliversion: 2.71.0
           inlineScript: |
-            pip install pyyaml && \
             s/deploy-revision.py \
               --name {{ secrets.AZURE_STAGING_APP_NAME }} \
               --resource-group {{ secrets.AZURE_RESOURCE_GROUP }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_CORE_USE_MSAL_HTTP_CACHE: false
         with:
           azcliversion: 2.71.0
           inlineScript: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: 'Run CI script'
+        uses: azure/cli@v2
         env:
           AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}
           AZURE_CONFIG_STORAGE_ACCOUNT: ${{ secrets.AZURE_CONFIG_STORAGE_ACCOUNT }}
@@ -33,21 +34,11 @@ jobs:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        run: s/ci
-      
-      # TODO MRB: put back into s/ci once https://github.com/Azure/azure-cli/pull/31508 is released
-      #   (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003)
-      - name: 'Deploy staging'
-        uses: azure/cli@v2
         with:
           # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
           azcliversion: 2.71.0
-          inlineScript: |
-            s/deploy-revision.py \
-              --name {{ secrets.AZURE_STAGING_APP_NAME }} \
-              --resource-group {{ secrets.AZURE_RESOURCE_GROUP }} \
-              --git-hash ${{ github.sha }}
-
+          inlineScript: s/ci
+      
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - live
-      - mbarton/fix-az-cli-snafu
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,7 @@ jobs:
           # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
           azcliversion: 2.71.0
           inlineScript: |
+            pip install pyyaml && \
             s/deploy-revision.py \
               --name {{ secrets.AZURE_STAGING_APP_NAME }} \
               --resource-group {{ secrets.AZURE_RESOURCE_GROUP }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: 'Run CI script'
-        uses: azure/cli@v2
         env:
           AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}
           AZURE_CONFIG_STORAGE_ACCOUNT: ${{ secrets.AZURE_CONFIG_STORAGE_ACCOUNT }}
@@ -34,11 +33,21 @@ jobs:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        run: s/ci
+      
+      # TODO MRB: put back into s/ci once https://github.com/Azure/azure-cli/pull/31508 is released
+      #   (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003)
+      - name: 'Deploy staging'
+        uses: azure/cli@v2
         with:
           # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
           azcliversion: 2.71.0
-          inlineScript: s/ci
-      
+          inlineScript: |
+            s/deploy-revision.py \
+              --name {{ secrets.AZURE_STAGING_APP_NAME }} \
+              --resource-group {{ secrets.AZURE_RESOURCE_GROUP }} \
+              --git-hash ${{ github.sha }}
+
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - live
-      - mbarton/fix-az-cli-snafu
 
 permissions:
   id-token: write
@@ -26,7 +25,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: 'Run CI script'
-        uses: azure/cli@v2
         env:
           AZURE_REGISTRY_NAME: ${{ secrets.AZURE_REGISTRY_NAME }}
           AZURE_CONFIG_STORAGE_ACCOUNT: ${{ secrets.AZURE_CONFIG_STORAGE_ACCOUNT }}
@@ -34,10 +32,7 @@ jobs:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
           AZURE_LIVE_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        with:
-          # Pin az cli for now https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
-          azcliversion: 2.71.0
-          inlineScript: s/ci
+        run: s/ci
       
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       
       # Workaround https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
       # TODO MRB: remove the Docker wrapper once https://github.com/Azure/azure-cli/pull/31508 is released
-      - name: Azure CLI script
+      - name: Deploy to staging
         uses: azure/cli@v2
         env:
           AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_STAGING_APP_NAME }}
@@ -48,6 +48,20 @@ jobs:
           inlineScript: |
             s/deploy-revision.py \
               --name ${AZURE_STAGING_APP_NAME} \
+              --resource-group ${AZURE_RESOURCE_GROUP} \
+              --git-hash ${GITHUB_SHA}
+      
+      - name: Deploy to live
+        uses: azure/cli@v2
+        env:
+          AZURE_STAGING_APP_NAME: ${{ secrets.AZURE_LIVE_APP_NAME }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_CORE_USE_MSAL_HTTP_CACHE: false
+        with:
+          azcliversion: 2.71.0
+          inlineScript: |
+            s/deploy-revision.py \
+              --name ${AZURE_LIVE_APP_NAME} \
               --resource-group ${AZURE_RESOURCE_GROUP} \
               --git-hash ${GITHUB_SHA}
 

--- a/s/ci
+++ b/s/ci
@@ -26,8 +26,15 @@ azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
 docker tag npda-django:built ${azure_tag}
 docker push ${azure_tag}
 
-# Deploy temporarily moved up to GitHub workflow as a workound for
-# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
-# TODO MRB: put it back in here once https://github.com/Azure/azure-cli/pull/31508 is released
+# Deploy to Azure Container Apps
+s/deploy-revision.py \
+    --name ${AZURE_STAGING_APP_NAME} \
+    --resource-group ${AZURE_RESOURCE_GROUP} \
+    --git-hash ${GITHUB_SHA}
+
+# s/deploy-revision.py \
+#     --name ${AZURE_LIVE_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --git-hash ${GITHUB_SHA}
 
 # Deploy to the docs is handled in the GitHub workflow itself

--- a/s/ci
+++ b/s/ci
@@ -32,9 +32,9 @@ s/deploy-revision.py \
     --resource-group ${AZURE_RESOURCE_GROUP} \
     --git-hash ${GITHUB_SHA}
 
-# s/deploy-revision.py \
-#     --name ${AZURE_LIVE_APP_NAME} \
-#     --resource-group ${AZURE_RESOURCE_GROUP} \
-#     --git-hash ${GITHUB_SHA}
+s/deploy-revision.py \
+    --name ${AZURE_LIVE_APP_NAME} \
+    --resource-group ${AZURE_RESOURCE_GROUP} \
+    --git-hash ${GITHUB_SHA}
 
 # Deploy to the docs is handled in the GitHub workflow itself

--- a/s/ci
+++ b/s/ci
@@ -32,7 +32,7 @@ docker push ${azure_tag}
 docker run \
     --volume .:/opt/npda \
     mcr.microsoft.com/azure-cli:2.72.0 \
-        s/deploy-revision.py \
+        /opt/npda/s/deploy-revision.py \
             --name ${AZURE_STAGING_APP_NAME} \
             --resource-group ${AZURE_RESOURCE_GROUP} \
             --git-hash ${GITHUB_SHA}

--- a/s/ci
+++ b/s/ci
@@ -27,14 +27,19 @@ docker tag npda-django:built ${azure_tag}
 docker push ${azure_tag}
 
 # Deploy to Azure Container Apps
-s/deploy-revision.py \
-    --name ${AZURE_STAGING_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --git-hash ${GITHUB_SHA}
+# Workaround https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
+# TODO MRB: remove the Docker wrapper once https://github.com/Azure/azure-cli/pull/31508 is released
+docker run \
+    --volume .:/opt/npda \
+    mcr.microsoft.com/azure-cli:2.72.0 \
+        s/deploy-revision.py \
+            --name ${AZURE_STAGING_APP_NAME} \
+            --resource-group ${AZURE_RESOURCE_GROUP} \
+            --git-hash ${GITHUB_SHA}
 
-s/deploy-revision.py \
-    --name ${AZURE_LIVE_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --git-hash ${GITHUB_SHA}
+# s/deploy-revision.py \
+#     --name ${AZURE_LIVE_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --git-hash ${GITHUB_SHA}
 
 # Deploy to the docs is handled in the GitHub workflow itself

--- a/s/ci
+++ b/s/ci
@@ -27,15 +27,13 @@ docker tag npda-django:built ${azure_tag}
 docker push ${azure_tag}
 
 # Deploy to Azure Container Apps
-# Workaround https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
-# TODO MRB: remove the Docker wrapper once https://github.com/Azure/azure-cli/pull/31508 is released
-docker run \
-    --volume .:/opt/npda \
-    mcr.microsoft.com/azure-cli:2.72.0 \
-        /opt/npda/s/deploy-revision.py \
-            --name ${AZURE_STAGING_APP_NAME} \
-            --resource-group ${AZURE_RESOURCE_GROUP} \
-            --git-hash ${GITHUB_SHA}
+# Temporarily done in the GitHub workflow instead to Workaround https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
+# TODO MRB: put back here once https://github.com/Azure/azure-cli/pull/31508 is released
+
+# s/deploy-revision.py \
+#     --name ${AZURE_STAGING_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --git-hash ${GITHUB_SHA}
 
 # s/deploy-revision.py \
 #     --name ${AZURE_LIVE_APP_NAME} \

--- a/s/ci
+++ b/s/ci
@@ -26,15 +26,8 @@ azure_tag="${AZURE_REGISTRY_NAME}.azurecr.io/npda-django:${GITHUB_SHA}"
 docker tag npda-django:built ${azure_tag}
 docker push ${azure_tag}
 
-# Deploy to Azure Container Apps
-s/deploy-revision.py \
-    --name ${AZURE_STAGING_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --git-hash ${GITHUB_SHA}
-
-# s/deploy-revision.py \
-#     --name ${AZURE_LIVE_APP_NAME} \
-#     --resource-group ${AZURE_RESOURCE_GROUP} \
-#     --git-hash ${GITHUB_SHA}
+# Deploy temporarily moved up to GitHub workflow as a workound for
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003
+# TODO MRB: put it back in here once https://github.com/Azure/azure-cli/pull/31508 is released
 
 # Deploy to the docs is handled in the GitHub workflow itself

--- a/s/ci
+++ b/s/ci
@@ -32,9 +32,9 @@ s/deploy-revision.py \
     --resource-group ${AZURE_RESOURCE_GROUP} \
     --git-hash ${GITHUB_SHA}
 
-s/deploy-revision.py \
-    --name ${AZURE_LIVE_APP_NAME} \
-    --resource-group ${AZURE_RESOURCE_GROUP} \
-    --git-hash ${GITHUB_SHA}
+# s/deploy-revision.py \
+#     --name ${AZURE_LIVE_APP_NAME} \
+#     --resource-group ${AZURE_RESOURCE_GROUP} \
+#     --git-hash ${GITHUB_SHA}
 
 # Deploy to the docs is handled in the GitHub workflow itself

--- a/s/deploy-revision.py
+++ b/s/deploy-revision.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import yaml
+import re
 import tempfile
 import subprocess
 
@@ -21,14 +21,11 @@ template_str = subprocess.check_output(
     shell=True
 ).decode("utf-8")
 
-template_yaml = yaml.safe_load(template_str)
-
-for container in template_yaml["properties"]["template"]["containers"]:
-    [image_name, _] = container["image"].split(":")
-    container["image"] = f"{image_name}:{args.git_hash}"
+regex = re.compile(r"rcpch.azurecr.io/npda-django:\w+")
+template_str = regex.sub(f"rcpch.azurecr.io/npda-django:{args.git_hash}", template_str)
 
 with tempfile.NamedTemporaryFile() as fp:
-    fp.write(yaml.dump(template_yaml).encode("utf-8"))
+    fp.write(template_str.encode("utf-8"))
 
     subprocess.run(
         f"az containerapp update --name {args.name} --resource-group {args.resource_group} --yaml {fp.name} --query 'properties.provisioningState'",


### PR DESCRIPTION
Fixes https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1003

Our deploys broke due to an Azure CLI upgrade bringing in a bug in `az containerapp update`. I've raised a PR to fix it https://github.com/Azure/azure-cli/pull/31508 but obviously that won't be accepted or released for a while.

So in the meantime I've pinned the version of the CLI we use to run the `deploy-revision.py` script by moving it out to separate sections in the GitHub workflow.

The CLI GitHub action only has Python installed and doesn’t have pip. As we can’t install pyyaml in there I've changed the script to change the image tag using just a regex.