### PR TITLE
Improve Care At Diagnosis view (part 1)

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -4200,10 +4200,12 @@ class CalculateKPIS:
             self.kpi_1_total_eligible,
         )
 
-    def _get_total_kpi_2_eligible_pts_base_query_set_and_total_count(
+    def get_total_kpi_2_eligible_pts_base_query_set_and_total_count(
         self,
     ) -> Tuple[QuerySet[Patient], int]:
         """Enables reuse of the base query set for KPI 2
+
+        Also used in the Care At Diagnosis tab in the patient report.
 
         If running calculation methods in order, this attribute will be set in calculate_kpi_2_total_new_diagnoses().
 

--- a/project/npda/templates/patient_report/care_at_diagnosis_table_partial.html
+++ b/project/npda/templates/patient_report/care_at_diagnosis_table_partial.html
@@ -78,9 +78,10 @@
 {% endblock %}
 {% block table_body %}
   {% for patient in patients %}
-    <tr class="{% if not patient.is_complete_year_of_care %}bg-rcpch_orange_light_tint3{% endif %}">
+    <tr>
       <td>
-        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patient.pk is_complete_year_of_care=patient.is_complete_year_of_care patient_identifier=patient.patient_identifier %}
+        {% comment %}HACK: say the patient has completed a year of care just to suppress the tooltip{% endcomment %}
+        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patient.pk patient_identifier=patient.patient_identifier is_complete_year_of_care=True %}
       </td>
       <td>
         {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.coeliac_disease_screening %}

--- a/project/npda/templates/patient_report/care_at_diagnosis_table_partial.html
+++ b/project/npda/templates/patient_report/care_at_diagnosis_table_partial.html
@@ -1,6 +1,6 @@
 {% extends "patient_report/base_table.html" %}
 {% block description_box %}
-  {% include "patient_report/description_box.html" with description="Children and young people with Type 1 diabetes should be screened for thyroid disease and coeliac disease within 90 days of diagnosis. Newly diagnosed children and young people should also receive level 3 carbohydrate counting education within 14 days of diagnosis." proportion="diagnosed with T1DM in the audit year" extra="NOTE: this list is filtered to include only children diagnosed within the last 90 days." %}
+  {% include "patient_report/description_box.html" with description="Children and young people with Type 1 diabetes should be screened for thyroid disease and coeliac disease within 90 days of diagnosis. Newly diagnosed children and young people should also receive level 3 carbohydrate counting education within 14 days of diagnosis." proportion="diagnosed with T1DM in the audit year" %}
 {% endblock %}
 {% block table_headers %}
   <th class="whitespace-normal break-words">

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -493,14 +493,6 @@ class PatientReportView(
             )
         elif self.selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
             today = date.today()
-            all_t1dm_pts = all_t1dm_pts.filter(
-                Q(diagnosis_date__gte=today - relativedelta(days=90))
-            )
-            all_t1dm_pts_with_complete_year_of_care = (
-                all_t1dm_pts_with_complete_year_of_care.filter(
-                    Q(diagnosis_date__gte=today - relativedelta(days=90))
-                )
-            )
 
             pt_qs = (
                 pt_qs.filter(Q(diagnosis_date__gte=today - relativedelta(days=90)))

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -492,53 +492,51 @@ class PatientReportView(
                 "sick_day_rules_advice",
             )
         elif self.selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
-            pt_qs = (
-                pt_qs.annotate(
-                    coeliac_disease_screening=Case(
-                        When(
-                            Exists(
-                                calculate_kpis.calculate_kpi_41_coeliac_disease_screening()
-                                .patient_querysets["passed"]
-                                .filter(pk=OuterRef("pk"))
-                            ),
-                            then=True,
+            (pt_qs, _) = calculate_kpis.get_total_kpi_2_eligible_pts_base_query_set_and_total_count()
+            pt_qs = pt_qs.annotate(
+                patient_identifier=F(patient_identifier),
+                coeliac_disease_screening=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_41_coeliac_disease_screening()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
                         ),
-                        default=False,
-                        output_field=BooleanField(),
+                        then=True,
                     ),
-                    thyroid_disease_screening=Case(
-                        When(
-                            Exists(
-                                calculate_kpis.calculate_kpi_42_thyroid_disease_screening()
-                                .patient_querysets["passed"]
-                                .filter(pk=OuterRef("pk"))
-                            ),
-                            then=True,
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+                thyroid_disease_screening=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_42_thyroid_disease_screening()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
                         ),
-                        default=False,
-                        output_field=BooleanField(),
+                        then=True,
                     ),
-                    carbohydrate_counting_education=Case(
-                        When(
-                            Exists(
-                                calculate_kpis.calculate_kpi_43_carbohydrate_counting_education()
-                                .patient_querysets["passed"]
-                                .filter(pk=OuterRef("pk"))
-                            ),
-                            then=True,
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+                carbohydrate_counting_education=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_43_carbohydrate_counting_education()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
                         ),
-                        default=False,
-                        output_field=BooleanField(),
+                        then=True,
                     ),
-                )
-                .values(
-                    "pk",
-                    "patient_identifier",
-                    "is_complete_year_of_care",
-                    "coeliac_disease_screening",
-                    "thyroid_disease_screening",
-                    "carbohydrate_counting_education",
-                )
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+            ).values(
+                "pk",
+                "patient_identifier",
+                "coeliac_disease_screening",
+                "thyroid_disease_screening",
+                "carbohydrate_counting_education",
             )
         elif self.selected_category == TableCategories.ADMISSIONS.value:
             pt_qs = (
@@ -889,7 +887,12 @@ class PatientReportView(
                 pt_qs = self._calculate_hba1c_values(pt_qs, calculate_kpis)
         else:
             # Default ordering
-            pt_qs = pt_qs.order_by("-is_complete_year_of_care", "nhs_number")
+            order_by = ["-is_complete_year_of_care", patient_identifier]
+
+            if self.selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
+                order_by = [patient_identifier]
+
+            pt_qs = pt_qs.order_by(*order_by)
             pt_qs = self._calculate_hba1c_values(pt_qs, calculate_kpis)
 
         return pt_qs

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -492,11 +492,8 @@ class PatientReportView(
                 "sick_day_rules_advice",
             )
         elif self.selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
-            today = date.today()
-
             pt_qs = (
-                pt_qs.filter(Q(diagnosis_date__gte=today - relativedelta(days=90)))
-                .annotate(
+                pt_qs.annotate(
                     coeliac_disease_screening=Case(
                         When(
                             Exists(


### PR DESCRIPTION
Part of #1065 

Changes the care at diagnosis view to include all patients diagnosed in the audit year, not just those in the last 90 days. This avoids confusion when users can't find their patients after the 90 day timer to complete the measure expires.