### PR TITLE
Deep link to user guide page in docs

### DIFF
--- a/project/npda/templates/navbar/components/nav_links.html
+++ b/project/npda/templates/navbar/components/nav_links.html
@@ -11,7 +11,7 @@
   </li>
 {% endif %}
 <li>
-  <a href="{% docs_url %}"
+  <a href="{% docs_url %}/user-guide/user-guide/"
      class="text-xs font-montserrat font-semibold   text-gray-700  text-gray-400 hover:text-rcpch_light_blue hover:bg-transparent hover:underline underline-offset-8">
     User Guide
   </a>


### PR DESCRIPTION
Requested by @richardshepherd45, thanks!

It's confusing for users to click user guide and then have to navigate to the right page in our docs. This PR changes the navigation link to be a deep link to the user guide page itself.