### PR TITLE
achondroplasia-measurement-override

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -129,6 +129,7 @@ class VisitForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.patient = kwargs["initial"].get("patient")
+        self.override_height_weight = kwargs.pop("override_height_weight", False)
         super(VisitForm, self).__init__(*args, **kwargs)
         for field_name, field in self.fields.items():
             model_field = Visit._meta.get_field(field_name)
@@ -358,35 +359,35 @@ class VisitForm(forms.ModelForm):
     Custom clean methods for all fields requiring numbers
     """
 
-    def clean_height(self):
-        # Get the height value, if present round it to 1 decimal place
-        data = self.cleaned_data["height"]
-        if data is not None:
-            if data < 40:
-                raise ValidationError(
-                    "Please enter a valid height. Cannot be less than 40cm"
-                )
-            if data > 240:
-                raise ValidationError(
-                    "Please enter a valid height. Cannot be greater than 240cm"
-                )
-            data = round(data, 1)
-        return data
+    # def clean_height(self):
+    #     # Get the height value, if present round it to 1 decimal place
+    #     data = self.cleaned_data["height"]
+    #     if data is not None:
+    #         if data < 40:
+    #             raise ValidationError(
+    #                 "Please enter a valid height. Cannot be less than 40cm"
+    #             )
+    #         if data > 240:
+    #             raise ValidationError(
+    #                 "Please enter a valid height. Cannot be greater than 240cm"
+    #             )
+    #         data = round(data, 1)
+    #     return data
 
-    def clean_weight(self):
-        # Get the weight value, if present round it to 1 decimal place
-        data = self.cleaned_data["weight"]
-        if data is not None:
-            if data < 1:
-                raise ValidationError(
-                    "Patient Weight (kg)' invalid. Cannot be below 1kg"
-                )
-            if data > 200:
-                raise ValidationError(
-                    "Patient Weight (kg)' invalid. Cannot be above 200kg"
-                )
-            data = round(data, 1)
-        return data
+    # def clean_weight(self):
+    #     # Get the weight value, if present round it to 1 decimal place
+    #     data = self.cleaned_data["weight"]
+    #     if data is not None:
+    #         if data < 1:
+    #             raise ValidationError(
+    #                 "Patient Weight (kg)' invalid. Cannot be below 1kg"
+    #             )
+    #         if data > 200:
+    #             raise ValidationError(
+    #                 "Patient Weight (kg)' invalid. Cannot be above 200kg"
+    #             )
+    #         data = round(data, 1)
+    #     return data
 
     def clean_systolic_blood_pressure(self):
         systolic_blood_pressure = self.cleaned_data["systolic_blood_pressure"]
@@ -752,7 +753,7 @@ class VisitForm(forms.ModelForm):
         ]:
             result = getattr(self.async_validation_results, result_field)
 
-            if result and type(result) is ValidationError:
+            if result and type(result) is ValidationError and not self.override_height_weight:
                 for field in fields_to_attach_errors:
                     self.add_error(field, result)
 
@@ -801,7 +802,7 @@ class VisitForm(forms.ModelForm):
                     }
                 )
 
-        # Get centiles for height and weight and bmi if they are present as well as date and sex
+        # Get centiles for height and weight and bmi if they are present as well as date and sex, so long as overriding is not set
         if not getattr(self, "async_validation_results", None):
             self.async_validation_results = validate_visit_sync(
                 birth_date=birth_date,
@@ -1122,7 +1123,7 @@ class VisitForm(forms.ModelForm):
         # I haven't implemented it here. The risk is that future versions of Django will add more
         # behaviour that we miss out on.
 
-        if getattr(self, "async_validation_results"):
+        if getattr(self, "async_validation_results") and not self.override_height_weight:
             self.instance.bmi = self.async_validation_results.bmi
 
             for field_prefix in ["height", "weight", "bmi"]:

--- a/project/npda/general_functions/organisations_adapter.py
+++ b/project/npda/general_functions/organisations_adapter.py
@@ -72,7 +72,9 @@ def paediatric_diabetes_units_to_populate_select_field(
                             default=Value(""),
                             output_field=CharField(),
                         ),
-                    )
+                    ),
+                    default=Value("Royal College of Paediatrics and Child Health"),
+                    output_field=CharField(),
             )
         )
         .values_list("pz_code", "paediatric_diabetes_unit_name")

--- a/project/npda/templates/dashboard/components/cards/pdu_card.html
+++ b/project/npda/templates/dashboard/components/cards/pdu_card.html
@@ -7,7 +7,12 @@
   <!-- PZ Name -->
   <p class="flex justify-center tooltip text-center mt-2 text-lg"
      data-tip="Lead Organisation Name">
-    {{ pdu_object.parent_name }} ({{ pdu_object.pz_code }})
+    {% if pdu_object.parent_name %}
+      {{ pdu_object.parent_name }}
+    {% else %}
+      Royal College of Paediatrics and Child Health
+    {% endif %}
+    ({{ pdu_object.pz_code }})
   </p>
   <!-- Divider with Text "Trust" -->
   {% if pdu_object.paediatric_diabetes_network_name == 'Wales' %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -59,7 +59,7 @@
             {% include 'partials/visit_form_tab.html' with checked=tab.active label=tab.name categories=tab.categories errors=tab.errors %}
           {% endfor %}
         </div>
-        <div class="flex justify-end">
+        <div class="flex justify-end mt-3">
           <button type="submit"
                   value="Submit"
                   class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">

--- a/project/npda/templates/partials/visit_form_tab.html
+++ b/project/npda/templates/partials/visit_form_tab.html
@@ -141,6 +141,21 @@
       {% endfor %}
     </div>
   {% endfor %}
+  <input type="hidden"
+         name="override_height_weight"
+         value="{{ override_height_weight|yesno:'true,false' }}">
+  <!-- hidden field to store the state of the override_height_weight flag -->
+  {% if override_height_weight %}
+    <div role="alert" class="alert alert-info mt-3 mb-3">
+      <i class="fa-solid fa-circle-info"></i>
+      <div>
+        <h3 class="font-bold">Invalid Measurements - What does it mean?</h3>
+        <div class="text-xs">
+          You cannot submit this form because the measurements you have supplied are invalid. If you are sure values are correct (for example the child may have a growth or skeletal disorder), submit the form and it will save the measurement as provided. You can always change it later.
+        </div>
+      </div>
+    </div>
+  {% endif %}
 </div>
 {% block extra_js %}
   <script>

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -110,6 +110,7 @@ class VisitCreateView(
         context["form_method"] = "create"
         context["button_title"] = "Create New Visit"
         context["visit_tabs"] = get_visit_tabs(form=None)
+        context["override_height_weight"] = False
         # Getting the PDU for the patient most of the time will be the same as the selected PDU in session.
         # However, if the user has selected a different PDU in the session but has come here from a national view
         # then we can't use that.
@@ -170,6 +171,13 @@ class VisitCreateView(
         return reverse(
             "patient_visits", kwargs={"patient_id": self.kwargs["patient_id"]}
         )
+    
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        # Get override_postcode from POST data if available
+        if self.request.method in ('POST', 'PUT'):
+            kwargs['override_height_weight'] = self.request.POST.get('override_height_weight', 'false') == 'true'
+        return kwargs
 
     def get_initial(self):
         initial = super().get_initial()
@@ -187,6 +195,30 @@ class VisitCreateView(
 
         super(VisitCreateView, self).form_valid(form)
         return HttpResponseRedirect(self.get_success_url())
+    
+    def form_invalid(self, form):
+        context = self.get_context_data()
+        if "height" in form.errors or "weight" in form.errors:
+            # if the height or weight  is invalid, we want to allow the user to save the record anyway
+            if form.override_height_weight:
+                form.cleaned_data["override_height_weight"] = True
+                messages.warning(
+                    self.request,
+                    "The height or weight you have entered is invalid. The record will be saved but please check the measurement values and update it if necessary.",
+                )
+                form.postcode = form.cleaned_data["override_height_weight"]
+            else:
+                context['button_title'] = "Save Measurements Anyway"
+                context['override_height_weight'] = True
+                messages.error(
+                    self.request,
+                    "The measurement(s) you have entered are invalid. Please check the values entered and try again.",
+                )
+                form.override_height_weight = True
+            return self.render_to_response(context)
+        return super().form_invalid(form)
+
+
 
 
 class VisitUpdateView(
@@ -230,6 +262,13 @@ class VisitUpdateView(
         patient = Patient.objects.get(pk=self.kwargs["patient_id"])
         initial["patient"] = patient
         return initial
+    
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        # Get override_postcode from POST data if available
+        if self.request.method in ('POST', 'PUT'):
+            kwargs['override_height_weight'] = self.request.POST.get('override_height_weight', 'false') == 'true'
+        return kwargs
 
     def form_valid(self, form: BaseModelForm) -> HttpResponse:
         if "delete" in self.request.POST:
@@ -245,6 +284,28 @@ class VisitUpdateView(
         return HttpResponseRedirect(
             redirect_to=reverse("patient_visits", kwargs=context)
         )
+    
+    def form_invalid(self, form):
+        context = self.get_context_data()
+        if "height" in form.errors or "weight" in form.errors:
+            # if the height or weight  is invalid, we want to allow the user to save the record anyway
+            if form.override_height_weight:
+                form.cleaned_data["override_height_weight"] = True
+                messages.warning(
+                    self.request,
+                    "The height or weight you have entered is invalid. The record will be saved but please check the measurement values and update it if necessary.",
+                )
+                form.postcode = form.cleaned_data["override_height_weight"]
+            else:
+                context['button_title'] = "Save Measurements Anyway"
+                context['override_height_weight'] = True
+                messages.error(
+                    self.request,
+                    "The measurement(s) you have entered are invalid. Please check the values entered and try again.",
+                )
+                form.override_height_weight = True
+            return self.render_to_response(context)
+        return super().form_invalid(form)
 
 
 class VisitDeleteView(


### PR DESCRIPTION
### Overview
Some patients with diabetes have disorders which mean we cannot calculate their measurement centiles using UK-WHO. However, providing no measurements would mean the PDU would fail their care process for this measure, so the audit team have asked for an override button in the visit form to allow 'invalid' measurements to be saved anyway.

### Code changes
Introduction of a new `overrride_height_weight` flag in the visit form which conditionally shows an alert in the template and persists the 'invalid' measurement on second submit.

incidentally adds RCPCH name to the PDU list in the select

### Related Issues
closes #1030
