### PR TITLE
Filter submission by audit year for duplicate detection

### DIFF
--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -422,7 +422,7 @@ class PatientForm(forms.ModelForm):
 
         filter_kwargs = {
             "submission__submission_active": True,
-            "submission__audit_period": self.audit_period,
+            "submission__audit_year": self.audit_year,
             filter_field: value,
             "submission__paediatric_diabetes_unit": self.paediatric_diabetes_unit,
         }


### PR DESCRIPTION
When checking patient unique in submission (when submitting via questionnaire).

The async equivalent of this check (used in CSV upload) already referenced audit_year so this makes them consistent.

Submissions created from CSV upload didn't have audit_period set (#1051) but it didn't matter for this line anyway since this only ran during questionnaire submission.

So this really is just ensuring consistency. Once we reliably have `audit_period` set on all Submissions we could switch both of them over.