### PR TITLE
issue1055-eatyourpeas-mean-HbA1c-filter

### DIFF
--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -845,11 +845,15 @@ class PatientReportView(
                 "kpi_45_median_hba1c",
             ]:
                 reverse = sort_order == "desc"
+                field_name = sort_field.replace("-", "")
+                # Calculate HbA1c values
+                pt_qs = self._calculate_hba1c_values(pt_qs, calculate_kpis)
+                
                 pt_qs = sorted(
                     pt_qs,
                     key=lambda p: (
-                        p[sort_field.replace("-", "")] is None,
-                        p[sort_field.replace("-", "")] or 0,
+                        p.get(field_name) is None, 
+                        p.get(field_name) or 0,
                     ),
                     reverse=reverse,
                 )


### PR DESCRIPTION
### Overview
Fix for the broken sort by median and mean HbA1c in patient report

### Code changes
The `_calculate_hba1c_values` method was not called before trying to sort the list of dicts that would have been returned from this, so the key to sort by did not yet exist leading to an error. 

fixes #1055