### PR TITLE
Fix editing patients in questionnaire

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -388,6 +388,7 @@ class PatientForm(forms.ModelForm):
             self.add_error(field_name, ValidationError(error_message))
 
     def validate_uniqueness(self, nhs_number, unique_reference_number):
+        print(f"!! validate_uniqueness")
         """
         Validate that the NHS Number or Unique Reference Number is unique within this submission.
         Handles both synchronous and asynchronous contexts.

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -372,8 +372,8 @@ class PatientForm(forms.ModelForm):
         PatientSubmission = apps.get_model("npda", "PatientSubmission")
 
         @database_sync_to_async
-        def get_submissions_count(filter_kwargs):
-            return PatientSubmission.objects.filter(**filter_kwargs).count()
+        def get_submissions_count(filter_kwargs, exclude_kwargs):
+            return PatientSubmission.objects.filter(**filter_kwargs).exclude(**exclude_kwargs).count()
 
         filter_kwargs = {
             "submission__submission_active": True,
@@ -382,13 +382,17 @@ class PatientForm(forms.ModelForm):
             "submission__paediatric_diabetes_unit": self.paediatric_diabetes_unit,
         }
 
-        count = await get_submissions_count(filter_kwargs)
+        exclude_kwargs = {}
+
+        if self.instance:
+            exclude_kwargs["patient__pk"] = self.instance.pk
+
+        count = await get_submissions_count(filter_kwargs, exclude_kwargs)
 
         if count > 0:
             self.add_error(field_name, ValidationError(error_message))
 
     def validate_uniqueness(self, nhs_number, unique_reference_number):
-        print(f"!! validate_uniqueness")
         """
         Validate that the NHS Number or Unique Reference Number is unique within this submission.
         Handles both synchronous and asynchronous contexts.
@@ -413,8 +417,8 @@ class PatientForm(forms.ModelForm):
         self, value, field_name, filter_field, error_message
     ):
         PatientSubmission = apps.get_model("npda", "PatientSubmission")
-        def get_submissions_count(filter_kwargs):
-            return PatientSubmission.objects.filter(**filter_kwargs).count()
+        def get_submissions_count(filter_kwargs, exclude_kwargs):
+            return PatientSubmission.objects.filter(**filter_kwargs).exclude(**exclude_kwargs).count()
 
         filter_kwargs = {
             "submission__submission_active": True,
@@ -423,7 +427,12 @@ class PatientForm(forms.ModelForm):
             "submission__paediatric_diabetes_unit": self.paediatric_diabetes_unit,
         }
 
-        count = get_submissions_count(filter_kwargs)
+        exclude_kwargs = {}
+
+        if self.instance:
+            exclude_kwargs["patient__pk"] = self.instance.pk
+
+        count = get_submissions_count(filter_kwargs, exclude_kwargs)
 
         if count > 0:
             self.add_error(field_name, ValidationError(error_message))

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -23,6 +23,7 @@ from project.npda.tests.factories.patient_factory import (
     INDEX_OF_MULTIPLE_DEPRIVATION_QUINTILE,
 )
 from project.npda.tests.factories import PaediatricsDiabetesUnitFactory
+from project.constants import SEX_TYPE
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -689,3 +690,41 @@ def test_pass_validation_if_same_patient_twice_in_same_submission_but_different_
     )
     assert new_form.is_valid(), "Form should be valid even with the same patient in a different PDU"
     assert "nhs_number" not in new_form.errors.as_data(), "There should be no error for nhs_number when the patient is in a different PDU"
+
+
+@pytest.mark.django_db
+def test_edit_patient(mocked_pdu, mocked_audit_year):
+    NPDAUser = apps.get_model("npda", "NPDAUser")
+    pdu_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=mocked_pdu.pz_code
+    ).first()
+
+    form = PatientForm(
+        VALID_FIELDS, paediatric_diabetes_unit=mocked_pdu, audit_year=mocked_audit_year
+    )
+
+    assert len(form.errors.as_data()) == 0
+    patient = form.save()
+
+    # Add the patient to a submission (required to reproduce https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1039)
+    Submission = apps.get_model("npda", "Submission")
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=mocked_pdu,
+        audit_year=mocked_audit_year,
+        submission_active=True,
+        submission_date=TODAY,
+        submission_by=pdu_user,
+    )
+    submission.patients.add(patient)
+
+    form = PatientForm(
+        VALID_FIELDS | { "sex": SEX_TYPE[1][0] },
+        instance=patient,
+        paediatric_diabetes_unit=mocked_pdu,
+        audit_year=mocked_audit_year
+    )
+
+    assert len(form.errors.as_data()) == 0
+    patient = form.save()
+
+    assert patient.sex == SEX_TYPE[1][0]


### PR DESCRIPTION
Fixes #1039 

Fix bug where editing a patient always failed with `NHS Number must be unique within this submission.`, I think introduced in #1036.

Adds a patient form test for editing an existing patient. In particular adds the patient to a submission which is required to reproduce the issue. We didn't already have a test covering that - there was one but it was skipped:

https://github.com/rcpch/national-paediatric-diabetes-audit/blob/ab9b32d86111fe4efc62de1591575d740aee1548/project/npda/tests/form_tests/test_patient_form.py#L585

I tried unskipping it but it failed with a different error so I wrote a new test for now. I will unskip that test in a separate PR.