### PR TITLE
Issue1044-eatyourpeas-dka-validation

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -359,36 +359,6 @@ class VisitForm(forms.ModelForm):
     Custom clean methods for all fields requiring numbers
     """
 
-    # def clean_height(self):
-    #     # Get the height value, if present round it to 1 decimal place
-    #     data = self.cleaned_data["height"]
-    #     if data is not None:
-    #         if data < 40:
-    #             raise ValidationError(
-    #                 "Please enter a valid height. Cannot be less than 40cm"
-    #             )
-    #         if data > 240:
-    #             raise ValidationError(
-    #                 "Please enter a valid height. Cannot be greater than 240cm"
-    #             )
-    #         data = round(data, 1)
-    #     return data
-
-    # def clean_weight(self):
-    #     # Get the weight value, if present round it to 1 decimal place
-    #     data = self.cleaned_data["weight"]
-    #     if data is not None:
-    #         if data < 1:
-    #             raise ValidationError(
-    #                 "Patient Weight (kg)' invalid. Cannot be below 1kg"
-    #             )
-    #         if data > 200:
-    #             raise ValidationError(
-    #                 "Patient Weight (kg)' invalid. Cannot be above 200kg"
-    #             )
-    #         data = round(data, 1)
-    #     return data
-
     def clean_systolic_blood_pressure(self):
         systolic_blood_pressure = self.cleaned_data["systolic_blood_pressure"]
 

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -918,6 +918,19 @@ class VisitForm(forms.ModelForm):
                 [{"total_cholesterol": total_cholesterol}],
             )
 
+        thyroid_function_date = cleaned_data.get("thyroid_function_date")
+        thyroid_treatment_status = cleaned_data.get("thyroid_treatment_status")
+        if thyroid_function_date is not None and thyroid_treatment_status is None:
+            raise ValidationError(
+                {
+                    "thyroid_treatment_status": [
+                        "Thyroid Treatment Status must be filled in if Thyroid Function Date is filled in"
+                    ]
+                }
+            )
+
+        
+
         psychological_screening_assessment_date = cleaned_data.get(
             "psychological_screening_assessment_date"
         )

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -918,19 +918,6 @@ class VisitForm(forms.ModelForm):
                 [{"total_cholesterol": total_cholesterol}],
             )
 
-        thyroid_function_date = cleaned_data.get("thyroid_function_date")
-        thyroid_treatment_status = cleaned_data.get("thyroid_treatment_status")
-
-        has_thyroid_data = thyroid_function_date or thyroid_treatment_status
-        thyroid_treament_prescribed = thyroid_treatment_status not in [1, 99]
-
-        if has_thyroid_data and thyroid_treament_prescribed:
-            measure_must_have_date_and_value(
-                thyroid_function_date,
-                "thyroid_function_date",
-                [{"thyroid_treatment_status": thyroid_treatment_status}],
-            )
-
         psychological_screening_assessment_date = cleaned_data.get(
             "psychological_screening_assessment_date"
         )

--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -91,6 +91,9 @@ def csv_parse(csv_file):
     # The template published on the RCPCH website has trailing spaces on 'Observation Date: Thyroid Function '
     df.columns = df.columns.str.strip()
 
+    # issue #1038 - Twinkle users inexplicably submit CSV files with headings that are in quotes.
+    df.columns = df.columns.str.strip('\'"')
+
     # Replace headings which were different from in the old NPDA template with the new
     for column in df.columns:
         lowercase_col = column.lower()

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -1059,22 +1059,23 @@ def test_thyroid_treatment_status_none_form_fails_validation():
 
 
 @pytest.mark.django_db
-def test_thyroid_function_date_none_form_fails_validation():
+def test_thyroid_function_date_none_form_passes_validation():
     """
-    Test that missing thyroid function date is invalid
+    Test that missing thyroid function date is valid
     """
     patient = PatientFactory()
 
     form = VisitForm(
         data={
+            "visit_date": "2026-01-01",  # Required for validation
             "thyroid_treatment_status": 2,
             "thyroid_function_date": None,
         },
         initial={"patient": patient},
     )
     # Trigger the cleaners
-    assert form.is_valid() == False, f"No thyroid function date offered but test passed"
-    assert "thyroid_function_date" in form.errors
+    assert form.is_valid() == True, f"No thyroid function date offered with treatment should pass"
+    assert "thyroid_function_date" not in form.errors
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/625

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -228,7 +228,6 @@ def modify_raw_csv(csv_str, start=None, end=None, replacements={}):
 
     return output.getvalue()
 
-
 @pytest.mark.django_db
 def test_create_patient(test_user, single_row_valid_df):
 
@@ -2201,7 +2200,7 @@ def test_thyroid_treatment_missing_fails_validation(test_user, single_row_valid_
 
 
 @pytest.mark.django_db
-def test_thyroid_treatment_date_missing_fails_validation(
+def test_thyroid_treatment_date_missing_passes_validation(
     test_user, single_row_valid_df
 ):
     """
@@ -2215,7 +2214,7 @@ def test_thyroid_treatment_date_missing_fails_validation(
 
     errors = csv_upload_sync(test_user, single_row_valid_df)
 
-    assert "thyroid_function_date" in errors[0]
+    assert "thyroid_function_date" not in errors[0]
 
     visit = Visit.objects.first()
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -985,6 +985,14 @@ def test_mixed_case_column_headers(test_user, dummy_sheet_csv):
 
     assert df.columns[0] == "NHS Number"
 
+@pytest.mark.django_db
+def test_column_headers_with_quotes(test_user, dummy_sheet_csv):
+    csv = dummy_sheet_csv.replace("NHS Number", '"NHS Number"')
+    assert '"NHS Number"' in csv
+    df = read_csv_from_str(csv).df
+
+    assert df.columns[0] == "NHS Number"
+
 
 @pytest.mark.django_db
 def test_invalid_nhs_number_column_name(single_row_valid_df, client, test_rcpch_user, tmp_path):


### PR DESCRIPTION
### Overview
Sending this in now but not quite ready.
Fixes #1043
FIxes #1038

#1044 currently not flagging as an error in the questionnaire on testing locally but might be a parsing error of some other kind in the csv. Will update and fix this when clearer and can close all 3 issues together.

Otherwise:
- strips all single and double quotes for csv headers in `csv_parse`
- adds a test for this
- removes thyroid date from validation (but leaves validation error if date provided but no thyroid outcome)
- fixes/alters tests for thyroid validation


