### PR TITLE
Add login_and_otp_required to view_preference route

### DIFF
--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -45,6 +45,7 @@ def download_template(request):
     )
 
 
+@login_and_otp_required()
 def view_preference(request):
     """
     HTMX callback from the button press in the view_preference.html template.


### PR DESCRIPTION
It was missing it and should only be used by logged in users. Anonymous users couldn't use it anyway as they have no entry in the database but still better to cover it with the same permissions checks as everything else