### PR TITLE
Support ISO-8859-1 CSV files

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -66,7 +66,14 @@ def csv_parse(csv_file):
     lowercase_headings_list = [heading.lower() for heading in HEADINGS_LIST]
 
     # Read the first row of the csv file
-    df = pd.read_csv(csv_file)
+    try:
+        df = pd.read_csv(csv_file, encoding="utf-8")
+    except UnicodeDecodeError:
+        # This is the default you get from Excel when saving on a UK English machine
+        # Other encodings are unlikely. Our dataset doesn't expect non-ASCII characters
+        # but we have seen non-breaking spaces sneak in (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/999)
+        csv_file.seek(0)
+        df = pd.read_csv(csv_file, encoding="ISO-8859-1")
 
     if any(col.lower() in lowercase_headings_list for col in df.columns):
         # The first row of the csv file matches at least some of the predefined column names

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -193,9 +193,9 @@ async def csv_upload_sync(
     )
 
 
-def read_csv_from_str(contents):
+def read_csv_from_str(contents, encoding="utf-8"):
     with tempfile.NamedTemporaryFile() as f:
-        f.write(contents.encode())
+        f.write(contents.encode(encoding))
         f.seek(0)
 
         return csv_parse(f)
@@ -3566,3 +3566,21 @@ def test_bad_data_for_decimal_fields(test_user, dummy_sheet_csv, model_field):
 
     assert getattr(instance, model_field) == None
     assert model_field in instance.errors
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/999
+@pytest.mark.django_db
+def test_non_breaking_space_in_iso_8859_1_csv(test_user, dummy_sheet_csv):
+    """
+    Test that a non-breaking space in an ISO-8859-1 CSV is handled correctly
+    """
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "NHS Number", "value": "4773730404\xa0"}],
+    )
+
+    df = read_csv_from_str(one_row_csv, encoding="iso-8859-1").df
+
+    errors = csv_upload_sync(test_user, df)
+
+    assert len(errors) == 0

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -78,6 +78,7 @@ async def home(request):
             try:
                 parsed_csv = csv_parse(io.BytesIO(user_csv_bytes))
             except ValueError as e:
+                print(f"!! {dir(e)}")
                 messages.error(
                     request=request,
                     message=f"Invalid CSV format: {e}",

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -78,7 +78,6 @@ async def home(request):
             try:
                 parsed_csv = csv_parse(io.BytesIO(user_csv_bytes))
             except ValueError as e:
-                print(f"!! {dir(e)}")
                 messages.error(
                     request=request,
                     message=f"Invalid CSV format: {e}",


### PR DESCRIPTION
Fixes #999 

Unit reported a `UnicodeDecodeError` when uploading their file. Whilst we wouldn't expect any of our columns to contain non-ASCII characters there was a sneaky non-breaking space in an empty Death Date cell.

On a UK English machine Excel will save a CSV with non-ascii characters as ISO-8859-1 (Latin-1). It is possible to select the separate UTF-8 option but I think it's better for us to just fall back if UTF-8 decoding fails.