### PR TITLE
Use get_submission_for_request where possible

### DIFF
--- a/project/npda/general_functions/map.py
+++ b/project/npda/general_functions/map.py
@@ -51,25 +51,11 @@ Functions to return scatter plot of children by postcode
 """
 
 
-def get_children_by_pdu_audit_year(
-    audit_year, paediatric_diabetes_unit, paediatric_diabetes_unit_lead_organisation
-):
+def get_children_by_pdu_audit_year(submission, paediatric_diabetes_unit_lead_organisation):
     """
     Returns a list of children by postcode for a given audit year and paediatric diabetes unit
     """
     Patient = apps.get_model("npda", "Patient")
-    Submission = apps.get_model("npda", "Submission")
-
-    AuditPeriod = apps.get_model("npda", "AuditPeriod")
-    audit_period = AuditPeriod.objects.filter(
-        start_date__year=audit_year,
-    ).first()
-
-    submission = Submission.objects.filter(
-        audit_period=audit_period,
-        paediatric_diabetes_unit=paediatric_diabetes_unit,
-        submission_active=True,
-    ).first()
 
     if submission is None:
         return Patient.objects.none()

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -14,12 +14,8 @@ from project.npda.general_functions import (
 logger = logging.getLogger(__name__)
 
 
-def get_submission_actions(pz_code, audit_year):
+def get_submission_actions(pz_code, audit_period):
     Submission = apps.get_model("npda", "Submission")
-    AuditPeriod = apps.get_model("npda", "AuditPeriod")
-    audit_period = AuditPeriod.objects.filter(
-        start_date__year=audit_year
-    ).first()  # Ensure the audit period exists for the given year
 
     submission = Submission.objects.filter(
         paediatric_diabetes_unit__pz_code=pz_code,
@@ -82,7 +78,7 @@ def create_session_object(user):
     # This is the year that that audit period starts in
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    submission_actions = get_submission_actions(pz_code, audit_period.audit_year())
+    submission_actions = get_submission_actions(pz_code, audit_period)
     audit_period_data = get_audit_period_session_data(audit_period, user)
 
     session = {
@@ -100,9 +96,6 @@ def refresh_session_filters(request, pz_code=None, audit_year=None, csv_upload=N
 
     PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
     AuditPeriod = apps.get_model("npda", "AuditPeriod")
-
-    can_upload_csv = True
-    can_complete_questionnaire = True
 
     pz_code = pz_code or request.session.get("pz_code")
 
@@ -150,7 +143,7 @@ def refresh_session_filters(request, pz_code=None, audit_year=None, csv_upload=N
             "can_complete_questionnaire": True,
         }
     else:
-        session |= get_submission_actions(pz_code, audit_year)
+        session |= get_submission_actions(pz_code, audit_period)
     
     session |= get_audit_period_session_data(audit_period, request.user)
 

--- a/project/npda/models/patient.py
+++ b/project/npda/models/patient.py
@@ -273,27 +273,3 @@ class Patient(models.Model):
             .all()
         )
         return all_submissions
-    
-    def submission_for_current_audit_period(self):
-        """
-        Returns the audit period for the patient
-        """
-        AuditPeriod = apps.get_model(app_label="npda", model_name="AuditPeriod")
-        current_audit_period = AuditPeriod.objects.filter(
-            start_date__lte=date.today(),
-            end_date__gte=date.today()
-        ) # get the first current audit period if there is more than one
-        
-        submission = None
-        if current_audit_period.exists():
-            Submission = Submission = apps.get_model(app_label="npda", model_name="Submission")
-            submission = Submission.objects.filter(
-                audit_period=current_audit_period.first(),
-                submission_active=True,
-                patientsubmission__patient=self
-            ).first()
-        return submission
-
-
-
-

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -42,32 +42,21 @@ def get_map_chart_partial(request):
     if not request.htmx:
         return HttpResponseBadRequest("This view is only accessible via HTMX")
 
-    # Fetch data from query parameters
-    pz_code: str = request.session.get("pz_code")
-    selected_audit_year = request.session.get("selected_audit_year")
+    submission = Submission.objects.get_submission_for_request(request)
+    lead_organisation_ods_code = submission.paediatric_diabetes_unit.lead_organisation_ods_code
 
     try:
-        paediatric_diabetes_unit = PaediatricDiabetesUnitClass.objects.get(
-            pz_code=pz_code
-        )
-
-        # get lead organisation for the selected PDU
         pdu_lead_organisation = fetch_organisation_by_ods_code(
-            ods_code=paediatric_diabetes_unit.lead_organisation_ods_code
+            ods_code=lead_organisation_ods_code
         )
     except:
         raise ValueError(
-            f"Lead organisation for PDU {paediatric_diabetes_unit.lead_organisation_ods_code=} not found"
+            f"Lead organisation for PDU {lead_organisation_ods_code=} not found"
         )
 
     try:
-
-        # thes are all registered patients for the current cohort at the selected organisation to be plotted in the map
-        patients_to_plot = get_children_by_pdu_audit_year(
-            paediatric_diabetes_unit=paediatric_diabetes_unit,
-            paediatric_diabetes_unit_lead_organisation=pdu_lead_organisation,
-            audit_year=selected_audit_year,
-        )
+        # these are all registered patients for the current cohort at the selected organisation to be plotted in the map
+        patients_to_plot = get_children_by_pdu_audit_year(submission,pdu_lead_organisation)
 
         # aggregated distances (mean, median, max, min) that patients have travelled to the selected organisation
         aggregated_distances, patient_distances_dataframe = (
@@ -81,7 +70,7 @@ def get_map_chart_partial(request):
             generate_distance_from_organisation_scatterplot_figure(
                 geo_df=patient_distances_dataframe,
                 pdu_lead_organisation=pdu_lead_organisation,
-                paediatric_diabetes_unit=paediatric_diabetes_unit,
+                paediatric_diabetes_unit=submission.paediatric_diabetes_unit,
             )
         )
 

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -207,18 +207,8 @@ class PatientListView(
         submission = None
         submission_error_count = 0
 
-        # TODO MRB: this should probably be a method on the Submission model?
-        #           https://github.com/rcpch/national-paediatric-diabetes-audit/issues/533
         if pz_code and selected_audit_year:
-            submission = (
-                Submission.objects.filter(
-                    paediatric_diabetes_unit__pz_code=pz_code,
-                    paediatric_diabetes_unit__active=True,
-                    audit_year=selected_audit_year,
-                )
-                .order_by("-submission_date")
-                .first()
-            )
+            submission = Submission.objects.get_submission_for_request(self.request)
 
             if submission and submission.errors:
                 submission_errors = json.loads(submission.errors)


### PR DESCRIPTION
Closes https://github.com/rcpch/national-paediatric-diabetes-audit/issues/533

Also removes a strange call chain where `get_submission_actions` would receive an `audit_year` that came from the `AuditPeriod` helper only to use it to lookup the `AuditPeriod` again.

And remove a redundant submission lookup in `get_children_by_pdu_audit_year`