### PR TITLE
Correctly report on children who turn 12 within the audit year

### DIFF
--- a/project/npda/tests/view_tests/dashboard/test_patient_measurements.py
+++ b/project/npda/tests/view_tests/dashboard/test_patient_measurements.py
@@ -76,5 +76,5 @@ def test_measurements_for_patients_turning_12_in_audit_year(
     assert response.status_code == HTTPStatus.OK
 
     assert response.context["total_eligible_blood_pressure"] == 0
-    assert response.context["total_eligble_urinary_albumin"] == 0
+    assert response.context["total_eligible_urinary_albumin"] == 0
     assert response.context["total_eligible_foot_exam"] == 0

--- a/project/npda/tests/view_tests/dashboard/test_patient_measurements.py
+++ b/project/npda/tests/view_tests/dashboard/test_patient_measurements.py
@@ -1,0 +1,80 @@
+"""Tests for the patient report view"""
+
+from decimal import Decimal
+from http import HTTPStatus
+
+# Python imports
+import pytest
+
+# 3rd party imports
+from django.urls import reverse
+
+# E12 imports
+from project.npda.models import NPDAUser
+from project.npda.models.audit_period import AuditPeriod
+from project.npda.models.patient import Patient
+from project.npda.models.submission import Submission
+from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
+from project.npda.tests.factories import (
+    test_user_audit_centre_editor_data
+)
+from project.npda.tests.utils import login_and_verify_user
+from project.npda.tests.factories.patient_factory import PatientFactory
+from project.npda.tests.factories.visit_factory import VisitFactory
+from project.constants.diabetes_types import DIABETES_TYPES
+from project.constants.hba1c_format import HBA1C_FORMATS
+from project.npda.views.patient_report.patient_report import TableCategories
+from dateutil.relativedelta import relativedelta
+
+
+@pytest.mark.django_db
+def test_measurements_for_patients_turning_12_in_audit_year(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=11, days=2)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2), # complete year of care
+    )
+
+    # Need a visit in the audit period to be eligible
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        hba1c=60,  # 60 mmol/mol
+        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_date=audit_period.start_date + relativedelta(days=10),
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    response = client.get(reverse("patient_measurements"))
+    assert response.status_code == HTTPStatus.OK
+
+    assert response.context["total_eligible_blood_pressure"] == 0
+    assert response.context["total_eligble_urinary_albumin"] == 0
+    assert response.context["total_eligible_foot_exam"] == 0

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -412,3 +412,7 @@ def test_health_checks_for_patients_turning_12_in_audit_year(
     assert patient["passed_blood_pressure"] is None
     assert patient["passed_urinary_albumin"] is None
     assert patient["passed_foot_exam"] is None
+
+    assert response.context["total_eligible_blood_pressure"] == 0
+    assert response.context["total_eligible_urinary_albumin"] == 0
+    assert response.context["total_eligible_foot_exam"] == 0

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -354,7 +354,7 @@ def test_outcomes_multiple_hba1c_measurements(
 
 
 @pytest.mark.django_db
-def test_health_checks_for_patients_turning_12_in_audit_year(
+def test_report_for_patients_turning_12_in_audit_year(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
@@ -416,3 +416,17 @@ def test_health_checks_for_patients_turning_12_in_audit_year(
     assert response.context["total_eligible_blood_pressure"] == 0
     assert response.context["total_eligible_urinary_albumin"] == 0
     assert response.context["total_eligible_foot_exam"] == 0
+
+    response = client.get(
+        reverse("patient_report") + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["smoking_status"] is None
+    assert patient["smoking_cessation_referral"] is None

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -24,7 +24,10 @@ from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.patient import Patient
 from project.npda.models.submission import Submission
 from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
-from project.npda.tests.factories import test_user_rcpch_audit_team_data
+from project.npda.tests.factories import (
+    test_user_rcpch_audit_team_data,
+    test_user_audit_centre_editor_data
+)
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.urls import patient_report_urlpatterns
 from project.npda.tests.factories.patient_factory import PatientFactory
@@ -348,3 +351,64 @@ def test_outcomes_multiple_hba1c_measurements(
         "previous_to_latest_hba1c_date"
     ] == AUDIT_START_DATE + relativedelta(days=10)
     assert patient_data["days_delta_between_latest_and_previous_hba1c"] == 10
+
+
+@pytest.mark.django_db
+def test_health_checks_for_patients_turning_12_in_audit_year(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=11, days=2)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2), # complete year of care
+    )
+
+    # Need a visit in the audit period to be eligible
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        hba1c=60,  # 60 mmol/mol
+        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_date=audit_period.start_date + relativedelta(days=10),
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    response = client.get(
+        reverse("patient_report") + f"?category={TableCategories.HEALTH_CHECKS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["passed_blood_pressure"] is None
+    assert patient["passed_urinary_albumin"] is None
+    assert patient["passed_foot_exam"] is None

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -146,14 +146,6 @@ def dashboard(request):
         "aggregation_level": "pdu",
     }
 
-    # Gather totals for the patient health check KPIs
-    # patient_health_check_totals_to_return = patient_health_check_totals(
-    #     calculate_kpis=calculate_kpis,
-    #     pz_code=pz_code,
-    #     calculation_date=calculation_date,
-    # )
-    # context.update(patient_health_check_totals_to_return)
-
     return render(request, template_name=template, context=context)
 
 

--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -78,6 +78,7 @@ def patient_measurements(request):
     returned_patient_health_check_totals = patient_health_check_totals(
         pz_code=pz_code,
         calculation_date=calculation_date,
+        audit_start_date=audit_period.start_date
     )
 
     context={
@@ -98,7 +99,7 @@ def patient_measurements(request):
         template_name=template
     )
 
-def patient_health_check_totals(pz_code, calculation_date):
+def patient_health_check_totals(pz_code, calculation_date, audit_start_date):
     """
     Returns the totals for the patient health check KPIs.
     Note this repeats some of the logic in the patient_report. Probably should be refactored into a common function.
@@ -156,7 +157,7 @@ def patient_health_check_totals(pz_code, calculation_date):
     
     # For age-specific checks (12+ years old)
     complete_year_12plus = complete_year_patients.filter(
-        date_of_birth__lte=calculation_date - relativedelta(years=12)
+        date_of_birth__lte=audit_start_date - relativedelta(years=12)
     )
     
     total_passed_blood_pressure = calculate_kpis.calculate_kpi_28_blood_pressure().patient_querysets["passed"].filter(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -395,7 +395,7 @@ class PatientReportView(
                     output_field=BooleanField(),
                 ),
                 is_gte_12yo=Q(
-                    date_of_birth__lte=calculation_date - relativedelta(years=12)
+                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
                 ),
                 smoking_status=Case(
                     When(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -148,9 +148,8 @@ class PatientReportView(
             raise ValueError(f"Invalid category: {category}")
         self.selected_category = category
         pz_code = request.session.get("pz_code")
-        calculation_date = AuditPeriod.objects.get_audit_period_for_request(
-            self.request
-        ).kpi_calculation_date()
+        audit_period = AuditPeriod.objects.get_audit_period_for_request(request)
+        calculation_date = audit_period.kpi_calculation_date()
         calculate_kpis = CalculateKPIS(
             calculation_date=calculation_date, return_pt_querysets=True, is_jersey=pz_code == "PZ248"
         )
@@ -202,9 +201,9 @@ class PatientReportView(
             ).count()
             self.total_eligible_thyroid_screen = complete_year_patients.count()
             
-            # For age-specific checks (12+ years old)
+            # For age-specific checks (12+ years old at start of audit period)
             complete_year_12plus = complete_year_patients.filter(
-                date_of_birth__lte=calculation_date - relativedelta(years=12)
+                date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
             )
             
             self.total_passed_blood_pressure = calculate_kpis.calculate_kpi_28_blood_pressure().patient_querysets["passed"].filter(
@@ -223,7 +222,7 @@ class PatientReportView(
             self.total_eligible_foot_exam = complete_year_12plus.count()
             pt_qs = pt_qs.annotate(
                 is_gte_12yo=Q(
-                    date_of_birth__lte=calculation_date - relativedelta(years=12)
+                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
                 ),
                 passed_hba1c=Case(
                     When(


### PR DESCRIPTION
Fixes #1148 

Previously children who turned 12 between the start of the current audit year and now (i.e. not 12 at the start of the audit year) were marked as failing some measures even though they are not eligible for them:

- Blood pressure (28)
- Urinary albumin (29)
- Foot exam (31)
- Smoking screening (35)
- Smoking referral (36)

Whilst the code in `CalculateKPIs` was correct the code that then generated the patient report and patient measurement panel were incorrectly checking if the child was 12 years old *today*. This mismatch lead to us marking them as incomplete.

After this PR they are correctly marked as ineligible.