### PR TITLE
add to all the create_groups new and existing

### DIFF
--- a/project/npda/management/commands/create_groups.py
+++ b/project/npda/management/commands/create_groups.py
@@ -216,7 +216,6 @@ def groups_seeder(
             newGroup = Group.objects.filter(name=group).get()
 
             # NPDA_AUDIT_TEAM_FULL_ACCESS = RCPCH AUDIT TEAM
-            # NPDA_AUDIT_TEAM_FULL_ACCESS = RCPCH AUDIT TEAM
             if group == NPDA_AUDIT_TEAM_FULL_ACCESS:
                 # basic permissions
                 add_permissions_to_group(RCPCH_AUDIT_TEAM_PERMISSIONS, newGroup)
@@ -305,6 +304,7 @@ def groups_seeder(
                 elif group == TRUST_AUDIT_TEAM_COORDINATOR_ACCESS:
                     # basic permissions
                     add_permissions_to_group(COORDINATOR_PERMISSIONS, newGroup)
+                    add_permissions_to_group(COORDINATOR_CUSTOM_PERMISSIONS, newGroup)
                     add_permissions_to_group(EDITOR_CUSTOM_PERMISSIONS, newGroup)
 
                 elif group == PATIENT_ACCESS:

--- a/project/npda/management/commands/create_groups.py
+++ b/project/npda/management/commands/create_groups.py
@@ -178,6 +178,13 @@ def groups_seeder(
         {"codename": "can_download_csv", "content_type": npdauserContentType},
     ]
 
+    COORDINATOR_CUSTOM_PERMISSIONS = [
+        {
+            "codename": CAN_TRANSFER_NPDA_LEAD_CENTRE[0],
+            "content_type": transferContentType,
+        }
+    ]
+
     PATIENT_ACCESS_PERMISSIONS = [
         # currently not used
         {
@@ -231,6 +238,7 @@ def groups_seeder(
             elif group == TRUST_AUDIT_TEAM_COORDINATOR_ACCESS:
                 # basic permissions
                 add_permissions_to_group(COORDINATOR_PERMISSIONS, newGroup)
+                add_permissions_to_group(COORDINATOR_CUSTOM_PERMISSIONS, newGroup)
                 add_permissions_to_group(EDITOR_CUSTOM_PERMISSIONS, newGroup)
 
             elif group == PATIENT_ACCESS:


### PR DESCRIPTION
### Overview
Follow up from #1151

the `can_transfer_npda_lead_centre` permission is leveraged to allow coordinators to change employer affiliations. Unfortunately, this was a permission not allocated to coordinators - it was only allocated to NPDA Admin. This fixes this for the seeding data, though the permission itself has now been updated in live

### Code changes
Updates the `create_groups.py`

### Documentation changes (done or required as a result of this PR)
previously done