### PR TITLE
Remove some calls to AuditPeriod.audit_year

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -43,7 +43,6 @@ from project.npda.models import (
 async def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None):
     old_submission = await Submission.objects.filter(
         paediatric_diabetes_unit=pdu,
-        audit_year=audit_period.audit_year(), # compatibility
         audit_period=audit_period,
         submission_active=True,
     ).afirst()

--- a/project/npda/models/submission.py
+++ b/project/npda/models/submission.py
@@ -2,6 +2,20 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.conf import settings
 
+from .audit_period import AuditPeriod
+
+
+class SubmissionManager(models.Manager):
+    def get_submission_for_request(self, request, audit_period=None):
+        pz_code = request.session.get("pz_code")
+        effective_audit_period = audit_period or AuditPeriod.objects.get_audit_period_for_request(request)
+
+        return self.filter(
+            audit_period=effective_audit_period,
+            paediatric_diabetes_unit__pz_code=pz_code,
+            submission_active=True
+        ).first()
+
 
 class Submission(models.Model):
     """
@@ -11,6 +25,8 @@ class Submission(models.Model):
     and the PZ code of the Paediatric Diabetes Unit that is conducting the audit.
     Each submission comprises  a list of unique patients and their visits as well as the csv file as a BinaryField.
     """
+
+    objects = SubmissionManager()
 
     # This was the original field before audit_period was introduced. It remains for compatibility.
     audit_year = models.IntegerField(

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -122,7 +122,7 @@ def get_metric_scatter_plot(request):
 
         if request.method == "POST":
             selected_chart = request.POST["scatter_plot_select"]
-            submission, calculation_date = submission_and_calculation_date(request)
+            calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date
             data, title, tooltip_text = get_selected_chart_data(
                 selected_chart, calculation_date, request.session.get("pz_code")
             )
@@ -247,7 +247,7 @@ def get_new_diagnoses_partial(request):
     # Get new diagnoses this submission
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=False
@@ -278,7 +278,7 @@ def get_new_admissions_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=False
@@ -305,7 +305,7 @@ def get_transitioned_to_adult_service_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
@@ -336,7 +336,7 @@ def get_moved_out_of_area_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
@@ -363,7 +363,7 @@ def get_n_on_hcl_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
@@ -402,7 +402,7 @@ def get_pump_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
@@ -438,7 +438,7 @@ def get_cgm_partial(request):
 
     pz_code = request.session.get("pz_code")
 
-    submission, calculation_date = submission_and_calculation_date(request)
+    calculation_date = AuditPeriod.objects.get_audit_period_for_request(request).kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
         calculation_date=calculation_date, return_pt_querysets=True
@@ -492,39 +492,3 @@ def get_selected_chart_data(selected_chart: str, calculation_date: date, pz_code
             "Numbers of patients with diabetes transitioned to adult services by quarter. These numbers include all patients who transition to adults by quarter in blue. Cumulative totals by quarter are shown in grey.",
         )
 
-
-def submission_and_calculation_date(request):
-    # Get new diagnoses this submission
-    pz_code = request.session.get("pz_code")
-
-    PaediatricDiabetesUnit: PaediatricDiabetesUnitClass = apps.get_model(
-        "npda", "PaediatricDiabetesUnit"
-    )
-    try:
-        pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
-    except PaediatricDiabetesUnit.DoesNotExist:
-        messages.error(
-            request=request,
-            message=f"Paediatric Diabetes Unit with PZ code {pz_code} does not exist",
-        )
-        return render(request, "dashboard.html")
-
-    audit_period = AuditPeriod.objects.get_audit_period_for_request(request)
-
-    if Submission.objects.filter(
-        paediatric_diabetes_unit=pdu,
-        audit_year=audit_period.audit_year(),
-        submission_active=True,
-    ).exists():
-        submission = Submission.objects.get(
-            paediatric_diabetes_unit=pdu,
-            audit_year=audit_period.audit_year(),
-            submission_active=True,
-        )
-        
-    else:
-        submission = None
-    
-    calculation_date = audit_period.kpi_calculation_date()
-
-    return submission, calculation_date

--- a/project/npda/views/dashboard/patient_characteristics.py
+++ b/project/npda/views/dashboard/patient_characteristics.py
@@ -247,22 +247,10 @@ def all_patient_charts(request):
         "Unknown": 0,
     }
 
-    if Submission.objects.filter(
-        audit_year=audit_period.audit_year(),
-        submission_active=True,
-        paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-        paediatric_diabetes_unit__active=True,
-    ).exists():
-        all_patients_in_this_submission = (
-            Submission.objects.filter(
-                audit_year=audit_period.audit_year(),
-                submission_active=True,
-                paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-                paediatric_diabetes_unit__active=True,
-            )
-            .get()
-            .patients.all()
-        )
+    current_submission = Submission.objects.get_submission_for_request(request, audit_period=audit_period)
+
+    if current_submission:
+        all_patients_in_this_submission = current_submission.patients.all()
 
         for patient in all_patients_in_this_submission.values(
             "pk",

--- a/project/npda/views/dashboard/patient_characteristics.py
+++ b/project/npda/views/dashboard/patient_characteristics.py
@@ -121,22 +121,10 @@ def patient_ages(request):
 
     number_of_patients = 0
 
-    if Submission.objects.filter(
-        audit_year=audit_period.audit_year(),
-        submission_active=True,
-        paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-        paediatric_diabetes_unit__active=True,
-    ).exists():
-        all_patients_in_this_submission = (
-            Submission.objects.filter(
-                audit_year=audit_period.audit_year(),
-                submission_active=True,
-                paediatric_diabetes_unit__pz_code=request.session.get("pz_code"),
-                paediatric_diabetes_unit__active=True,
-            )
-            .get()
-            .patients.all()
-        )
+    current_submission = Submission.objects.get_submission_for_request(request, audit_period=audit_period)
+
+    if current_submission:
+        all_patients_in_this_submission = current_submission.patients.all() 
 
         comparison_date = audit_period.kpi_calculation_date()
 

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -8,8 +8,6 @@ from project.npda.models import Visit, Submission, AuditPeriod
 
 @login_and_otp_required()
 def patient_measurements(request):
-
-    # First need to get the relevant calculations
     pz_code = request.session.get("pz_code")
 
     audit_period = AuditPeriod.objects.get_audit_period_for_request(request)
@@ -51,11 +49,7 @@ def patient_measurements(request):
         calculate_kpis.calculate_kpi_hba1c_vals_stratified_by_diabetes_type()
     )
 
-    current_submission = Submission.objects.filter(
-        audit_period=audit_period,
-        paediatric_diabetes_unit__pz_code=pz_code,
-        submission_active=True
-    ).first()
+    current_submission = Submission.objects.get_submission_for_request(request, audit_period=audit_period)
 
     if current_submission:
         visits = Visit.objects.filter(patient__in=current_submission.patients.all())

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -51,18 +51,13 @@ def patient_measurements(request):
         calculate_kpis.calculate_kpi_hba1c_vals_stratified_by_diabetes_type()
     )
 
-    if Submission.objects.filter(
-        audit_year=audit_period.audit_year(),
+    current_submission = Submission.objects.filter(
+        audit_period=audit_period,
         paediatric_diabetes_unit__pz_code=pz_code,
-        paediatric_diabetes_unit__active=True,
-        submission_active=True,
-    ).exists():
-        current_submission = Submission.objects.filter(
-            audit_year=audit_period.audit_year(),
-            paediatric_diabetes_unit__pz_code=pz_code,
-            paediatric_diabetes_unit__active=True,
-            submission_active=True,
-        ).get()
+        submission_active=True
+    ).first()
+
+    if current_submission:
         visits = Visit.objects.filter(patient__in=current_submission.patients.all())
         submission_visits_with_errors = visits.filter(errors__isnull=False)
         submission_visit_error_count = submission_visits_with_errors.count()
@@ -81,8 +76,6 @@ def patient_measurements(request):
         request,
         template_name=template,
         context={
-            "selected_audit_year": audit_period.audit_year(),
-            "pz_code": pz_code,
             "hba1c_value_counts_stratified_by_diabetes_type": hba1c_value_counts_stratified_by_diabetes_type,
             "submission_visit_error_count": submission_visit_error_count,
             "submission_date": submission_date,

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -402,7 +402,7 @@ def upload_csv_in_progress(request):
 
     last_submission = Submission.objects.filter(
         paediatric_diabetes_unit__pz_code=pz_code,
-        audit_year=audit_period.audit_year(),
+        audit_period=audit_period
     ).order_by("-submission_date").first()
 
     seconds_since_submission = (datetime.now(timezone.utc) - last_submission.submission_date).seconds

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -370,7 +370,7 @@ async def upload_csv(request):
         audit_period = await sync_to_async(AuditPeriod.objects.get_audit_period_for_request)(request)
 
         if not audit_period.is_open and not (request.user.is_superuser or request.user.is_rcpch_audit_team_member):
-            raise PermissionDenied(f"Upload is closed for {audit_period.audit_year()}.")
+            raise PermissionDenied(f"Upload is closed for {audit_period}.")
 
         new_submission = await create_csv_submission(
             pdu=pdu,


### PR DESCRIPTION
In the spirit of #947, remove many calls to the `audit_year()` compatibility helper on `AuditPeriod`. Also introduces a helper method on `Submission` to get the current submission (#533)