### PR TITLE
Put back PDU selector for audit team users creating new users

### DIFF
--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -17,7 +17,7 @@
               <div class="text-left md:w-2/3" id="primary_pdu">
                 {% include 'partials/employers.html' with organisation_employers=organisation_employers employer_choices=form.employer_choices %}
               </div>
-            {% else %}
+            {% elif form.employer_choices|length > 1 %}
               <strong class="font-montserrat font-bold md:w-1/3 text-right pr-2 mt-5">Employer(s)</strong>
               <div class="text-left md:w-2/3 mb-2" id="primary_pdu">
                 {% include 'partials/rcpch_organisation_select.html' with employer_choices=form.employer_choices selected_organisation=selected_pdu %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -20,7 +20,7 @@
             {% else %}
               <strong class="font-montserrat font-bold md:w-1/3 text-right pr-2 mt-5">Employer(s)</strong>
               <div class="text-left md:w-2/3 mb-2" id="primary_pdu">
-                {% include 'partials/rcpch_organisation_select.html' with employer_choices=form.employer_choices selected_organisation=selected_pdu editable=False %}
+                {% include 'partials/rcpch_organisation_select.html' with employer_choices=form.employer_choices selected_organisation=selected_pdu %}
               </div>
             {% endif %}
           {% endif %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -126,7 +126,7 @@
           <button value="Submit"
                   name="resend_email"
                   class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 px-3 mt-20 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_npdauser %}disabled{% endif %}">
-            Resend Confirmation Email {{ npda_user|multiple_pdu_memberships }}
+            Resend Confirmation Email
           </button>
         {% endif %}
         <button name="deactivate"

--- a/project/npda/templates/partials/employers.html
+++ b/project/npda/templates/partials/employers.html
@@ -59,7 +59,7 @@
     {% endif %}
   </div>
   <div class="flex flex-row">
-    {% include 'partials/rcpch_organisation_select.html' with employer_choices=employer_choices selected_organisation=selected_pdu %}
+    {% include 'partials/rcpch_organisation_select.html' with employer_choices=employer_choices selected_organisation=selected_pdu hidden=True %}
     <button hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
             id="add_submit_button"
             class="btn bg-rcpch_light_blue text-white font-semibold hover:text-white py-2 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue mb-2 text-xs hidden"

--- a/project/npda/templates/partials/rcpch_organisation_select.html
+++ b/project/npda/templates/partials/rcpch_organisation_select.html
@@ -1,6 +1,6 @@
 <select id="add_employer_select"
         name="add_employer"
-        class="select rcpch-select rounded-none hidden">
+        class="select rcpch-select rounded-none {% if hidden %} hidden {% endif %}">
   {% for choice in employer_choices %}
     <option value="{{ choice.0 }}"
             {% if selected_organisation == choice.0 %}selected="{{ choice.0 }}"{% endif %}>

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -455,13 +455,6 @@ def exclude_admin_user_field(field, user):
     return True
 
 @register.filter
-def multiple_pdu_memberships(user):
-    """
-    Returns true if the user has multiple PDU memberships
-    """
-    return user.number_of_pdu_memberships() > 1
-
-@register.filter
 def include_admin_users(user):
     """
     Returns true if the user is an RCPCH staff member or superuser


### PR DESCRIPTION
Fixes #1153.

Follow up to #1151. RCPCH audit team users should be able to select the PDU for a user at creation time.

Also removed an unused tag that was adding "False" to the "Resend Confirmation Email" button.