### PR TITLE
deprecate lead_organisation_name to parent_name

### DIFF
--- a/project/npda/admin.py
+++ b/project/npda/admin.py
@@ -20,8 +20,8 @@ class OrganisationEmployerAdmin(admin.ModelAdmin):
     search_fields = (
         "pk",
         "paediatric_diabetes_unit__pz_code",
-        "paediatric_diabetes_unit__lead_organisation_ods_code",
-        "paediatric_diabetes_unit__lead_organisation_name",
+        "paediatric_diabetes_unit__parent_ods_code",
+        "paediatric_diabetes_unit__parent_name",
         "npda_user__email",
         "npda_user__first_name",
         "npda_user__surname",
@@ -29,7 +29,7 @@ class OrganisationEmployerAdmin(admin.ModelAdmin):
     list_display = (
         "pk",
         "paediatric_diabetes_unit__pz_code",
-        "paediatric_diabetes_unit__lead_organisation_name",
+        "paediatric_diabetes_unit__parent_name",
         "npda_user__email",
         "npda_user__first_name",
         "npda_user__surname",
@@ -61,16 +61,16 @@ class PaediatricDiabetesUnitAdmin(admin.ModelAdmin):
     search_fields = (
         "pk",
         "pz_code",
-        "lead_organisation_ods_code",
-        "lead_organisation_name",
+        "parent_ods_code",
+        "parent_name",
     )
     list_display = (
         "pz_code",
-        "lead_organisation_ods_code",
-        "lead_organisation_name",
+        "parent_ods_code",
+        "parent_name",
         "active",
     )
-    ordering = ("lead_organisation_name",)
+    ordering = ("parent_name",)
 
 
 @admin.register(Transfer)

--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -10,10 +10,10 @@ def session_data(request):
         ),
         "can_upload_csv": request.session.get("can_upload_csv", False),
         "pz_code": request.session.get("pz_code", None),
-        "lead_organisation": request.session.get("lead_organisation", None),
+        "parent_name": request.session.get("parent_name", None),
         "requested_audit_year": request.session.get("requested_audit_year", None),
         "audit_years": request.session.get("audit_years", []),
-        "lead_organisation": request.session.get("lead_organisation", None),
+        "parent_name": request.session.get("parent_name", None),
     }
 
 

--- a/project/npda/general_functions/organisations_adapter.py
+++ b/project/npda/general_functions/organisations_adapter.py
@@ -58,15 +58,13 @@ def paediatric_diabetes_units_to_populate_select_field(
             )
 
     return (
-        filtered_pdus.order_by("lead_organisation_name")
+        filtered_pdus.order_by("parent_name")
         .annotate(
-            paediatric_diabetes_unit_name=Concat(
-                F("lead_organisation_name"),
+            paediatric_diabetes_unit_name=
                 Case(
                     When(
                         parent_name__isnull=False,
                         then=Concat(
-                            Value(" - "),
                             F("parent_name"),
                             Value(" - "),
                             Upper(F("paediatric_diabetes_network_name")),
@@ -75,7 +73,6 @@ def paediatric_diabetes_units_to_populate_select_field(
                             output_field=CharField(),
                         ),
                     )
-                ),
             )
         )
         .values_list("pz_code", "paediatric_diabetes_unit_name")

--- a/project/npda/general_functions/organisations_adapter.py
+++ b/project/npda/general_functions/organisations_adapter.py
@@ -57,7 +57,7 @@ def paediatric_diabetes_units_to_populate_select_field(
                 npda_users__npda_user=requesting_user
             )
 
-    return (
+    pdu_choices = (
         filtered_pdus.order_by("parent_name")
         .annotate(
             paediatric_diabetes_unit_name=
@@ -77,3 +77,5 @@ def paediatric_diabetes_units_to_populate_select_field(
         )
         .values_list("pz_code", "paediatric_diabetes_unit_name")
     )
+
+    return pdu_choices

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -80,8 +80,6 @@ def create_session_object(user):
     submission_actions = get_submission_actions(pz_code, audit_period.audit_year())
     audit_period_data = get_audit_period_session_data(audit_period, user)
 
-    print(pdu_choices)
-
     session = {
         "pz_code": pz_code,
         "parent": primary_organisation.paediatric_diabetes_unit.parent_name,

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -80,9 +80,11 @@ def create_session_object(user):
     submission_actions = get_submission_actions(pz_code, audit_period.audit_year())
     audit_period_data = get_audit_period_session_data(audit_period, user)
 
+    print(pdu_choices)
+
     session = {
         "pz_code": pz_code,
-        "lead_organisation": primary_organisation.paediatric_diabetes_unit.lead_organisation_name,
+        "parent": primary_organisation.paediatric_diabetes_unit.parent_name,
         "pdu_choices": list(pdu_choices),
         "selected_audit_year": audit_period.audit_year(),
     } | submission_actions | audit_period_data
@@ -93,7 +95,6 @@ def create_session_object(user):
 def refresh_session_filters(request, pz_code=None, audit_year=None, csv_upload=None, questionnaire=None):
     session = {}
 
-    Submission = apps.get_model("npda", "Submission")
     PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
     AuditPeriod = apps.get_model("npda", "AuditPeriod")
 
@@ -125,10 +126,10 @@ def refresh_session_filters(request, pz_code=None, audit_year=None, csv_upload=N
             raise PermissionDenied()
 
         session["pz_code"] = pz_code
-        session["lead_organisation"] = PaediatricDiabetesUnit.objects.get(
+        session["parent"] = PaediatricDiabetesUnit.objects.get(
             pz_code=pz_code,
             active=True
-        ).lead_organisation_name
+        ).parent_name
         session["pdu_choices"] = list(
             organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
                 requesting_user=user, user_instance=None

--- a/project/npda/management/commands/seed_functions/paediatric_diabetes_units_seeder.py
+++ b/project/npda/management/commands/seed_functions/paediatric_diabetes_units_seeder.py
@@ -93,6 +93,10 @@ def paediatric_diabetes_units_seeder():
                 pz_code=pdu["pz_code"],
                 defaults=default,
             )
+            if is_rcpch:
+                new_pdu.parent_ods_code = "PZ999"
+                new_pdu.parent = "Royal College of Paediatrics and Child Health"
+                new_pdu.save()
         except DatabaseError as e:
             logger.error(f"Error creating PaediatricDiabetesUnit: {e}")
             continue

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -17,7 +17,7 @@ def test_task():
     logger.info("These are the PDUs registered in the database:")
 
     for pdu in PaediatricDiabetesUnit.objects.all():
-        logger.info(f"\t{pdu.lead_organisation_name} [{pdu.pz_code}]")
+        logger.info(f"\t{pdu.parent_name} [{pdu.pz_code}]")
 
 
 @shared_task

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -1,6 +1,6 @@
 {% extends 'dashboard/components/bases/base_card.html' %}
 {% block card_title %}
-  Distribution of patients ({{ pdu_object.lead_organisation_name }} {{ pdu_object.pz_code }})
+  Distribution of patients - {{ pdu_object.parent_name }} ({{ pdu_object.pz_code }})
 {% endblock card_title %}
 {% block card_body %}
   <div hx-get="{% url 'get_map_chart_partial' %}"

--- a/project/npda/templates/dashboard/components/cards/pdu_card.html
+++ b/project/npda/templates/dashboard/components/cards/pdu_card.html
@@ -7,7 +7,7 @@
   <!-- PZ Name -->
   <p class="flex justify-center tooltip text-center mt-2 text-lg"
      data-tip="Lead Organisation Name">
-    {{ pdu_object.lead_organisation_name }}
+    {{ pdu_object.parent_name }} ({{ pdu_object.pz_code }})
   </p>
   <!-- Divider with Text "Trust" -->
   {% if pdu_object.paediatric_diabetes_network_name == 'Wales' %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -8,7 +8,7 @@
   <div class="flex justify-center bg-white">
     <div class="max-w-full lg:max-w-[75%] px-2 bg-white font-montserrat">
       <strong>
-        {{ title }} - NPDA ID {{ patient.pk }} ({% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %}) at {{ paediatric_diabetes_unit.lead_organisation_name }} ({{ paediatric_diabetes_unit.pz_code }})
+        {{ title }} - NPDA ID {{ patient.pk }} ({% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %}) at {{ paediatric_diabetes_unit.parent_name }} ({{ paediatric_diabetes_unit.pz_code }})
       </strong>
       <form id="update-form"
             class="mt-5"

--- a/project/npda/templates/partials/employers.html
+++ b/project/npda/templates/partials/employers.html
@@ -6,7 +6,7 @@
     </div>
   {% else %}
     <div>
-      {{ organisation_employer.paediatric_diabetes_unit.lead_organisation_name }}
+      {{ organisation_employer.paediatric_diabetes_unit.parent_name }} ({{ organisation_employer.paediatric_diabetes_unit.pz_code }})
       <button class="bg-rcpch_light_blue text-white font-semibold hover:text-white border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue p-1 m-1"
               hx-post="{% url 'npdauser-update' npda_user.pk %}"
               hx-target="#primary_pdu"

--- a/project/npda/templates/partials/kpi_table.html
+++ b/project/npda/templates/partials/kpi_table.html
@@ -3,7 +3,7 @@
      style="max-height: inherit">
   <table class="table table-auto table-pin-cols table-pin-rows border-collapse text-sm text-left text-gray-500 mb-5 font-montserrat">
     <caption class="caption-top font-montserrat text-rcpch_strong_blue font-bold">
-      Table: {{ aggregation_level }}-Level Key Performance Indicators for {{ pdu.lead_organisation_name }} (<span class="font-mono">{{ pdu.pz_code }}</span>)
+      Table: {{ aggregation_level }}-Level Key Performance Indicators for {{ pdu.parent_name }} (<span class="font-mono">{{ pdu.pz_code }}</span>)
       {% if pdu.parent_name is not None %}
         - ({{ pdu.parent_name }}) - {{ pdu.paediatric_diabetes_network_name }} ({{ pdu.paediatric_diabetes_network_code }})
       {% endif %}

--- a/project/npda/templates/partials/npda_user_table.html
+++ b/project/npda/templates/partials/npda_user_table.html
@@ -1,7 +1,7 @@
 {% load npda_tags %}
 <h1 class="font-montserrat text-md text-rcpch_dark_blue font-semibold">
   {% if request.user.view_preference == 1 %}
-    NPDA Users at {{ lead_organisation }} ({{ chosen_pdu }})
+    NPDA Users at {{ parent }} ({{ chosen_pdu }})
   {% elif request.user.view_preference == 2 %}
     National View - All NPDA Users
   {% endif %}
@@ -123,7 +123,7 @@
             <td class="w-1/12 text-center">
               <div class="tooltip tooltip-top">
                 <span class="tooltip tooltip-left"
-                      data-tip="{% for item in npda_user.organisation_employers.all %}{{ item.lead_organisation_name }}{% if not forloop.last %}, {% endif %}{% endfor %}">
+                      data-tip="{% for item in npda_user.organisation_employers.all %}{{ item.parent_name }} ({{ item.pz_code }}){% if not forloop.last %}, {% endif %}{% endfor %}">
                   <i class="fa-solid fa-hospital fa-xl text-rcpch_pink ml-2 mr-2"></i>
                   {% for item in npda_user.organisation_employers.all %}
                     {{ item }}

--- a/project/npda/templates/partials/page_elements/patient_table_page_controls.html
+++ b/project/npda/templates/partials/page_elements/patient_table_page_controls.html
@@ -3,7 +3,7 @@
         <span class="tooltip tooltip-bottom"
               data-tip="All patients in this submission for April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}. Note this includes patients who have been discharged or transferred out of the unit in the audit year and those that have no visits.">
             <strong>
-            {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ paginator.count }} patients in audit year April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }} at {{ pdu.lead_organisation_name }} ({{ pdu.pz_code }})</strong>
+            {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ paginator.count }} patients in audit year April {{ request.session.selected_audit_year }} - March {{ request.session.selected_audit_year|add:'1' }} at {{ pdu.parent_name }} ({{ pdu.pz_code }})</strong>
             <i class="fa-solid fa-info-circle"></i>
         </span>
     </th>

--- a/project/npda/templates/partials/submission_employer_selector.html
+++ b/project/npda/templates/partials/submission_employer_selector.html
@@ -21,7 +21,7 @@
                    type="radio"
                    name="employers"
                    value="{{ employer.paediatric_diabetes_unit.pz_code }}"
-                   aria-label="{{ employer.paediatric_diabetes_unit.lead_organisation_name }} ({{ employer.paediatric_diabetes_unit.pz_code }})" />
+                   aria-label="{{ employer.paediatric_diabetes_unit.parent_name }} ({{ employer.paediatric_diabetes_unit.pz_code }})" />
           {% endfor %}
         </form>
       {% endif %}

--- a/project/npda/templates/partials/submission_employer_selector.html
+++ b/project/npda/templates/partials/submission_employer_selector.html
@@ -4,7 +4,7 @@
   <div>
     <h3 class="font-bold">Important Information</h3>
     <div class="text-xs">
-      You are about to upload data to the NPDA for <strong>{{ request.session.pz_code }} ({{ request.session.lead_organisation }})</strong>.
+      You are about to upload data to the NPDA for <strong>{{ request.session.pz_code }} ({{ request.session.parent }})</strong>.
       {% if employers|length > 1 %}
         <p class="text-xs mt-2 mb-2">
           If this is incorrect, please select the correct employer below.

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -103,7 +103,7 @@
                   </td>
                   {% if request.user.view_preference == 2 %}
                     <td>
-                      {{ submission.paediatric_diabetes_unit.pz_code }} ({{ submission.paediatric_diabetes_unit.lead_organisation_name }})
+                      {{ submission.paediatric_diabetes_unit.pz_code }} ({{ submission.paediatric_diabetes_unit.parent_name }})
                     </td>
                   {% endif %}
                   <td class="flex flex-row flex-wrap justify-start items-stretch gap-2 xl:flex-nowrap">

--- a/project/npda/templates/partials/submission_stats.html
+++ b/project/npda/templates/partials/submission_stats.html
@@ -9,7 +9,7 @@
       {{ submission_statistics.latest_submission.pdu.pz_code|none_to_dash }}
     </div>
     <div class="stat-desc">
-      {{ submission_statistics.latest_submission.pdu.lead_organisation_name|none_to_dash }} on {{ submission_statistics.latest_submission.submission_date|none_to_dash }}
+      {{ submission_statistics.latest_submission.pdu.parent_name|none_to_dash }} on {{ submission_statistics.latest_submission.submission_date|none_to_dash }}
     </div>
   </div>
   <div class="stat shadow">
@@ -21,7 +21,7 @@
       {{ submission_statistics.fewest_errors.error_number|none_to_dash }}
     </div>
     <div class="stat-desc">
-      {{ submission_statistics.fewest_errors.pdu.lead_organisation_name|none_to_dash }} ({{ submission_statistics.fewest_errors.pdu.pz_code|none_to_dash }})
+      {{ submission_statistics.fewest_errors.pdu.parent_name|none_to_dash }} ({{ submission_statistics.fewest_errors.pdu.pz_code|none_to_dash }})
     </div>
   </div>
   <div class="stat">
@@ -33,7 +33,7 @@
       {{ submission_statistics.most_patients.patient_number|none_to_dash }}
     </div>
     <div class="stat-desc">
-      {{ submission_statistics.most_patients.pdu.lead_organisation_name|none_to_dash }} ({{ submission_statistics.most_patients.pdu.pz_code|none_to_dash }})
+      {{ submission_statistics.most_patients.pdu.parent_name|none_to_dash }} ({{ submission_statistics.most_patients.pdu.pz_code|none_to_dash }})
     </div>
   </div>
   <div class="stat">
@@ -45,7 +45,7 @@
       {{ submission_statistics.most_visits.visit_number_per_patient|none_to_dash }}
     </div>
     <div class="stat-desc">
-      {{ submission_statistics.most_visits.pdu.lead_organisation_name|none_to_dash }} ({{ submission_statistics.most_patients.pdu.pz_code|none_to_dash }})
+      {{ submission_statistics.most_visits.pdu.parent_name|none_to_dash }} ({{ submission_statistics.most_patients.pdu.pz_code|none_to_dash }})
     </div>
   </div>
 </div>

--- a/project/npda/templates/partials/view_preference.html
+++ b/project/npda/templates/partials/view_preference.html
@@ -31,7 +31,7 @@
       {% for pdu_choice in pdu_choices %}
         <option value="{{ pdu_choice.0 }}"
                 {% if chosen_pdu == pdu_choice.0 %}selected="{{ chosen_pdu }}"{% endif %}>
-          [{{ pdu_choice.0 }}] {{ pdu_choice.1 }}
+          {{ pdu_choice.0 }} {{ pdu_choice.1 }}
         </option>
       {% endfor %}
     </select>

--- a/project/npda/templates/partials/view_preference.html
+++ b/project/npda/templates/partials/view_preference.html
@@ -31,7 +31,7 @@
       {% for pdu_choice in pdu_choices %}
         <option value="{{ pdu_choice.0 }}"
                 {% if chosen_pdu == pdu_choice.0 %}selected="{{ chosen_pdu }}"{% endif %}>
-          {{ pdu_choice.1 }} [{{ pdu_choice.0 }}]
+          [{{ pdu_choice.0 }}] {{ pdu_choice.1 }}
         </option>
       {% endfor %}
     </select>

--- a/project/npda/templates/patients.html
+++ b/project/npda/templates/patients.html
@@ -13,7 +13,7 @@
         <div class="flex w-full justify-center mt-5 mb-5">
           <div class="alert alert-info w-2/5 text-white" role="alert">
             <i class="fa-solid fa-info"></i>
-            We don't have any data from {{ pdu.lead_organisation_name }} for {{ selected_audit_year }}.
+            We don't have any data from {{ pdu.parent_name }} ({{ pdu.pz_code }}) for {{ selected_audit_year }}.
             <br />
             Choose from the input methods below. You can't change after you add data.
           </div>

--- a/project/npda/templates/visits.html
+++ b/project/npda/templates/visits.html
@@ -8,7 +8,7 @@
         <div class="w-full overflow-x-auto relative">
           {% include 'partials/page_elements/data_rules_banner.html' %}
           <div>
-            <strong>All {{ paediatric_diabetes_unit.lead_organisation_name }} ({{ paediatric_diabetes_unit.pz_code }}) Visits (April {{ submission.audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}) for {% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %} (NPDA ID-{{ patient.pk }})</strong>
+            <strong>All {{ paediatric_diabetes_unit.parent_name }} ({{ paediatric_diabetes_unit.pz_code }}) Visits (April {{ submission.audit_year }} - March {{ request.session.selected_audit_year|add:'1' }}) for {% nhs_number_vs_urn pz_code %} {% nhs_number_vs_urn pz_code patient %} (NPDA ID-{{ patient.pk }})</strong>
           </div>
           {% if visits %}
             <table class="font-montserrat table-md w-full table mb-5 text-sm text-left text-gray-400 text-gray-500 rtl:text-right">

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -57,12 +57,12 @@ def patient_measurements(request):
         paediatric_diabetes_unit__active=True,
         submission_active=True,
     ).exists():
-        current_submission = Submission.objects.get(
+        current_submission = Submission.objects.filter(
             audit_year=audit_period.audit_year(),
             paediatric_diabetes_unit__pz_code=pz_code,
             paediatric_diabetes_unit__active=True,
             submission_active=True,
-        )
+        ).get()
         visits = Visit.objects.filter(patient__in=current_submission.patients.all())
         submission_visits_with_errors = visits.filter(errors__isnull=False)
         submission_visit_error_count = submission_visits_with_errors.count()

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -103,6 +103,7 @@ class NPDAUserListView(
                 requesting_user=self.request.user, user_instance=self.request.user
             )
         )
+        context["parent"] = self.request.session.get("parent")
         context["chosen_pdu"] = self.request.session.get("pz_code")
         return context
 

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -345,11 +345,11 @@ class PatientCreateView(
         pz_code = self.request.session.get("pz_code")
         pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
         context = super().get_context_data(**kwargs)
-        title = f"Add New Child to {pdu.lead_organisation_name}  ({pdu.pz_code})"
+        title = f"Add New Child to {pdu.parent_name}  ({pdu.pz_code})"
         if (
             pdu.parent_name is not None
         ):  # if the PDU has a parent, include the parent name in the title
-            title = f"Add New Child to {pdu.lead_organisation_name} - {pdu.parent_name} ({pz_code})"
+            title = f"Add New Child to {pdu.parent_name} - {pdu.parent_name} ({pz_code})"
         context["title"] = title
         context["button_title"] = "Create New Child Patient Record"
         context["form_method"] = "create"
@@ -487,11 +487,11 @@ class PatientUpdateView(
         pdu = PaediatricDiabetesUnit.objects.get(
             pz_code=transfer.paediatric_diabetes_unit.pz_code
         )
-        title = f"Edit Child Details in {pdu.lead_organisation_name}  ({transfer.paediatric_diabetes_unit.pz_code})"
+        title = f"Edit Child Details in {pdu.parent_name}  ({transfer.paediatric_diabetes_unit.pz_code})"
         if (
             transfer.paediatric_diabetes_unit.parent_name is not None
         ):  # if the PDU has a parent, include the parent name in the title
-            title = f"Add New Child to {transfer.paediatric_diabetes_unit.lead_organisation_name} - {transfer.paediatric_diabetes_unit.parent_name} ({transfer.paediatric_diabetes_unit.pz_code})"
+            title = f"Add New Child to {transfer.paediatric_diabetes_unit.parent_name} - {transfer.paediatric_diabetes_unit.parent_name} ({transfer.paediatric_diabetes_unit.pz_code})"
         context["title"] = title
         context["button_title"] = "Save Changes"
         context["form_method"] = "update"

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -349,7 +349,7 @@ class PatientCreateView(
         if (
             pdu.parent_name is not None
         ):  # if the PDU has a parent, include the parent name in the title
-            title = f"Add New Child to {pdu.parent_name} - {pdu.parent_name} ({pz_code})"
+            title = f"Add New Child to  {pdu.parent_name} ({pz_code})"
         context["title"] = title
         context["button_title"] = "Create New Child Patient Record"
         context["form_method"] = "create"
@@ -491,7 +491,7 @@ class PatientUpdateView(
         if (
             transfer.paediatric_diabetes_unit.parent_name is not None
         ):  # if the PDU has a parent, include the parent name in the title
-            title = f"Add New Child to {transfer.paediatric_diabetes_unit.parent_name} - {transfer.paediatric_diabetes_unit.parent_name} ({transfer.paediatric_diabetes_unit.pz_code})"
+            title = f"Add New Child to {transfer.paediatric_diabetes_unit.parent_name} ({transfer.paediatric_diabetes_unit.pz_code})"
         context["title"] = title
         context["button_title"] = "Save Changes"
         context["form_method"] = "update"

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -186,7 +186,7 @@ class SubmissionsListView(
                     When(latest_submission_date__gte=F("quarter4_start"), latest_submission_date__lte=F("quarter4_end"), then=Value(4)),
                     output_field=IntegerField(),
                 ),
-            ).values("pz_code", "lead_organisation_name", "latest_submission_quarter")
+            ).values("pz_code", "parent_name", "latest_submission_quarter")
             column_chart = create_column_chart(paediatric_diabetes_units, selected_audit_year)
             context["column_chart"] = column_chart.to_html(full_html=False)
             context["submission_statistics"] = submission_stats(selected_audit_year)


### PR DESCRIPTION
### Overview
Bowing to pressure to get rid of lead organisation name.

This is a refactor that deprecates it and promotes parent_name. They are both in the model so no major structural change.

The query constructing the PDU selector removes the lead organisation and keeps the trust and network.

Now Trusts that have more than one PDU naturally group together. So long as users know what their PZ code is this will work.