### PR TITLE
Separate setting for change notifications

### DIFF
--- a/envs/example.env
+++ b/envs/example.env
@@ -61,3 +61,6 @@ REDIS_DATABASE_NUMBER=0
 AUTO_LOGOUT_IDLE_TIME_SECONDS=86400 # 1 day
 
 ENABLE_REQUEST_LOGGING="True"
+
+# List of email addresses to receive notifications on changes like creating new users and assigning them to PDUs
+CHANGE_NOTIFICATION_EMAILS=[]

--- a/project/npda/signals.py
+++ b/project/npda/signals.py
@@ -415,12 +415,13 @@ def _send_admin_notification(user, changes, current_user):
     """
     # send to admins
     try:
-        send_email_to_recipients(
-            recipients=settings.ADMIN_EMAIL_LIST,
-            subject=subject,
-            message=message
-        )
-        logger.info(f"Admin notification sent for user changes: {user.email}")
+        if settings.CHANGE_NOTIFICATION_EMAILS:
+            send_email_to_recipients(
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message
+            )
+            logger.info(f"Admin notification sent for user changes: {user.email}")
     except Exception as e:
         logger.error(f"Failed to send admin notification for user {user.email}: {e}")
 
@@ -439,12 +440,13 @@ def _send_user_creation_notification(user, current_user):
     
     # Send to audit team members  
     try:
-        send_email_to_recipients(
-            recipients=settings.ADMIN_EMAIL_LIST,
-            subject=subject,
-            message=message
-        )
-        logger.info(f"User creation notification sent for: {user.email}")
+        if settings.CHANGE_NOTIFICATION_EMAILS:
+            send_email_to_recipients(
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message
+            )
+            logger.info(f"User creation notification sent for: {user.email}")
     except Exception as e:
         logger.error(f"Failed to send user creation notification for {user.email}: {e}")
 
@@ -514,12 +516,13 @@ def _send_pdu_assignment_notification(organisation_employer_instance, current_us
     """
     # Send to audit team members
     try:
-        send_email_to_recipients(
-            recipients=settings.ADMIN_EMAIL_LIST,
-            subject=subject,
-            message=message
-        )
-        logger.info(f"PDU assignment notification sent for user {user.email}")
+        if settings.CHANGE_NOTIFICATION_EMAILS:
+            send_email_to_recipients(
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message
+            )
+            logger.info(f"PDU assignment notification sent for user {user.email}")
     except Exception as e:
         logger.error(f"Failed to send PDU assignment notification for user {user.email}: {e}")
 
@@ -554,11 +557,12 @@ def _send_user_deletion_notification(user_instance, current_user):
     
     # Send to audit team members
     try:
-        send_email_to_recipients(
-            recipients=settings.ADMIN_EMAIL_LIST,
-            subject=subject,
-            message=message
-        )
-        logger.info(f"User deletion notification sent for: {deletion_data.get('email', 'Unknown')}")
+        if CHANGE_NOTIFICATION_EMAILS:
+            send_email_to_recipients(
+                recipients=settings.CHANGE_NOTIFICATION_EMAILS,
+                subject=subject,
+                message=message
+            )
+            logger.info(f"User deletion notification sent for: {deletion_data.get('email', 'Unknown')}")
     except Exception as e:
         logger.error(f"Failed to send user deletion notification: {e}")

--- a/project/settings.py
+++ b/project/settings.py
@@ -298,15 +298,8 @@ PASSWORD_RESET_TIMEOUT = os.environ.get(
 SITE_CONTACT_EMAIL = os.environ.get("SITE_CONTACT_EMAIL")
 
 ADMINS = os.environ.get("ADMINS", '')
-# NOTE THAT IN DEVELOPMENT THIS LIST WILL BE EMPTY SO EMAILS WILL NOT BE SENT
-# This is a list of admin emails that will receive notifications for changes to the NPDAUser model
-ADMIN_EMAIL_LIST = [SITE_CONTACT_EMAIL]
-if ADMINS:
-    # If ADMINS is set, split it by commas and take the first part after the colon
-    ADMIN_EMAIL_LIST += [e.split(":")[1] for e in ADMINS.split(",") if e]
-if len(ADMIN_EMAIL_LIST) == 0:
-    logger.warning("No admin emails configured. Please set SITE_CONTACT_EMAIL or ADMINS in settings.py.")
-    ADMIN_EMAIL_LIST = ["admin@rcpch.dummy"]  # Fallback for development
+
+CHANGE_NOTIFICATION_EMAILS = os.getenv("CHANGE_NOTIFICATION_EMAILS", "").split(",")
 
 # Set the ADMINS variable to a list of tuples (name, email)
 if ADMINS:


### PR DESCRIPTION
Sync behaviour with E12 https://github.com/rcpch/rcpch-audit-engine/pull/1259

Use separate setting for user notification emails rather than relying implicitly on `ADMINS` and `SITE_CONTACT_EMAIL`