### PR TITLE
Temporarily hide health check completion rate

### DIFF
--- a/project/npda/templates/patient_report/health_checks_table_partial.html
+++ b/project/npda/templates/patient_report/health_checks_table_partial.html
@@ -27,7 +27,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  HBA1c ({{ total_passed_hba1c|percentage:total_eligible_hba1c }} complete)
+  HBA1c <!-- ({{ total_passed_hba1c|percentage:total_eligible_hba1c }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_hba1c&order=desc"
           hx-target="#table-area"
@@ -44,7 +44,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  BMI ({{ total_passed_bmi|percentage:total_eligible_bmi }} complete)
+  BMI <!-- ({{ total_passed_bmi|percentage:total_eligible_bmi }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_bmi&order=desc"
           hx-target="#table-area"
@@ -61,7 +61,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Thyroid Screen ({{ total_passed_thyroid_screen|percentage:total_eligible_thyroid_screen }} complete)
+  Thyroid Screen <!-- ({{ total_passed_thyroid_screen|percentage:total_eligible_thyroid_screen }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_thyroid_screen&order=desc"
           hx-target="#table-area"
@@ -78,7 +78,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Blood Pressure ({{ total_passed_blood_pressure|percentage:total_eligible_blood_pressure }} complete)
+  Blood Pressure <!-- ({{ total_passed_blood_pressure|percentage:total_eligible_blood_pressure }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_blood_pressure&order=desc"
           hx-target="#table-area"
@@ -95,7 +95,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Urinary Albumin ({{ total_passed_urinary_albumin|percentage:total_eligible_urinary_albumin }} complete)
+  Urinary Albumin <!-- ({{ total_passed_urinary_albumin|percentage:total_eligible_urinary_albumin }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_urinary_albumin&order=desc"
           hx-target="#table-area"
@@ -112,7 +112,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Foot Exam ({{ total_passed_foot_exam|percentage:total_eligible_foot_exam }} complete)
+  Foot Exam <!-- ({{ total_passed_foot_exam|percentage:total_eligible_foot_exam }} complete) https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1059 -->
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_foot_exam&order=desc"
           hx-target="#table-area"


### PR DESCRIPTION
It confusingly only reflects the patients in the current page (see #1059)