### PR TITLE
Handle spaces in optional date columns

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -183,7 +183,8 @@ def csv_parse(csv_file):
             for row_index, (value_before, value_after) in enumerate(
                 zip(column_before, column_after)
             ):
-                if not pd.isna(value_before) and pd.isna(value_after):
+                # Handle empty strings (including spaces) for optional date columns
+                if not pd.isna(value_before) and pd.isna(value_after) and not (type(value_before) is str and value_before.strip() == ""):
                     model_field = csv_definition_for(column)["model_field"]
                     errors_to_return[row_index][model_field].append(
                         "Date format is incorrect (expected DD/MM/YYYY)"

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3579,6 +3579,23 @@ def test_remove_empty_spaces_from_empty_fields(test_user, dummy_sheet_csv):
     assert Visit.objects.filter(patient=patient).first().dka_additional_therapies == None, f"Expected empty string for DKA additional therapies, but got {Visit.objects.filter(patient=patient).first().dka_additional_therapies}"
 
 @pytest.mark.django_db
+def test_remove_empty_spaces_in_empty_date_fields(test_user, dummy_sheet_csv):
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "Death Date", "value": "   "}],
+    )
+
+    df = read_csv_from_str(one_row_csv).df
+
+    errors = csv_upload_sync(test_user, df)
+
+    assert len(errors) == 0
+
+    patient = Patient.objects.first()
+    assert patient.death_date == None, f"Expected empty date for death date, but got {patient.death_date}"
+
+@pytest.mark.django_db
 def test_csv_height_weight_fields_with_units_have_units_removed(test_user, dummy_sheet_csv):
     """
     Test that height and weight fields with units have the units removed

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3586,14 +3586,13 @@ def test_remove_empty_spaces_in_empty_date_fields(test_user, dummy_sheet_csv):
         replacements=[{"row": 1, "column": "Death Date", "value": "   "}],
     )
 
-    df = read_csv_from_str(one_row_csv).df
+    print(one_row_csv)
 
-    errors = csv_upload_sync(test_user, df)
+    parsed_csv = read_csv_from_str(one_row_csv)
+    assert len(parsed_csv.errors_to_return) == 0, f"Expected no errors when parsing CSV, got {parsed_csv.errors_to_return}"
 
-    assert len(errors) == 0
-
-    patient = Patient.objects.first()
-    assert patient.death_date == None, f"Expected empty date for death date, but got {patient.death_date}"
+    errors = csv_upload_sync(test_user, parsed_csv.df, errors_to_return=parsed_csv.errors_to_return)
+    assert len(errors) == 0, f"Expected no errors when uploading CSV, got {errors}"
 
 @pytest.mark.django_db
 def test_csv_height_weight_fields_with_units_have_units_removed(test_user, dummy_sheet_csv):

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3586,8 +3586,6 @@ def test_remove_empty_spaces_in_empty_date_fields(test_user, dummy_sheet_csv):
         replacements=[{"row": 1, "column": "Death Date", "value": "   "}],
     )
 
-    print(one_row_csv)
-
     parsed_csv = read_csv_from_str(one_row_csv)
     assert len(parsed_csv.errors_to_return) == 0, f"Expected no errors when parsing CSV, got {parsed_csv.errors_to_return}"
 


### PR DESCRIPTION
The CSV file from Bristol Royal Hospital for Children quite reasonably marks empty optional date columns with a single space (eg death date). Unfortunately, since #780 we mark that as a date format error.

This PR adds a special case to the logic from #780 to only flag the date format as incorrect if the source value is not empty.