### PR TITLE
Coordinators can only change email or role for users in exactly the same PDUs as themselves

### DIFF
--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -75,6 +75,7 @@ class NPDAUserForm(forms.ModelForm):
         # get the request object from the kwargs
         self.request = kwargs.pop("request", None)
         employer_choices = kwargs.pop("employer_choices", [])
+        restricted_fields = kwargs.pop("restricted_fields", [])
         super().__init__(*args, **kwargs)
         self.fields["title"].required = False
         self.fields["first_name"].required = True
@@ -87,6 +88,10 @@ class NPDAUserForm(forms.ModelForm):
         self.fields["add_employer"].required = False
         self.fields["add_employer"].choices = employer_choices
         self.employer_choices = employer_choices
+
+        for field in restricted_fields:
+            # Deliberately using readonly rather than disabled as permission checks are done in the view
+            self.fields[field].widget.attrs['readonly'] = True
 
         # only if the form is bound - this user is being updated
         if self.instance.pk is not None:

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -147,7 +147,7 @@
       <div class="alert alert-info mb-5">
         <i class="fa-solid fa-info-circle"></i>
         <strong>Note:</strong>
-        <span>Users cannot be deleted from NPDA. If a user is nolonger part of the audit team, their account can be deactivated. This allows NPDA to maintain an accurate audit trail.</span>
+        <span>Users cannot be deleted from NPDA. If a user is no longer part of the audit team, deactivate their account. This allows NPDA to maintain an accurate audit trail.</span>
       </div>
     </form>
     {% comment %} modal dialog - are you sure? {% endcomment %}

--- a/project/npda/templates/npda/npdauser_form.html
+++ b/project/npda/templates/npda/npdauser_form.html
@@ -45,7 +45,8 @@
                 <select id="{{ field.id_for_label }}"
                         name="{{ field.html_name }}"
                         class="select rcpch-select rounded-none {% if field.id_for_label == 'id_add_employer' %}hidden{% endif %}"
-                        {% if not perms.npda.change_npdauser %}disabled{% endif %}>
+                        {% if not perms.npda.change_npdauser %}disabled{% endif %}
+                        {% if field.field.widget.attrs.readonly %}disabled{% endif %}>
                   {% for choice in field.field.choices %}
                     {% if not show_rcpch_team and choice.1 == "RCPCH Audit Team" %}
                       <!-- Do nothing, hide Audit Team option if not already in audit team-->

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -49,6 +49,7 @@ from project.npda.tests.UserDataClasses import (
     test_user_rcpch_audit_team_data,
 )
 from project.npda.tests.utils import login_and_verify_user
+from project.constants import VIEW_PREFERENCES
 
 logger = logging.getLogger(__name__)
 
@@ -1625,3 +1626,115 @@ def test_user_update_has_a_timestamp_and_user(
         activity=12,  # User role change
         npdauser_admin=test_user,  # The user who made the change
     ).exists(), "VisitActivity should have been created with new user role change"
+
+@pytest.mark.django_db
+def test_coordinator_cannot_change_email_for_user_with_multiple_pdus(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    # Create a test coordinator in PZ999
+    malicious_coordinator = NPDAUserFactory(
+        first_name="Malicious",
+        surname="Coordinator",
+        role=AUDIT_CENTRE_COORDINATOR,
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+        groups=[test_user_audit_centre_coordinator_data.group_name],
+        view_preference=VIEW_PREFERENCES[1][0],
+        organisation_employers=["PZ999"],
+    )
+
+    # Create a test reader in PZ999
+    victim_reader = NPDAUserFactory(
+        first_name="Victim",
+        surname="Reader",
+        role=AUDIT_CENTRE_READER,
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+        groups=[test_user_audit_centre_reader_data.group_name],
+        view_preference=VIEW_PREFERENCES[1][0],
+        organisation_employers=["PZ999", "PZ001"],
+    )
+
+    # Login coordinator
+    client = login_and_verify_user(client, malicious_coordinator)
+
+    email_before = victim_reader.email
+
+    url = reverse("npdauser-update", kwargs={"pk": victim_reader.pk})
+    client.post(
+        url,
+        {
+            "email": "malicious@actor.com",
+            # Other required fields
+            "role": victim_reader.role,
+            "surname": victim_reader.surname,
+            "first_name": victim_reader.first_name,
+        },
+    )
+
+    victim_reader.refresh_from_db()
+
+    assert victim_reader.email == email_before, (
+        f"Malicious coordinator should not be able to change email of user in multiple PDUs.")
+
+@pytest.mark.django_db
+def test_coordinator_cannot_change_role_for_user_with_multiple_pdus(
+    client: Client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    # Create a test coordinator in PZ999
+    malicious_coordinator = NPDAUserFactory(
+        first_name="Malicious Coordinator",
+        role=AUDIT_CENTRE_COORDINATOR,
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+        groups=[test_user_audit_centre_coordinator_data.group_name],
+        view_preference=VIEW_PREFERENCES[1][0],
+        organisation_employers=["PZ999"],
+    )
+
+    # Create a test reader in PZ999
+    victim_reader = NPDAUserFactory(
+        first_name="Victim Reader",
+        role=AUDIT_CENTRE_READER,
+        is_active=True,
+        is_staff=False,
+        is_rcpch_audit_team_member=False,
+        is_rcpch_staff=False,
+        groups=[test_user_audit_centre_reader_data.group_name],
+        view_preference=VIEW_PREFERENCES[1][0],
+        organisation_employers=["PZ999", "PZ001"],
+    )
+
+    # Login coordinator
+    client = login_and_verify_user(client, malicious_coordinator)
+
+    email_before = victim_reader.email
+
+    url = reverse("npdauser-update", kwargs={"pk": victim_reader.pk})
+    client.post(
+        url,
+        {
+            "role": AUDIT_CENTRE_COORDINATOR,
+            # Other required fields
+            "email": victim_reader.email,
+            "surname": victim_reader.surname,
+            "first_name": victim_reader.first_name,
+        },
+    )
+
+    victim_reader.refresh_from_db()
+
+    assert victim_reader.role == AUDIT_CENTRE_READER, (
+        f"Malicious coordinator should not be able to change role of user in multiple PDUs.")

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -322,6 +322,21 @@ class NPDAUserUpdateView(
                 "You do not have permission to set the is_rcpch_staff flag."
             )
         
+        my_pz_codes = set(self.request.user.organisation_employers.values_list("pz_code", flat=True))
+        their_pz_codes = set(self.get_object().organisation_employers.values_list("pz_code", flat=True))
+        restricted_fields = [field for field in ["role", "email"] if field in form.changed_data]
+
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1159
+        # A coordinator can only change the role or email of a user if they share exactly the same PDU assignments
+        # This prevents a coordinator accessing other PDUs by changing the email to one they control and doing a password reset
+        if my_pz_codes != their_pz_codes and restricted_fields and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+            # if the user is changing their role or email, they must be in the same PDU as the logged in user
+            logger.warning(f"User {self.request.user.email} [{my_pz_codes}] tried to change {", ".join(restricted_fields)} of user {self.get_object().email} [{their_pz_codes}] but they do not have exactly the same PDU assignments")
+
+            raise PermissionDenied(
+                "You do not have permission to edit this user. Contact the NPDA for assistance."
+            )
+        
         user = form.save(commit=False)
         user.save() # save the user first to ensure the user instance is updated and the updated_by and updated_at fields are set
         form.save_m2m()  # save the m2m fields (groups, employers, etc.)

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -256,6 +256,18 @@ class NPDAUserUpdateView(
     success_message = "NPDA User record updated successfully"
     success_url = reverse_lazy("npda_users")
 
+    def get_restricted_fields(self):
+        my_pz_codes = set(self.request.user.organisation_employers.values_list("pz_code", flat=True))
+        their_pz_codes = set(self.get_object().organisation_employers.values_list("pz_code", flat=True))
+
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1159
+        # A coordinator can only change the role or email of a user if they share exactly the same PDU assignments
+        # This prevents a coordinator accessing other PDUs by changing the email to one they control and doing a password reset
+        if my_pz_codes == their_pz_codes or self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member:
+            return []
+        
+        return ["role", "email"]
+
     def get_form_kwargs(self):
         # add the request object to the form kwargs
         kwargs = super().get_form_kwargs()
@@ -267,6 +279,7 @@ class NPDAUserUpdateView(
                 user_instance=self.get_object(),
             )
         )
+        kwargs["restricted_fields"] = self.get_restricted_fields()
         
         return kwargs
 
@@ -322,16 +335,14 @@ class NPDAUserUpdateView(
                 "You do not have permission to set the is_rcpch_staff flag."
             )
         
-        my_pz_codes = set(self.request.user.organisation_employers.values_list("pz_code", flat=True))
-        their_pz_codes = set(self.get_object().organisation_employers.values_list("pz_code", flat=True))
-        restricted_fields = [field for field in ["role", "email"] if field in form.changed_data]
+        changed_restricted_fields = [field for field in self.get_restricted_fields() if field in form.changed_data]
 
         # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1159
         # A coordinator can only change the role or email of a user if they share exactly the same PDU assignments
         # This prevents a coordinator accessing other PDUs by changing the email to one they control and doing a password reset
-        if my_pz_codes != their_pz_codes and restricted_fields and not (self.request.user.is_superuser or self.request.user.is_rcpch_audit_team_member):
+        if len(changed_restricted_fields) > 0:
             # if the user is changing their role or email, they must be in the same PDU as the logged in user
-            logger.warning(f"User {self.request.user.email} [{my_pz_codes}] tried to change {", ".join(restricted_fields)} of user {self.get_object().email} [{their_pz_codes}] but they do not have exactly the same PDU assignments")
+            logger.warning(f"User {self.request.user.email} tried to change {", ".join(changed_restricted_fields)} of user {self.get_object().email} but they do not have exactly the same PDU assignments")
 
             raise PermissionDenied(
                 "You do not have permission to edit this user. Contact the NPDA for assistance."


### PR DESCRIPTION
Fixes https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1159