### PR TITLE
[NPDA User Form] Display pz code next to trust for org employer dropdown

### DIFF
--- a/project/npda/templates/partials/rcpch_organisation_select.html
+++ b/project/npda/templates/partials/rcpch_organisation_select.html
@@ -4,7 +4,7 @@
   {% for choice in employer_choices %}
     <option value="{{ choice.0 }}"
             {% if selected_organisation == choice.0 %}selected="{{ choice.0 }}"{% endif %}>
-      {{ choice.1 }}
+      ({{ choice.0 }}) {{ choice.1 }}
     </option>
   {% endfor %}
 </select>


### PR DESCRIPTION
Signed-off-by: anchit-chandran <anchit97123@gmail.com>

### Overview

can't differentiate duplicate trusts with different pz codes:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/823e291f-eaa5-4a37-82b7-571af5098a1e" />

So just render those alongside the trust name:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/99a5293b-0317-479b-b769-037d8793c4bd" />

