### PR TITLE
remove missing hba1cs before median calculation

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -3445,8 +3445,6 @@ class CalculateKPIS:
         )
         total_ineligible = self.total_patients_count - total_eligible
 
-        print(eligible_patients)
-
         hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
             eligible_patients
         )

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -3445,6 +3445,8 @@ class CalculateKPIS:
         )
         total_ineligible = self.total_patients_count - total_eligible
 
+        print(eligible_patients)
+
         hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
             eligible_patients
         )
@@ -3508,6 +3510,7 @@ class CalculateKPIS:
         hba1c_values_by_patient = defaultdict(
             lambda: {"hb1ac_values": [], "nhs_number": ""}
         )
+        
         for visit in valid_visits:
             hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(
                 visit["hba1c"]
@@ -3518,6 +3521,10 @@ class CalculateKPIS:
 
         # Now calculate the median for each patient
         for patient_id, values in hba1c_values_by_patient.items():
+            # remove  empty hba1c values
+            values["hb1ac_values"] = [
+                value for value in values["hb1ac_values"] if value is not None
+            ]
             hba1c_values_by_patient[patient_id]["median"] = self.calculate_median(
                 values["hb1ac_values"]
             )


### PR DESCRIPTION
### Overview
Bug fix
If PDUs have submitted by csv, because of our permissive validation strategy, it is possible to submit HbA1cs that are None if the associated date is not empty.

### Code changes
Before the median is calculated (which accepts a list of HbA1cs by patients), None values are filtered out.

This fixes #1027

I am not sure if this will have implications for @anchit-chandran 's latest feature which looks at latest hbA1cs in the patient report - tagging him here as a heads up just in case