### PR TITLE
Remove special case for national view in patient create

### DIFF
--- a/project/npda/tests/permissions_tests/test_mixins_against_session.py
+++ b/project/npda/tests/permissions_tests/test_mixins_against_session.py
@@ -24,9 +24,9 @@ from project.npda.tests.factories.paediatrics_diabetes_unit_factory import (
 from project.constants.user import RCPCH_AUDIT_TEAM
 from project.npda.forms.patient_form import PatientForm
 from project.npda.forms.visit_form import VisitForm
-from project.npda.models import NPDAUser, Visit, Patient, Transfer, AuditPeriod
+from project.npda.models import NPDAUser, Patient, Transfer, AuditPeriod
 from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
-from project.npda.tests.utils import login_and_verify_user
+from project.npda.tests.utils import login_and_verify_user, create_submission
 from project.npda.tests.UserDataClasses import test_user_audit_centre_editor_data
 from project.npda.general_functions import audit_period
 from project.npda.tests.factories.visit_factory import VisitFactory, COMPLETED_VISIT
@@ -233,8 +233,13 @@ class TestQuestionnaireView:
         """
         Test that users who do have questionnaire permission can save a visit through the questionnaire view.
         """
-        # Create a patient
         patient = PatientFactory()
+
+        sub = create_submission(
+            audit_start_date=date.today(),
+            pz_code=ALDER_HEY_PZ_CODE,
+        )
+        patient.submissions.add(sub)
 
         form = VisitForm(data=COMPLETED_VISIT, initial={"patient": patient})
 

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -111,57 +111,9 @@ class VisitCreateView(
         context["button_title"] = "Create New Visit"
         context["visit_tabs"] = get_visit_tabs(form=None)
         context["override_height_weight"] = False
-        # Getting the PDU for the patient most of the time will be the same as the selected PDU in session.
-        # However, if the user has selected a different PDU in the session but has come here from a national view
-        # then we can't use that.
-        if self.request.user.view_preference == 2:
-            # we potentially have a choice here if the patient is in multiple PDUs
-            PatientSubmission = apps.get_model("npda", "PatientSubmission")
-            if (
-                PatientSubmission.objects.filter(
-                    patient=patient,
-                    submission__audit_year=self.request.session.get(
-                        "selected_audit_year"
-                    ),
-                    submission__submission_active=True,
-                ).count()
-                > 1
-            ):
-                # this patient has more than one active submission
-                # if the user has selected a PDU in the session, we can use that
-                if PatientSubmission.objects.filter(
-                    patient=patient,
-                    submission__audit_year=self.request.session.get(
-                        "selected_audit_year"
-                    ),
-                    submission__submission_active=True,
-                    submission__paediatric_diabetes_unit=PaediatricDiabetesUnit.objects.get(
-                        pz_code=self.request.session.get("pz_code")
-                    ),
-                ).exists():
-                    context["paediatric_diabetes_unit"] = (
-                        PaediatricDiabetesUnit.objects.get(
-                            pz_code=self.request.session.get("pz_code")
-                        )
-                    )
-                else:
-                    # if we can't use the PDU in the session, we shall have to use the first one
-                    context["paediatric_diabetes_unit"] = (
-                        PatientSubmission.objects.filter(
-                            patient=patient,
-                            submission__audit_year=self.request.session.get(
-                                "selected_audit_year"
-                            ),
-                            submission__submission_active=True,
-                        )
-                        .first()
-                        .submission.paediatric_diabetes_unit
-                    )
-        else:
-            PaediatricDiabetesUnit = apps.get_model("npda", "PaediatricDiabetesUnit")
-            context["paediatric_diabetes_unit"] = PaediatricDiabetesUnit.objects.get(
-                pz_code=self.request.session.get("pz_code")
-            )
+
+        context["paediatric_diabetes_unit"] = patient.submissions.first().paediatric_diabetes_unit
+
         return context
 
     def get_success_url(self):


### PR DESCRIPTION
As patients are not generally in multiple submissions we don't need this special case any more.

Part of removing some more references to `selected_audit_year` (#947)