### PR TITLE
String-int-visit-error

### DIFF
--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -42,10 +42,8 @@ def clean_csv_measurement(value):
         # Remove any non-numeric characters except for decimal points
         # This will handle cases like "5.9cm", "70kg", etc.
         # It will also remove any leading or trailing whitespace
-        print(f"Original value: '{value}', {type(value)} {value is None}")
         value = ''.join(char for char in value if char.isdigit() or char == '.')
     try:
-        print(f"Converting value to float: {value}")
         return float(value)
     except ValueError:
         return None

--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -23,13 +23,41 @@ def clean_csv_sex(value):
             # Return Not Known. The patient won't save in the database without a numeric value.
             return 0
 
+def clean_csv_measurement(value):
+    """
+    Convert measurement values to float, handling empty strings and non-numeric values.
+    Remove extraneous non-numeric characters if necessary.
+    Returns None for empty strings or non-numeric values.
+    If the value is a valid number, it will be converted to float.
+    If the value is an empty string, it will return None.
+    If the value cannot be converted to float, it will return None.
+    """
+    if value == "":
+        return None
+    if isinstance(value, str):
+        # Remove any non-numeric characters except for decimal points
+        value = ''.join(char for char in value if char.isdigit() or char == '.')
+    
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
 
 def csv_clean(df):
     if not is_numeric_dtype(df["Stated gender"]):
         df["Stated gender"] = df["Stated gender"].apply(clean_csv_sex)
     
+    # strip whitespace and convert height and weight to numeric, removing any non-numeric characters (eg, "cm", "kg")
+    if not is_numeric_dtype(df["Patient Height (cm)"]):
+        df["Patient Height (cm)"] = df["Patient Height (cm)"].apply(clean_csv_measurement)
+    if not is_numeric_dtype(df["Patient Weight (kg)"]):
+        df["Patient Weight (kg)"] = df["Patient Weight (kg)"].apply(clean_csv_measurement)
+    
     # Strip whitespace only fields of whitespaces and replace with None
     for col in df.select_dtypes(include=['object']).columns:
         df[col] = df[col].astype(str).str.strip().replace('', None)
+    
+
 
     return df

--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -35,14 +35,26 @@ def clean_csv_measurement(value):
     if value == "":
         return None
     if isinstance(value, str):
+        # Return the string if it contains no digits as this will be handled by the form validation
+        if not any(char.isdigit() for char in value):
+            return value
+        # This string now contains numbers and possibly some characters
         # Remove any non-numeric characters except for decimal points
+        # This will handle cases like "5.9cm", "70kg", etc.
+        # It will also remove any leading or trailing whitespace
+        print(f"Original value: '{value}', {type(value)} {value is None}")
         value = ''.join(char for char in value if char.isdigit() or char == '.')
-    
     try:
+        print(f"Converting value to float: {value}")
         return float(value)
     except ValueError:
         return None
 
+def clean_whitespace(x):
+    if isinstance(x, str):
+        stripped = x.strip()
+        return None if stripped == '' else stripped
+    return x
 
 def csv_clean(df):
     if not is_numeric_dtype(df["Stated gender"]):
@@ -54,10 +66,8 @@ def csv_clean(df):
     if not is_numeric_dtype(df["Patient Weight (kg)"]):
         df["Patient Weight (kg)"] = df["Patient Weight (kg)"].apply(clean_csv_measurement)
     
-    # Strip whitespace only fields of whitespaces and replace with None
+    # Strip whitespace only fields of whitespaces
     for col in df.select_dtypes(include=['object']).columns:
-        df[col] = df[col].astype(str).str.strip().replace('', None)
-    
-
+        df[col] = df[col].apply(clean_whitespace)
 
     return df

--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -27,5 +27,9 @@ def clean_csv_sex(value):
 def csv_clean(df):
     if not is_numeric_dtype(df["Stated gender"]):
         df["Stated gender"] = df["Stated gender"].apply(clean_csv_sex)
+    
+    # Strip whitespace only fields of whitespaces and replace with None
+    for col in df.select_dtypes(include=['object']).columns:
+        df[col] = df[col].astype(str).str.strip().replace('', None)
 
     return df

--- a/project/npda/templates/partials/rcpch_organisation_select.html
+++ b/project/npda/templates/partials/rcpch_organisation_select.html
@@ -4,7 +4,7 @@
   {% for choice in employer_choices %}
     <option value="{{ choice.0 }}"
             {% if selected_organisation == choice.0 %}selected="{{ choice.0 }}"{% endif %}>
-      {{ choice.1 }}
+            {{ choice.0 }} {{ choice.1 }}
     </option>
   {% endfor %}
 </select>

--- a/project/npda/tests/model_tests/test_submissions.py
+++ b/project/npda/tests/model_tests/test_submissions.py
@@ -105,6 +105,8 @@ def test_npda_user_cannot_submit_same_patient_twice_within_the_same_submission(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE
     ).first()
 
+    Submission.objects.all().delete()  # Clear any existing submissions
+
     # Login as Alder Hey user
     client = login_and_verify_user(client, ah_user)
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -860,6 +860,8 @@ def test_additional_columns_causes_error(
     single_row_valid_df["extra_one"] = "ada"
     single_row_valid_df["extra_two"] = "lovelace"
 
+    Submission.objects.all().delete() # Clear any previous submissions
+
     # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     single_row_valid_df.to_csv(tmp_csv_path, index=False)
@@ -894,6 +896,8 @@ def test_duplicate_columns_causes_error(single_row_valid_df, client, test_rcpch_
 
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     single_row_valid_df.to_csv(tmp_csv_path, index=False)
+
+    Submission.objects.all().delete()  # Clear any previous submissions
 
     # Log in user
     client = login_and_verify_user(client, test_rcpch_user)
@@ -931,6 +935,8 @@ def test_missing_columns_causes_error(test_rcpch_user, single_row_valid_df, clie
     df = single_row_valid_df.drop(
         columns=["Urinary Albumin Level (ACR)", "Total Cholesterol Level (mmol/l)"]
     )
+
+    Submission.objects.all().delete()  # Clear any previous submissions
 
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     df.to_csv(tmp_csv_path, index=False)
@@ -3551,3 +3557,49 @@ def test_non_breaking_space_in_iso_8859_1_csv(test_user, dummy_sheet_csv):
     errors = csv_upload_sync(test_user, df)
 
     assert len(errors) == 0
+
+@pytest.mark.django_db
+def test_remove_empty_spaces_from_empty_fields(test_user, dummy_sheet_csv):
+    """
+    Test that empty spaces in empty fields are removed
+    """
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "Only complete if DKA selected in previous question: During this DKA admission did the patient receive any of the following therapies?", "value": "   "}],
+    )
+
+    df = read_csv_from_str(one_row_csv).df
+
+    errors = csv_upload_sync(test_user, df)
+
+    assert len(errors) == 0
+
+    patient = Patient.objects.first()
+    assert Visit.objects.filter(patient=patient).first().dka_additional_therapies == None, f"Expected empty string for DKA additional therapies, but got {Visit.objects.filter(patient=patient).first().dka_additional_therapies}"
+
+@pytest.mark.django_db
+def test_csv_height_weight_fields_with_units_have_units_removed(test_user, dummy_sheet_csv):
+    """
+    Test that height and weight fields with units have the units removed
+    """
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[
+            {"row": 1, "column": "Patient Height (cm)", "value": "150 cm"},
+            {"row": 1, "column": "Patient Weight (kg)", "value": "50 kg"},
+        ],
+    )
+
+    df = read_csv_from_str(one_row_csv).df
+
+    errors = csv_upload_sync(test_user, df)
+
+    assert len(errors) == 0
+
+    patient = Patient.objects.first()
+    visit = Visit.objects.filter(patient=patient).first()
+
+    assert visit.height == Decimal("150.0"), f"Expected height to be 150.0, but got {visit.height}"
+    assert visit.weight == Decimal("50.0"), f"Expected weight to be 50.0, but got {visit.weight}"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ httpx==0.27.2
 ## django and misc
 channels==4.2.0
 dj_database_url==2.1.0
-django
+django==5.2.0
 django-filter==23.5
 django-htmx==1.17.3
 django-two-factor-auth==1.16.0
@@ -53,10 +53,11 @@ isort==5.13.2
 
 # testing and code analysis
 coverage==7.4.3
-pytest-django==4.8.0
+pytest-django==4.11.1
 pytest-factoryboy==2.7.0
 pytest-asyncio==0.24.0
 freezegun==1.5.1
+pytest==8.3.0
 
 # versioning
 bump2version


### PR DESCRIPTION
## Overview
This PR fixes a csv parsing vulnerability highlighted by two different PDUs. It also addresses a new dependency issue in pytest-django

Two users (Salisbury and Frimley Park) have identified parsing errors in the csv. These are strictly user errors, rather than bugs in the platform but highlight a need for NPDA to be more flexible with csv parsing.

Items reported were:
1. invisible white space in free text fields was generating errors when dependent fields were empty (eg DKA admission fields require a date and a reason for admission to pass validation)
2. height and weight fields expect floats but the user was submitting the measurement with the units so this parsed as a string

The solution to these was to apply more cleaning functions to the `clean_csv` file.

### Code changes
1. height and weight fields return floats or None (if empty). If the fields are supplied as a string, all characters except the numbers and the decimal place are removed and returned as a float. If the whole string has no numbers, that is still returned to be cleaned and rejected downstream in form validation.
2. fields with only whitespace in all other rows have that stripped

Tests have been added for both of these

### Pytest Versions
This is documented in the API branch where this was first noticed as a problem.
Recently `pytest-factoryboy` became incompatible with `pytest-django` as the `pytest` version inside it (8.4) broke the way `pytest-factoryboy` handled fixtures. This is documented in this [github issue](https://github.com/pytest-dev/pytest-factoryboy/issues/232). The fix is hopefully fairly temporary - to pin `pytest` to 8.3.0. There is a PR already open to fix the underlying issue.
In the same breath I have pinned django to latest stable (5.2) and bumped `pytest-django` to latest version (4.11.1). Mostly selfishly as this is what I have done in the API PR and it will prevent merge conflicts later on.