### PR TITLE
Revert "hotfix-not-building"

### DIFF
--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -28,7 +28,7 @@ from project.npda.views.decorators import login_and_otp_required
 
 # RCPCH imports
 from project.constants.colors import RCPCH_LIGHT_BLUE
-from ..general_functions.session import refresh_session_filters # save_csv_uploading_user_to_visitactivity 
+from ..general_functions.session import refresh_session_filters, save_csv_uploading_user_to_visitactivity
 from ..general_functions.csv import (
     download_csv,
     download_xlsx,
@@ -388,7 +388,7 @@ async def upload_csv(request):
         # update the session fields - this stores that the user has uploaded a csv and disables the ability to use the questionnaire
         await sync_to_async(refresh_session_filters)(request, csv_upload=True)
 
-        # await sync_to_async(save_csv_uploading_user_to_visitactivity)(request=request)
+        await sync_to_async(save_csv_uploading_user_to_visitactivity)(request=request)
         
         return redirect("upload-csv-in-progress")
 
@@ -454,7 +454,7 @@ def switch_paediatric_diabetes_unit(request):
         "error_message": error_message,
     }
     # update the session with the new PDU
-    # refresh_session_filters(request, pz_code=selected_pz_code)
+    refresh_session_filters(request, pz_code=selected_pz_code)
 
     return render(request, template, context=context)
 


### PR DESCRIPTION
Reverts rcpch/national-paediatric-diabetes-audit#1086

The issue was not this but a misconfiguration where the Azure Container Apps managed identity no longer had `CREATE` access to the postgres schema. I fixed this manually in the psql CLI.