### PR TITLE
Issue1022-eatyourpeas-duplicate-patients

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -112,6 +112,7 @@ class PatientForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.audit_year = kwargs.pop("audit_year", None)
+        self.audit_period = kwargs.pop("audit_period", None)
         self.paediatric_diabetes_unit = kwargs.pop("paediatric_diabetes_unit", None)
         self.override_postcode = kwargs.pop("override_postcode", False)
     
@@ -393,31 +394,30 @@ class PatientForm(forms.ModelForm):
         """
         if nhs_number:
             self._validate_field_uniqueness(
-                nhs_number,
-                "nhs_number",
-                "patient__nhs_number",
-                "NHS Number must be unique within this submission.",
+                value=nhs_number,
+                field_name="nhs_number",
+                filter_field="patient__nhs_number",
+                error_message="NHS Number must be unique within this submission.",
             )
 
         if unique_reference_number:
             self._validate_field_uniqueness(
-                unique_reference_number,
-                "unique_reference_number",
-                "patient__unique_reference_number",
-                "Unique Reference Number must be unique within this submission.",
+               value=unique_reference_number,
+                field_name="unique_reference_number",
+                filter_field="patient__unique_reference_number",
+                error_message="Unique Reference Number must be unique within this submission.",
             )
 
     def _validate_field_uniqueness(
         self, value, field_name, filter_field, error_message
     ):
         PatientSubmission = apps.get_model("npda", "PatientSubmission")
-
         def get_submissions_count(filter_kwargs):
             return PatientSubmission.objects.filter(**filter_kwargs).count()
 
         filter_kwargs = {
             "submission__submission_active": True,
-            "submission__audit_year": self.audit_year,
+            "submission__audit_period": self.audit_period,
             filter_field: value,
             "submission__paediatric_diabetes_unit": self.paediatric_diabetes_unit,
         }

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -651,3 +651,41 @@ def test_fail_validation_if_same_patient_twice_in_same_submission(
     new_form.is_valid()
 
     assert "nhs_number" in new_form.errors.as_data()
+
+@pytest.mark.django_db
+def test_pass_validation_if_same_patient_twice_in_same_submission_but_different_pdu(
+    mocked_pdu,
+    mocked_audit_year,
+    seed_groups_fixture,
+    seed_users_fixture,
+):
+    NPDAUser = apps.get_model("npda", "NPDAUser")
+    pdu_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=mocked_pdu.pz_code
+    ).first()
+
+    form = PatientForm(
+        VALID_FIELDS, paediatric_diabetes_unit=mocked_pdu, audit_year=mocked_audit_year
+    )
+    assert len(form.errors.as_data()) == 0
+    patient = form.save()
+
+    # add the patient to a submission
+    Submission = apps.get_model("npda", "Submission")
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=mocked_pdu,
+        audit_year=mocked_audit_year,
+        submission_active=True,
+        submission_date=TODAY,
+        submission_by=pdu_user,
+    )
+    submission.patients.add(patient)
+
+    another_pdu = PaediatricsDiabetesUnitFactory(pz_code="PZ075")
+
+    # Create a new form with the same patient but in a different PDU
+    new_form = PatientForm(
+        VALID_FIELDS, paediatric_diabetes_unit=another_pdu, audit_year=mocked_audit_year
+    )
+    assert new_form.is_valid(), "Form should be valid even with the same patient in a different PDU"
+    assert "nhs_number" not in new_form.errors.as_data(), "There should be no error for nhs_number when the patient is in a different PDU"

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -7,6 +7,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.mixins import AccessMixin
+from django.shortcuts import get_object_or_404
 
 from project.npda.models.npda_user import NPDAUser
 from project.npda.models.patient import Patient
@@ -80,7 +81,7 @@ class CheckPDUListMixin(AccessMixin):
         # get pdu that user is requesting access of
         requested_pdu = ""
         if model == "Visit":
-            requested_patient = Patient.objects.get(pk=self.kwargs["patient_id"])
+            requested_patient = get_object_or_404(Patient, pk=self.kwargs["patient_id"])
             Transfer = apps.get_model("npda", "Transfer")
             transfer = Transfer.objects.get(patient=requested_patient)
             requested_pdu = transfer.paediatric_diabetes_unit.pz_code
@@ -145,12 +146,12 @@ class CheckPDUInstanceMixin(AccessMixin):
 
 
         elif model == "Patient":
-            requested_patient = Patient.objects.get(pk=self.kwargs["pk"])
+            requested_patient = get_object_or_404(Patient, pk=self.kwargs["pk"])
             transfer = Transfer.objects.get(patient=requested_patient)
             requested_pdu = transfer.paediatric_diabetes_unit.pz_code
 
         elif model == "Visit":
-            requested_patient = Patient.objects.get(pk=self.kwargs["patient_id"])
+            requested_patient = get_object_or_404(Patient, pk=self.kwargs["patient_id"])
             transfer = Transfer.objects.get(patient=requested_patient)
             requested_pdu = transfer.paediatric_diabetes_unit.pz_code
 

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -132,7 +132,7 @@ class CheckPDUInstanceMixin(AccessMixin):
         user_pdus = [org.pz_code for org in request.user.organisation_employers.all()]
 
         if model == "NPDAUser":
-            requested_user = NPDAUser.objects.get(pk=self.kwargs["pk"])
+            requested_user = get_object_or_404(NPDAUser, pk=self.kwargs['pk'])
             if requested_user.organisation_employers.filter(pz_code=request.session.get('pz_code')).exists():
                 if requested_user.number_of_pdu_memberships() == 1:
                     # if the user is a member of the requested pdu and there is only one, then we can use that

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -14,7 +14,7 @@ from django.db.models import Count, Case, When, Max, Q, F
 from django.forms import BaseForm
 from django.forms import BaseForm
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render, redirect, reverse
+from django.shortcuts import get_object_or_404, render, redirect, reverse
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
@@ -473,8 +473,7 @@ class PatientUpdateView(
 
     def get_context_data(self, **kwargs):
         Transfer = apps.get_model("npda", "Transfer")
-        # pz_code = self.request.session.get("pz_code")
-        patient = Patient.objects.get(pk=self.kwargs["pk"])
+        patient = get_object_or_404(Patient, pk=self.kwargs["pk"])
         transfer = Transfer.objects.get(patient=patient)
         context = super().get_context_data(**kwargs)
         PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -5,7 +5,6 @@ from datetime import date
 
 # Django imports
 from django.apps import apps
-from django.utils import timezone
 from django.contrib import messages
 from django.contrib.gis.db.models.functions import Distance
 from django.contrib.gis.geos import Point
@@ -14,13 +13,10 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Count, Case, When, Max, Q, F
 from django.forms import BaseForm
 from django.forms import BaseForm
-from django.http import HttpResponse
-from django.http.response import HttpResponse
-from django.contrib.postgres.aggregates import StringAgg
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render, redirect, reverse
-from django.template.loader import render_to_string
 from django.urls import reverse_lazy
-from django.utils.html import escape
+from django.utils import timezone
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic import ListView
 
@@ -508,6 +504,8 @@ class PatientUpdateView(
         return super().form_valid(form)
     
     def form_invalid(self, form):
+        if "delete" in self.request.POST:
+            return redirect(reverse("patient-delete", kwargs={"pk": self.kwargs["pk"]}))
         context = self.get_context_data()
         if "postcode" in form.errors:
             # if the postcode is invalid, we want to allow the user to save the record anyway
@@ -531,8 +529,15 @@ class PatientUpdateView(
     
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        # Get override_postcode from POST data if available
+        PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
+        AuditPeriod = apps.get_model("npda", "AuditPeriod")
+        pz_code = self.request.session.get("pz_code")
+        pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+        audit_year = self.request.session.get("selected_audit_year")
+        kwargs["paediatric_diabetes_unit"] = pdu
         kwargs["audit_period"] = AuditPeriod.objects.get_audit_period_for_request(self.request)
+        kwargs["audit_year"] = audit_year
+        # Get override_postcode from POST data if available
         if self.request.method in ('POST', 'PUT'):
             kwargs['override_postcode'] = self.request.POST.get('override_postcode', 'false') == 'true'
         return kwargs

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -333,11 +333,16 @@ class PatientCreateView(
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
+        AuditPeriod = apps.get_model("npda", "AuditPeriod")
         pz_code = self.request.session.get("pz_code")
         pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
         audit_year = self.request.session.get("selected_audit_year")
         kwargs["paediatric_diabetes_unit"] = pdu
+        kwargs["audit_period"] = AuditPeriod.objects.get_audit_period_for_request(self.request)
         kwargs["audit_year"] = audit_year
+        # Get override_postcode from POST data if available
+        if self.request.method in ('POST', 'PUT'):
+            kwargs['override_postcode'] = self.request.POST.get('override_postcode', 'false') == 'true'
         return kwargs
 
     def get_context_data(self, **kwargs):
@@ -355,13 +360,6 @@ class PatientCreateView(
         context["form_method"] = "create"
         context["override_postcode"] = False
         return context
-    
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        # Get override_postcode from POST data if available
-        if self.request.method in ('POST', 'PUT'):
-            kwargs['override_postcode'] = self.request.POST.get('override_postcode', 'false') == 'true'
-        return kwargs
     
     def form_invalid(self, form):
         context = self.get_context_data()
@@ -534,6 +532,7 @@ class PatientUpdateView(
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         # Get override_postcode from POST data if available
+        kwargs["audit_period"] = AuditPeriod.objects.get_audit_period_for_request(self.request)
         if self.request.method in ('POST', 'PUT'):
             kwargs['override_postcode'] = self.request.POST.get('override_postcode', 'false') == 'true'
         return kwargs


### PR DESCRIPTION
### Overview
First noticed by KCH (PZ215) where one patient was entered twice in error in the questionnaire and the user could not delete it.
This led to a conversation with the audit team who advised that a patient (identified by NHS number) can be in duplicated in the same submission if the duplicates are in different PDUs, but cannot be duplicates in the same PDU.

### Code changes
In the course of investigation I discovered that the `get_form_kwargs` method in `PatientCreateView` had been duplicated following introduction of the `postcode_override` so only the second one was being called. This meant that PDU and audit year were not making it into the initialized form, and therefore the patient would always be saved. These methods have now been merged. The update class has been amended also.
I also discovered that it was not possible to delete patients who had validation errors so this has also been fixed.
A test has been added.

### Related Issues
closes #1022
