### PR TITLE
Fix map partial crash if no submission

### DIFF
--- a/project/npda/templates/dashboard/map_chart_partial.html
+++ b/project/npda/templates/dashboard/map_chart_partial.html
@@ -2,6 +2,10 @@
   <div class="alert alert-danger">
     <i class="fa-solid fa-person-circle-exclamation"></i> {{ error }}
   </div>
+{% elif info %}
+  <div class="alert alert-info">
+    <i class="fa-solid fa-person-circle-exclamation"></i> {{ info }}
+  </div>
 {% elif chart_html %}
   <div id='chart_html'>{{ chart_html|safe }}</div>
   {% if aggregated_distances.max_distance_travelled_km %}

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -43,6 +43,14 @@ def get_map_chart_partial(request):
         return HttpResponseBadRequest("This view is only accessible via HTMX")
 
     submission = Submission.objects.get_submission_for_request(request)
+
+    if not submission:
+        return render(
+            request,
+            "dashboard/map_chart_partial.html",
+            {"info": "No patient data yet"},
+        )
+
     lead_organisation_ods_code = submission.paediatric_diabetes_unit.lead_organisation_ods_code
 
     try:


### PR DESCRIPTION
Map partial crashes if you haven't submitted data yet. Noticed this error from GOSH in our telemetry.