### PR TITLE
Switcher follows audit period and PZ code in URL

### DIFF
--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -19,7 +19,7 @@ def current_audit_period_slug(request):
     if request.resolver_match:
         audit_period_slug = request.resolver_match.kwargs.get("audit_period", None)
 
-     # Temporary hack until all pages migrated over to new URL structure
+    # Temporary hack until all pages migrated over to new URL structure
     if not audit_period_slug:
         audit_year = request.session.get("selected_audit_year", None)
 
@@ -27,6 +27,14 @@ def current_audit_period_slug(request):
             audit_period_slug = f"{audit_year}-{audit_year + 1}"
 
     return audit_period_slug
+
+# Temporary hack until switcher removed so you can only change audit period by following links
+def current_audit_year(audit_period_slug):
+    if audit_period_slug:
+        start_year = int(audit_period_slug.split("-")[0])
+        return start_year
+    
+    return None
 
 
 def session_data(request):
@@ -45,6 +53,8 @@ def session_data(request):
         "audit_period_slug": audit_period_slug,
         "parent_name": request.session.get("parent_name", None),
         "audit_years": request.session.get("audit_years", []),
+        # Required for switcher
+        "selected_audit_year": current_audit_year(audit_period_slug),
     }
 
 

--- a/project/npda/templates/navbar/components/filters.html
+++ b/project/npda/templates/navbar/components/filters.html
@@ -6,7 +6,7 @@
     <div class="modal-box">
       <div id="global_audit_year"
            class="join-item items-stretch flex-grow basis-1/5">
-        {% include 'partials/audit_year_select.html' with audit_years=request.session.audit_years selected_audit_year=request.session.selected_audit_year hx_target='#global_audit_year' %}
+        {% include 'partials/audit_year_select.html' with audit_years=request.session.audit_years selected_audit_year=selected_audit_year hx_target='#global_audit_year' %}
       </div>
       <div id="global_view_preference"
            class="join-item items-stretch flex-grow  basis-2/4">

--- a/project/npda/templates/navbar/components/filters.html
+++ b/project/npda/templates/navbar/components/filters.html
@@ -10,7 +10,7 @@
       </div>
       <div id="global_view_preference"
            class="join-item items-stretch flex-grow  basis-2/4">
-        {% include 'partials/view_preference.html' with view_preference=request.user.view_preference pdu_choices=request.session.pdu_choices chosen_pdu=request.session.pz_code hx_target='#global_view_preference' %}
+        {% include 'partials/view_preference.html' with view_preference=request.user.view_preference pdu_choices=request.session.pdu_choices chosen_pdu=pz_code hx_target='#global_view_preference' %}
       </div>
       <div class="modal-action">
         <form method="dialog">

--- a/project/npda/tests/permissions_tests/test_mixins_against_session.py
+++ b/project/npda/tests/permissions_tests/test_mixins_against_session.py
@@ -105,8 +105,6 @@ class TestQuestionnaireView:
         session = self.client.session
         session["can_upload_csv"] = False
         session["can_complete_questionnaire"] = True
-        session["pz_code"] = ALDER_HEY_PZ_CODE
-        session["selected_audit_year"] = self.audit_period.audit_year()
         session.save()
 
     def test_users_with_correct_permissions_can_save_patient(self):

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -255,8 +255,6 @@ def test_reader_cannot_upload_csv(
     session = client.session
     session["can_upload_csv"] = True
     session["can_complete_questionnaire"] = False
-    session["pz_code"] = ALDER_HEY_PZ_CODE
-    # session["selected_audit_year"] = audit_period.audit_year()
     session.save()
 
     # upload the CSV file by posting to  'home' view

--- a/project/npda/tests/view_tests/test_upload.py
+++ b/project/npda/tests/view_tests/test_upload.py
@@ -119,8 +119,6 @@ def test_coordinator_cannot_upload_csv_to_closed_audit_year(
     session = client.session
     session["can_upload_csv"] = True
     session["can_complete_questionnaire"] = False
-    session["pz_code"] = ALDER_HEY_PZ_CODE
-    session["selected_audit_year"] = audit_period.audit_year()
     session.save()
     
     csv_file = SimpleUploadedFile(

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -101,13 +101,8 @@ def audit_year(request):
 
         return redirect_after_switcher(request)
 
-    context = {
-        "audit_years": request.session.get("audit_years"),
-        "selected_audit_year": request.session.get("selected_audit_year"),
-    }
-
     response = render(
-        request, template_name="partials/audit_year_select.html", context=context
+        request, template_name="partials/audit_year_select.html"
     )
 
     return response

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -101,14 +101,6 @@ class NPDAUserListView(
     def get_context_data(self, **kwargs):
         context = super(NPDAUserListView, self).get_context_data(**kwargs)
         context["title"] = "NPDA Users"
-        context["pz_code"] = self.request.session.get("pz_code")
-        context["pdu_choices"] = (
-            organisations_adapter.paediatric_diabetes_units_to_populate_select_field(  # This is used to populate the select field in view preference form
-                requesting_user=self.request.user, user_instance=self.request.user
-            )
-        )
-        context["parent"] = self.request.session.get("parent")
-        context["chosen_pdu"] = self.request.session.get("pz_code")
         return context
 
     def get(self, request, *args: str, **kwargs) -> HttpResponse:

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -204,13 +204,6 @@ class PatientListView(
 
         context["pz_code"] = self.pdu.pz_code
         context["audit_period"] = self.audit_period
-        context["pdu_choices"] = (
-            organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
-                requesting_user=self.request.user,
-                user_instance=self.request.user,
-            )
-        )
-        context["chosen_pdu"] = self.pdu.pz_code
         context["current_page"] = self.request.GET.get("page", 1)
         context["sort_by"] = self.get_sort_by()
 


### PR DESCRIPTION
Fixes a bug where if you navigated to a different audit period or PDU not via the switcher (i.e. not updating the underlying session) the switcher would show the one still in session.

There is still a variation on this bug where if you change the URL, navigate to a non PDU data page like "home" or "npda_users" then click on a PDU data nav link like "Patient Report", you end up at the PDU in the session not the one you started at. If you click the back button it works as expected since the changed PDU is in the URL. It's only if you navigate via a page that doesn't have a PDU in the URL that the bug occurs.

I would argue we fix that by pressing ahead with #1121 so that navigating into a PDU has to happen from the homepage and we remove the switcher entirely. We can then remove `selected_audit_year` and `pz_code` from the session entirely.