### PR TITLE
Fix more privilege escalation by coordinators vulnerabilitie

### DIFF
--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -40,8 +40,6 @@ class NPDAUserForm(forms.ModelForm):
             "first_name",
             "surname",
             "email",
-            "is_staff",
-            "is_superuser",
             "is_rcpch_audit_team_member",
             "is_rcpch_staff",
             "role",
@@ -52,12 +50,6 @@ class NPDAUserForm(forms.ModelForm):
             "first_name": forms.TextInput(attrs={"class": TEXT_INPUT}),
             "surname": forms.TextInput(attrs={"class": TEXT_INPUT}),
             "email": forms.EmailInput(attrs={"class": TEXT_INPUT}),
-            "is_staff": forms.CheckboxInput(attrs={"class": "toggle border-rcpch_light_blue js-toggle-checkbox"}),
-            "is_superuser": forms.CheckboxInput(
-                attrs={
-                    "class": "toggle border-rcpch_light_blue bg-rcpch_light_blue checked:bg-rcpch_pink_light_tint2 checked:border-rcpch_pink hover:bg-rcpch_pink"
-                }
-            ),
             "is_rcpch_audit_team_member": forms.CheckboxInput(
                 attrs={
                     "class": "toggle border-rcpch_light_blue bg-rcpch_light_blue checked:bg-rcpch_pink_light_tint2 checked:border-rcpch_pink hover:bg-rcpch_pink"

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -629,13 +629,52 @@ def test_coordinators_cannot_set_user_flags(
 @pytest.mark.parametrize(
     "user_flag",
     [
-        "is_superuser",
-        "is_staff",
         "is_rcpch_audit_team_member",
         "is_rcpch_staff"
     ],
 )
-def test_coordinators_cannot_create_users_with_flags(
+def test_coordinators_cannot_create_users_with_superuser_flags(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    user_flag
+):
+    user_count_before = NPDAUser.objects.count()
+
+    coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, coordinator)
+
+    url = reverse("npdauser-create")
+
+    data = {
+        "first_name": "Bob",
+        "surname": "Bobertson",
+        "email": "bob@bobertson.com",
+        "add_employer": ALDER_HEY_PZ_CODE,
+        "role": AUDIT_CENTRE_COORDINATOR,
+    }
+
+    data[user_flag] = "on"
+
+    client.post(url, data)
+
+    user_count_after = NPDAUser.objects.count()
+    assert user_count_after == user_count_before
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_flag",
+    [
+        "is_superuser",
+        "is_staff"
+    ],
+)
+def test_coordinators_cannot_create_users_with_django_admin_flags(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -582,43 +582,65 @@ def test_audit_team_can_add_employers_outside_of_their_pdu(
     assert employers == { ALDER_HEY_PZ_CODE, GOSH_PZ_CODE }
 
 
-# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/911
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_flag",
+    [
+        "is_superuser",
+        "is_staff",
+        "is_rcpch_audit_team_member",
+        "is_rcpch_staff"
+    ],
+)
 def test_coordinators_cannot_set_user_flags(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
+    user_flag
 ):
     coordinator = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
     ).first()
 
-    assert coordinator.is_superuser is False
+    assert getattr(coordinator, user_flag) is False
 
     client = login_and_verify_user(client, coordinator)
 
     url = reverse("npdauser-update", kwargs={"pk": coordinator.pk})
 
-    response = client.post(url, data={
+    data = {
         "add_employer": ALDER_HEY_PZ_CODE,
         "first_name": coordinator.first_name,
         "surname": coordinator.surname,
         "email": coordinator.email,
         "role": coordinator.role,
-        "is_superuser": "on",
-    })
+    }
+
+    data[user_flag] = "on"
+
+    client.post(url, data)
 
     coordinator.refresh_from_db()
-    assert coordinator.is_superuser is False
+    assert getattr(coordinator, user_flag) is False
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_flag",
+    [
+        "is_superuser",
+        "is_staff",
+        "is_rcpch_audit_team_member",
+        "is_rcpch_staff"
+    ],
+)
 def test_coordinators_cannot_create_users_with_flags(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
+    user_flag
 ):
     user_count_before = NPDAUser.objects.count()
 
@@ -630,17 +652,17 @@ def test_coordinators_cannot_create_users_with_flags(
 
     url = reverse("npdauser-create")
 
-    client.post(
-        url,
-        {
-            "first_name": "Bob",
-            "surname": "Bobertson",
-            "email": "bob@bobertson.com",
-            "add_employer": ALDER_HEY_PZ_CODE,
-            "role": AUDIT_CENTRE_COORDINATOR,
-            "is_superuser": "on"
-        },
-    )
+    data = {
+        "first_name": "Bob",
+        "surname": "Bobertson",
+        "email": "bob@bobertson.com",
+        "add_employer": ALDER_HEY_PZ_CODE,
+        "role": AUDIT_CENTRE_COORDINATOR,
+    }
+
+    data[user_flag] = "on"
+
+    client.post(url, data)
 
     user_count_after = NPDAUser.objects.count()
     assert user_count_after == user_count_before

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -582,6 +582,70 @@ def test_audit_team_can_add_employers_outside_of_their_pdu(
     assert employers == { ALDER_HEY_PZ_CODE, GOSH_PZ_CODE }
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/911
+@pytest.mark.django_db
+def test_coordinators_cannot_set_user_flags(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+):
+    coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    assert coordinator.is_superuser is False
+
+    client = login_and_verify_user(client, coordinator)
+
+    url = reverse("npdauser-update", kwargs={"pk": coordinator.pk})
+
+    response = client.post(url, data={
+        "add_employer": ALDER_HEY_PZ_CODE,
+        "first_name": coordinator.first_name,
+        "surname": coordinator.surname,
+        "email": coordinator.email,
+        "role": coordinator.role,
+        "is_superuser": "on",
+    })
+
+    coordinator.refresh_from_db()
+    assert coordinator.is_superuser is False
+
+
+@pytest.mark.django_db
+def test_coordinators_cannot_create_users_with_flags(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+):
+    user_count_before = NPDAUser.objects.count()
+
+    coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    client = login_and_verify_user(client, coordinator)
+
+    url = reverse("npdauser-create")
+
+    client.post(
+        url,
+        {
+            "first_name": "Bob",
+            "surname": "Bobertson",
+            "email": "bob@bobertson.com",
+            "add_employer": ALDER_HEY_PZ_CODE,
+            "role": AUDIT_CENTRE_COORDINATOR,
+            "is_superuser": "on"
+        },
+    )
+
+    user_count_after = NPDAUser.objects.count()
+    assert user_count_after == user_count_before
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "user_data",

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -642,8 +642,6 @@ def test_coordinators_cannot_create_users_with_flags(
     client,
     user_flag
 ):
-    user_count_before = NPDAUser.objects.count()
-
     coordinator = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
     ).first()
@@ -664,8 +662,8 @@ def test_coordinators_cannot_create_users_with_flags(
 
     client.post(url, data)
 
-    user_count_after = NPDAUser.objects.count()
-    assert user_count_after == user_count_before
+    user = NPDAUser.objects.get(email="bob@bobertson.com")
+    assert getattr(user, user_flag) is False
 
 
 @pytest.mark.django_db

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -187,6 +187,16 @@ class NPDAUserCreateView(
                 "You do not have permission to add a user with RCPCH Audit Team role."
             )
 
+        if form.cleaned_data["is_rcpch_audit_team_member"] and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+            raise PermissionDenied(
+                "You do not have permission to add a user with the is_rcpch_audit_team_member flag."
+            )
+
+        if form.cleaned_data["is_rcpch_staff"] and not (self.request.user.is_superuser or self.request.user.is_rcpch_staff):
+            raise PermissionDenied(
+                "You do not have permission to add a user with the is_rcpch_staff flag."
+            )
+
         new_user = form.save(commit=False)
         new_user.set_unusable_password()
         new_user.is_active = True
@@ -285,7 +295,17 @@ class NPDAUserUpdateView(
         
         if form.cleaned_data["role"] == RCPCH_AUDIT_TEAM and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
             raise PermissionDenied(
-                "You do not have permission to add a user with RCPCH Audit Team role."
+                "You do not have permission to grant the RCPCH Audit Team role."
+            )
+
+        if form.cleaned_data["is_rcpch_audit_team_member"] and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+            raise PermissionDenied(
+                "You do not have permission to set the is_rcpch_audit_team_member flag."
+            )
+
+        if form.cleaned_data["is_rcpch_staff"] and not (self.request.user.is_superuser or self.request.user.is_rcpch_staff):
+            raise PermissionDenied(
+                "You do not have permission to set the is_rcpch_staff flag."
             )
         
         user = form.save(commit=True)


### PR DESCRIPTION
Fixes #1072 

Follow up to #908 which stopped coordinators from constructing a malicious `POST` request to grant themselves or others the RCPCH Audit Team role. This PR extends that protection to the user flags:

- `is_superuser` and `is_staff`: can now only be set in the Django Admin
- `is_rcpch_audit_team_member` and `is_rcpch_staff`: can now only be set if the user already has that flag or `is_superuser`