### PR TITLE
Revert "Temporarily put back the gunicorn logs"

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -20,14 +20,15 @@ from dotenv import load_dotenv
 #  django imports
 from django.core.management.utils import get_random_secret_key
 
+# Has to be before logging_settings as that reads ENABLE_REQUEST_LOGGING
+load_dotenv("envs/.env")
+
 # RCPCH imports
 from .logging_settings import (
     LOGGING,
 )  # no it is not an unused import, it pulls LOGGING into the settings file
 
 logger = logging.getLogger(__name__)
-
-load_dotenv("envs/.env")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/s/start-prod
+++ b/s/start-prod
@@ -8,6 +8,4 @@ python manage.py seed --mode=seed_groups_and_permissions
 gunicorn \
     --bind=0.0.0.0:8000 \
     --timeout 600 \
-    --access-logfile '-' \
-    --access-logformat '%({x-forwarded-for}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"' \
     project.wsgi


### PR DESCRIPTION
Reverts rcpch/national-paediatric-diabetes-audit#1097 and loads `.env` before `logging_settings`. It worked without this in dev because we spray all the env vars from `.env` into the container in the Docker compose file. But in staging and live, we just call `load_dotenv`. So it has to come before `logging_settings` for that to be able to read `ENABLE_REQUEST_LOGGING`.