### PR TITLE
Fix username in request logging

### DIFF
--- a/project/npda/logging.py
+++ b/project/npda/logging.py
@@ -66,11 +66,7 @@ class NPDARequestLoggingMiddleware:
             # %({x-forwarded-for}i)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"
             gunicorn_formatted_datetime = datetime.now().astimezone().strftime("%d/%m/%y:%H:%M:%S %z")
 
-            user = get_current_user()
-            
-            username_to_log = user if user else "-"
-            if user and hasattr(user, "email"):
-                username_to_log = user.email
+            username_to_log = "-" if request.user.is_anonymous else request.user.email
 
             request_logger.info(f"{request.META.get('HTTP_X_FORWARDED_FOR', '')} - {username_to_log} [{gunicorn_formatted_datetime}] \"{request.method} {request.get_full_path()}\" {response.status_code} {response.get('Content-Length', "-")} \"{request.META.get('HTTP_REFERER', '-')}\" \"{request.META.get('HTTP_USER_AGENT', '-')}\" audit_year=\"{request.session.get('selected_audit_year', '-')}\" pz_code=\"{request.session.get('pz_code', '-')}\"")
 


### PR DESCRIPTION
Follow on from #1090. The current user variable was unset by the time we got to the logging middleware after splitting it in two to get `Content-Length`. Instead get it from `request.user`.