### PR TITLE
Issue1033-eatyourpeas-patient-report-crash

### DIFF
--- a/project/npda/templates/patient_report/base_table.html
+++ b/project/npda/templates/patient_report/base_table.html
@@ -4,7 +4,7 @@
 {% block description_box %}{% endblock %}
 <!-- Patient table -->
 <div class="table-container h-[60vh] overflow-y-auto">
-  <table class="table w-full text-center table-fixed">
+  <table class="table w-full text-center">
     <thead class="sticky top-0 z-10">
       <tr class="bg-rcpch_dark_blue text-white">
         {% block table_headers %}{% endblock %}

--- a/project/npda/templates/patient_report/paginator.html
+++ b/project/npda/templates/patient_report/paginator.html
@@ -25,10 +25,10 @@
            hx-target="#table-area"
            hx-swap="innerHTML"
            class="join-item btn btn-outline">Next</a>
-        <a hx-get="?category={{ selected_category }}&page={{ paginator.num_pages }}"&sort={{ sort_field }}&order={{ sort_order }}"
-          hx-target="#table-area"
-          hx-swap="innerHTML"
-        class="join-item btn btn-outline">Last</a>
+        <a hx-get="?category={{ selected_category }}&page={{ paginator.num_pages }}&sort={{ sort_field }}&order={{ sort_order }}"
+           hx-target="#table-area"
+           hx-swap="innerHTML"
+           class="join-item btn btn-outline">Last</a>
       {% else %}
         <button class="join-item btn btn-outline btn-disabled">Next</button>
         <button class="join-item btn btn-outline btn-disabled">Last</button>

--- a/project/npda/templates/patient_report/patient_report.html
+++ b/project/npda/templates/patient_report/patient_report.html
@@ -10,7 +10,7 @@
         {% comment %} Just the default table, htmx views swap this out {% endcomment %}
         {% if selected_category == "treatment" %}
           <!-- slight hack: this is designed for htmx but now we navigate here from the dashboard just for treatment also -->
-          {% include "patient_report/treatment_table_partial.html" with sort_field="treatment" sort_order=sort_order %}
+          {% include "patient_report/treatment_table_partial.html" with sort_field="treatment_regimen" sort_order=sort_order %}
         {% else %}
           {% include "patient_report/health_checks_table_partial.html" with sort_field=sort_field sort_order=sort_order %}
         {% endif %}

--- a/project/npda/templates/patient_report/patient_report.html
+++ b/project/npda/templates/patient_report/patient_report.html
@@ -2,15 +2,15 @@
 {% load static %}
 {% load npda_tags %}
 {% block content %}
-  <div class="p-4 font-montserrat text-rcpch_dark_blue">
+  <div class="p-4 font-montserrat text-rcpch_dark_blue w-full">
     <!-- SELECT TABS & TABLE -->
     <div class="p-4" hx-boost="true">
       <h1 class="text-2xl font-bold mb-4">Patient Report</h1>
-      <div id="table-area" hx-swap="innerHTML">
+      <div id="table-area" hx-swap="innerHTML" class="w-full">
         {% comment %} Just the default table, htmx views swap this out {% endcomment %}
         {% if selected_category == "treatment" %}
           <!-- slight hack: this is designed for htmx but now we navigate here from the dashboard just for treatment also -->
-          {% include "patient_report/treatment_table_partial.html" with sort_field="treatment_regimen" sort_order=sort_order %}
+          {% include "patient_report/treatment_table_partial.html" with sort_field=sort_field sort_order=sort_order %}
         {% else %}
           {% include "patient_report/health_checks_table_partial.html" with sort_field=sort_field sort_order=sort_order %}
         {% endif %}

--- a/project/npda/templates/patient_report/treatment_table_partial.html
+++ b/project/npda/templates/patient_report/treatment_table_partial.html
@@ -79,7 +79,7 @@
 {% block table_body %}
   {% for patient in patients %}
     {% if  patient.is_first_complete_year_of_care %}
-      <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50">
+      <thead class="bg-rcpch_strong_blue text-xs text-white text-gray-700 uppercase bg-gray-50 w-full">
         <tr>
           <th colspan="9">These patients are completing their first year of care.</th>
         </tr>


### PR DESCRIPTION
### Overview
[BUG FIX]
Navigating to the treatment tab from the dashboard is broken when pagination is used.

### Code changes
The `sort_field` has been corrected to use `treatment_regimen` rather than `treatment`. A second issue with table width has been fixed by removing the `table-fixed` daisyui class

fixes #1033