### PR TITLE
Zero out numbers from CSV upload that are too big

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -359,36 +359,6 @@ class VisitForm(forms.ModelForm):
     Custom clean methods for all fields requiring numbers
     """
 
-    # def clean_height(self):
-    #     # Get the height value, if present round it to 1 decimal place
-    #     data = self.cleaned_data["height"]
-    #     if data is not None:
-    #         if data < 40:
-    #             raise ValidationError(
-    #                 "Please enter a valid height. Cannot be less than 40cm"
-    #             )
-    #         if data > 240:
-    #             raise ValidationError(
-    #                 "Please enter a valid height. Cannot be greater than 240cm"
-    #             )
-    #         data = round(data, 1)
-    #     return data
-
-    # def clean_weight(self):
-    #     # Get the weight value, if present round it to 1 decimal place
-    #     data = self.cleaned_data["weight"]
-    #     if data is not None:
-    #         if data < 1:
-    #             raise ValidationError(
-    #                 "Patient Weight (kg)' invalid. Cannot be below 1kg"
-    #             )
-    #         if data > 200:
-    #             raise ValidationError(
-    #                 "Patient Weight (kg)' invalid. Cannot be above 200kg"
-    #             )
-    #         data = round(data, 1)
-    #     return data
-
     def clean_systolic_blood_pressure(self):
         systolic_blood_pressure = self.cleaned_data["systolic_blood_pressure"]
 
@@ -763,7 +733,7 @@ class VisitForm(forms.ModelForm):
         def round_to_one_decimal_place(value):
             return Decimal(value).quantize(
                 Decimal("0.1"), rounding=ROUND_HALF_UP
-            )  # round to 1 decimal place: although the rounding is done in the clean methods for height and weight, this is a final check
+            )  # round to 1 decimal place
 
         birth_date = self.patient.date_of_birth
         sex = self.patient.sex

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -9,7 +9,7 @@ import collections
 # django imports
 from django.apps import apps
 from django.utils import timezone
-from django.core.exceptions import ValidationError
+from django.core.exceptions import FieldDoesNotExist
 
 # third part imports
 import pandas as pd
@@ -181,6 +181,24 @@ async def csv_upload(
 
         return True
 
+    # Numbers larger than (max_digits - decimal_places) will fail to save at the database level
+    # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/993
+    def is_too_big_number(model, field_name, value):
+        try:
+            model_definition = model._meta.get_field(field_name)
+
+            max_digits = getattr(model_definition, "max_digits", None)
+            decimal_places = getattr(model_definition, "decimal_places", None)
+
+            if max_digits and decimal_places:
+                max_value = 10 ** (max_digits - decimal_places) - 1
+                return value >= max_value
+
+            return False
+        except FieldDoesNotExist:
+            # Handle fields like date_leaving_service that are on the PatientForm but not on the Patient model
+            return False
+
     def save_errors_and_retain_valid_fields(row_index, form):
         # We want to retain fields so that we can show them in the user interface
         # Use the field value from cleaned_data, falling back to data if it's not there
@@ -189,7 +207,9 @@ async def csv_upload(
             setattr(form.instance, key, value)
 
         for key, value in form.data.items():
-            if key not in form.cleaned_data and can_save_field(form, key):
+            if is_too_big_number(form._meta.model, key, value):
+                setattr(form.instance, key, 0)
+            elif key not in form.cleaned_data and can_save_field(form, key):
                 setattr(form.instance, key, value)
             elif not hasattr(form.instance, key):
                 setattr(form.instance, key, None)

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -207,7 +207,7 @@ async def csv_upload(
             setattr(form.instance, key, value)
 
         for key, value in form.data.items():
-            if is_too_big_number(form._meta.model, key, value):
+            if value and is_too_big_number(form._meta.model, key, value):
                 setattr(form.instance, key, 0)
             elif key not in form.cleaned_data and can_save_field(form, key):
                 setattr(form.instance, key, value)

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -192,7 +192,12 @@ async def csv_upload(
 
             if max_digits and decimal_places:
                 max_value = 10 ** (max_digits - decimal_places) - 1
-                return value >= max_value
+
+                try:
+                    return value >= max_value
+                # Missing values or strings
+                except TypeError:
+                    return False
 
             return False
         except FieldDoesNotExist:
@@ -207,7 +212,7 @@ async def csv_upload(
             setattr(form.instance, key, value)
 
         for key, value in form.data.items():
-            if value and is_too_big_number(form._meta.model, key, value):
+            if is_too_big_number(form._meta.model, key, value):
                 setattr(form.instance, key, 0)
             elif key not in form.cleaned_data and can_save_field(form, key):
                 setattr(form.instance, key, value)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3628,3 +3628,43 @@ def test_submission_has_audit_period_attached(test_user, single_row_valid_df):
     submission = Submission.objects.first()
 
     assert submission.audit_period == audit_period, f"Expected submission to have audit period {audit_period}, but got {submission.audit_period}"
+
+@pytest.mark.django_db
+def test_visit_with_too_big_decimal_number_still_saves(test_user, dummy_sheet_csv):
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "Patient Weight (kg)", "value": "3405.5"}],
+    )
+
+    parsed_csv = read_csv_from_str(one_row_csv)
+    assert len(parsed_csv.errors_to_return) == 0, f"Expected no errors when parsing CSV, got {parsed_csv.errors_to_return}"
+
+    errors = csv_upload_sync(test_user, parsed_csv.df, errors_to_return=parsed_csv.errors_to_return)
+    
+    assert "weight" in errors[0], f"Expected weight to be in errors, but got {errors}"
+
+    assert Visit.objects.count() == 1, "Expected one visit to be created"
+    visit = Visit.objects.first()
+
+    assert visit.weight == Decimal(0)
+    assert "weight" in visit.errors, f"Expected weight to have an error, but got {visit.errors}"
+
+@pytest.mark.django_db
+def test_visit_with_too_precise_decimal_number_is_rounded(test_user, dummy_sheet_csv):
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "Patient Weight (kg)", "value": "34.12345612"}],
+    )
+
+    parsed_csv = read_csv_from_str(one_row_csv)
+    assert len(parsed_csv.errors_to_return) == 0, f"Expected no errors when parsing CSV, got {parsed_csv.errors_to_return}"
+
+    errors = csv_upload_sync(test_user, parsed_csv.df, errors_to_return=parsed_csv.errors_to_return)
+    assert len(errors) == 0, f"Expected no errors when uploading CSV, got {errors}"
+
+    assert Visit.objects.count() == 1, "Expected one visit to be created"
+    visit = Visit.objects.first()
+
+    assert visit.weight == Decimal(34.1)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3667,4 +3667,4 @@ def test_visit_with_too_precise_decimal_number_is_rounded(test_user, dummy_sheet
     assert Visit.objects.count() == 1, "Expected one visit to be created"
     visit = Visit.objects.first()
 
-    assert visit.weight == Decimal(34.1)
+    assert visit.weight == Decimal('34.1')


### PR DESCRIPTION
Fixes #993 

We use `max_digits` on some fields (`height`, `hba1c`). Whilst this does cause a validation error when exceeded, our strategy for CSV uploads is just then to try and save the model anyway. It turns out those constraints are enforced at the database level so the entire visit fails to save.

This PR catches that situation in the CSV upload code and zeros out the number. The validation error still appears in the data quality report alongside the original incorrect value, although navigating to the visit in the UI will show 0. 