### PR TITLE
Temporarily put back the gunicorn logs

### DIFF
--- a/s/start-prod
+++ b/s/start-prod
@@ -8,4 +8,6 @@ python manage.py seed --mode=seed_groups_and_permissions
 gunicorn \
     --bind=0.0.0.0:8000 \
     --timeout 600 \
+    --access-logfile '-' \
+    --access-logformat '%({x-forwarded-for}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"' \
     project.wsgi


### PR DESCRIPTION
Whilst I investigate why #1090 is not working in live