### PR TITLE
Add audit period to CSV submissions

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -40,10 +40,11 @@ from project.npda.models import (
     VisitActivity
 )
 
-async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None):
+async def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None):
     old_submission = await Submission.objects.filter(
         paediatric_diabetes_unit=pdu,
-        audit_year=audit_year,
+        audit_year=audit_period.audit_year(), # compatibility
+        audit_period=audit_period,
         submission_active=True,
     ).afirst()
 
@@ -55,7 +56,8 @@ async def create_csv_submission(pdu, audit_year, csv_file_bytes, csv_file_name, 
         submission_date=timezone.now(),
         submission_by=user,
         paediatric_diabetes_unit=pdu,
-        audit_year=audit_year,
+        audit_year=audit_period.audit_year(), # compatibility
+        audit_period=audit_period,
         csv_file=csv_file_bytes,
         csv_file_name=csv_file_name,
         submission_active=submission_active

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -165,9 +165,9 @@ def test_rcpch_user(seed_groups_fixture, seed_users_fixture, seed_audit_periods_
 # https://github.com/pytest-dev/pytest-asyncio/issues/226
 @async_to_sync
 async def csv_upload_sync(
-    user, dataframe, pdu=None, errors_to_return=None
+    user, dataframe, pdu=None, errors_to_return=None, _audit_period=None
 ):
-    audit_period = await AuditPeriod.objects.afirst()
+    audit_period = _audit_period if _audit_period else await AuditPeriod.objects.afirst()
 
     if not pdu:
         pdu = await PaediatricDiabetesUnit.objects.aget(pz_code=ALDER_HEY_PZ_CODE)
@@ -3617,3 +3617,14 @@ def test_csv_height_weight_fields_with_units_have_units_removed(test_user, dummy
 
     assert visit.height == Decimal("150.0"), f"Expected height to be 150.0, but got {visit.height}"
     assert visit.weight == Decimal("50.0"), f"Expected weight to be 50.0, but got {visit.weight}"
+
+@pytest.mark.django_db
+def test_submission_has_audit_period_attached(test_user, single_row_valid_df):
+    audit_period = AuditPeriod.objects.first()
+
+    csv_upload_sync(test_user, single_row_valid_df, _audit_period=audit_period)
+
+    assert Submission.objects.count() == 1, "Expected one submission to be created"
+    submission = Submission.objects.first()
+
+    assert submission.audit_period == audit_period, f"Expected submission to have audit period {audit_period}, but got {submission.audit_period}"

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -174,7 +174,7 @@ async def csv_upload_sync(
 
     new_submission = await create_csv_submission(
         pdu=pdu,
-        audit_year=audit_period.audit_year(),
+        audit_period=audit_period,
         csv_file_bytes=None,
         csv_file_name=None,
         submission_active=True,

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -372,7 +372,7 @@ async def upload_csv(request):
 
         new_submission = await create_csv_submission(
             pdu=pdu,
-            audit_year=audit_period.audit_year(),
+            audit_period=audit_period,
             csv_file_bytes=user_csv_bytes,
             csv_file_name=user_csv_filename,
             # The celery task will flip it to active once complete


### PR DESCRIPTION
Fix mistake from #865 where the new `audit_period` reference field was not added to CSV submissions.

This contributed to an issue where NHS numbers were erroneously flagged as duplicates if a submission already existed in a different audit year (#1045). This PR does not fix that issue but will help to stop it happening for future submissions.