### PR TITLE
Fix crash on float values in integer columns

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -205,7 +205,7 @@ def csv_parse(csv_file):
         try:
             if column in df.columns:
                 df[column] = df[column].astype(dtype)
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             parse_type_error_columns.append(column)
             continue
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -3384,6 +3384,7 @@ def test_bad_data_for_positive_small_integer_fields(
     for [value, expected, assertion_message] in [
         [94, None, f"Failed to handle {model_field} with incorrect choice (94)"],
         [-1, None, f"Failed to handle {model_field} with -1 (negative number)"],
+        [99.5, None, f"Failed to handle {model_field} with 99.5 (float)"],
         [
             9999,
             None,


### PR DESCRIPTION
Fix #1057. Trying to parse a float value as int64 gives a `TypeError`, not the `ValueError` we were already catching.