### PR TITLE
change post-save to pre-save, comment out VisitActivity log

### DIFF
--- a/project/npda/signals.py
+++ b/project/npda/signals.py
@@ -230,7 +230,7 @@ def log_user_pdu_assignment(sender, instance, created, **kwargs):
         logger.info(f"PDU assignment updated for user {instance.npda_user.email} at PDU {instance.paediatric_diabetes_unit.pz_code}")
 
 
-@receiver(post_delete, sender=OrganisationEmployer)
+@receiver(pre_delete, sender=OrganisationEmployer)
 def log_user_pdu_removal(sender, instance, **kwargs):
     """
     Log when a user is removed from a PDU.
@@ -240,17 +240,17 @@ def log_user_pdu_removal(sender, instance, **kwargs):
     
     details = f"User {instance.npda_user.email} removed from PDU {instance.paediatric_diabetes_unit.pz_code} ({instance.paediatric_diabetes_unit.parent_name}) by {current_user.email if current_user else 'system'}"
     
-    _log_user_activity(
-        user=instance.npda_user,
-        activity_type=16,  # REMOVED_USER_FROM_PDU
-        details=details,
-        current_user=current_user
-    )
+    # _log_user_activity(
+    #     user=instance.npda_user,
+    #     activity_type=16,  # REMOVED_USER_FROM_PDU
+    #     details=details,
+    #     current_user=current_user
+    # )
     
     # Send notification to admins about PDU removal
     _send_pdu_assignment_notification(instance, current_user, is_new=False, is_removal=True)
     
-    logger.info(f"User {instance.npda_user.email} removed from PDU {instance.paediatric_diabetes_unit.pz_code}")
+    logger.info(details)
 
 @receiver(pre_save, sender=OrganisationEmployer)
 def capture_pdu_assignment_changes(sender, instance, **kwargs):

--- a/project/npda/templates/npda/npdauser_confirm_delete.html
+++ b/project/npda/templates/npda/npdauser_confirm_delete.html
@@ -1,28 +1,33 @@
 {% extends 'base.html' %}
+{% load static %}
+{% load npda_tags %}
 {% block content %}
-  <div class="px-8 mt-10">
-    <div class="flex items-center bg-rcpch_strong_blue text-white text-sm font-bold px-4 py-3"
-         role="alert">
-      <form method="post">
-        {% csrf_token %}
-        <span class="flex flex-row">
-          <svg class="fill-current w-4 h-4 mr-2"
-               xmlns="http://www.w3.org/2000/svg"
-               viewBox="0 0 20 20">
-            <path d="M12.432 0c1.34 0 2.01.912 2.01 1.957 0 1.305-1.164 2.512-2.679 2.512-1.269 0-2.009-.75-1.974-1.99C9.789 1.436 10.67 0 12.432 0zM8.309 20c-1.058 0-1.833-.652-1.093-3.524l1.214-5.092c.211-.814.246-1.141 0-1.141-.317 0-1.689.562-2.502 1.117l-.528-.88c2.572-2.186 5.531-3.467 6.801-3.467 1.057 0 1.233 1.273.705 3.23l-1.391 5.352c-.246.945-.141 1.271.106 1.271.317 0 1.357-.392 2.379-1.207l.6.814C12.098 19.02 9.365 20 8.309 20z" />
-          </svg>
-          <h1>
-            Deleting
-            {% if title %}{{ get_title_display }}{% endif %}
-            {{ object.first_name }} {{ object.surname }}
+  <form method="post">
+    {% csrf_token %}
+    <div class="hero bg-base-100 min-h-screen">
+      <div class="hero-content flex-col lg:flex-row">
+        <img src="{% static 'images/npda-logo-white.png' %}"
+             alt="NPDA Logo"
+             class="w-1/4 mx-auto mb-1" />
+        <div class="max-w-md">
+          <h1 class="text-4xl font-bold text-rcpch_red font-montserrat">
+            Confirmation Required
           </h1>
-        </span>
-        <p>Are you sure you want to delete?</p>
-        {{ form }}
-        <input class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue"
-               type="submit"
-               value="Confirm">
-      </form>
+          <h2 class="text-1xl font-bold text-rcpch_red font-montserrat">
+            Deleting {{ object.get_full_name }}
+          </h2>
+          <p class="my-4">
+            Are you sure you want to delete {{ object.get_full_name }} from the NPDA Platform? This action cannot be undone.
+          </p>
+          <button class="rcpch-danger-btn" type="submit" value="Delete" name="delete">
+            Delete
+          </button>
+          <button class="btn rcpch-btn bg-rcpch_yellow_light_tint1 border border-rcpch_yellow_light_tint1 hover:bg-rcpch_yellow hover:border-rcpch_yellow"
+                  type="submit"
+                  value="Cancel"
+                  name="cancel">Cancel</button>
+        </div>
+      </div>
     </div>
-  </div>
+  </form>
 {% endblock %}


### PR DESCRIPTION
### Overview
🌶️ [Hot FIX]

### PROBLEM

A recently added signal on the `post_delete` method of the `NPDAUser` model predictably threw an error when trying to log the activity in the VisitActivity model - since this model stores the user that has had a change applied, as well as the user that made the change. In the `post_delete` method, the user has already been deleted and therefore cannot be used to update `VisitActivity`

So the fix for the short term has been:
1. change `post_delete` to `pre_delete` to allow logging and email notification to admin to occur.
2. Comment out the saving of the activity to VisitActivity (since any record created there pre-delete would immediately be removed post-delete through referential integrity).

I am detailing this because after I close this PR, I think it would be helpful to have a conversation about what we do with our users that we delete?

I will open a new issue for this but detailing here for continuity.

closes #1098
