### PR TITLE
hide-download-from-questionnaire-users

### DIFF
--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -114,7 +114,7 @@
                       <input type="hidden" name="audit_id" value="{{ submission.pk }}">
                       {% if submission.submission_active %}
                         <!-- data quality report only visible for PDU view -->
-                        {% if request.user.view_preference == 1 and perms.npda.can_download_csv %}
+                        {% if request.user.view_preference == 1 and perms.npda.can_download_csv and can_upload_csv %}
                           <div class="join join-vertical grow items-center lg:join-horizontal">
                             <div class="h-full flex grow items-center px-2 text-white bg-gray-400">
                               <i class="fa-download fas mr-1"></i> Download:
@@ -133,7 +133,7 @@
                               <!-- Pop up which shows data protection guidance for quality report download -->
                               {% include 'partials/page_elements/quality_report_popup.html' %}
                             {% endif %}
-                            {% if perms.npda.can_download_csv %}
+                            {% if perms.npda.can_download_csv and can_upload_csv %}
                               <button name="submit-data"
                                       value="download-data"
                                       type="submit"


### PR DESCRIPTION
### Overview
[HOTFIX] adds a check for the can_upload_csv flag in the submission_history template. Questionnaire users cannot now download CSVs of their submissions
