### PR TITLE
issue1045-eatyourpeas-duplicate-patients

### DIFF
--- a/project/npda/models/patientsubmission.py
+++ b/project/npda/models/patientsubmission.py
@@ -32,20 +32,21 @@ class PatientSubmission(models.Model):
         return f"{self.submission} for {self.patient}"
 
 
-def save(self, *args, **kwargs):
-    # Check for existing submissions for the same patient and audit year
-    if (
-        PatientSubmission.objects.filter(
-            (
-                Q(patient__nhs_number=self.patient__nhs_number)
-                | Q(
-                    patient__unique_reference_number=self.patient__unique_reference_number
-                )
-            ),
-            submission__audit_year=self.submission.audit_year,
-        )
-        .exclude(pk=self.pk)
-        .exists()
-    ):
-        raise ValidationError("A patient can have only one submission per audit year.")
-    super().save(*args, **kwargs)
+    def save(self, *args, **kwargs):
+        # Check for existing submissions for the same patient and audit year
+        print("Checking for existing submissions...")
+        if (
+            PatientSubmission.objects.filter(
+                (
+                    Q(patient__nhs_number=self.patient.nhs_number)
+                    | Q(
+                        patient__unique_reference_number=self.patient.unique_reference_number
+                    )
+                ),
+                submission__audit_year=self.submission.audit_year,
+            )
+            .exclude(pk=self.pk)
+            .exists()
+        ):
+            raise ValidationError("A patient can have only one submission per audit year.")
+        super().save(*args, **kwargs)


### PR DESCRIPTION
### Overview
PZ122 reported an error that their upload was complaining that all their patients already existed in the current submission. We have recently added validation rules here so it looked related to this.

On investigation I found that:
PZ122 had got two active submissions (pk 9) and pk (351) -  the first made in Feb for 2023 audit year, the second made today for 2025. I have set the `submission_active` flag to false for the 2023 record in the admin. Interestingly the first submission against 2023 was made by Amani in February - part of testing perhaps?

## Code Changes
I am not sure how the submission_active flag was never flipped to false after February and why the audit_year of 2023 is being treated as current. Perhaps subsequent submissions after february were for a different audit year so the previous active submission was never made inactive. Neither record has an audit_period instance - in both cases the audit_year is present.

On reviewing the recent fix I now see two typos (sorry that I missed both of these on my code review). First issue is that the `save` method in the PatientSubmission model was not indented so not part of the class. The second issue was in the Q objects where the syntax was mixed between dot notation and underscore notation. 

I am not sure if these are the cause of this error, but this does look to me to need fixing anyway. 

## After thought
Possibly as part of this PR we should change this in `csv_upload.py` or check where we filter against `submission_active` higher up:
```python
async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None):
    old_submission = await Submission.objects.filter(
        paediatric_diabetes_unit=pdu,
        audit_year=audit_year,
        submission_active=True,
    ).afirst()

    if old_submission:
        old_submission.submission_active = False
        await old_submission.asave()
    
    submission = await Submission.objects.acreate(
        submission_date=timezone.now(),
        submission_by=user,
        paediatric_diabetes_unit=pdu,
        audit_year=audit_year,
        csv_file=csv_file_bytes,
        csv_file_name=csv_file_name,
        submission_active=submission_active
    )
```
Here we are filtering for previous submissions in the current audit year and setting them to false on creation of a new submission. However, it is still possible to have an active submission from a previous year.