### PR TITLE
Don't show list of PDUs for RCPCH audit team during CSV upload

### DIFF
--- a/project/npda/templates/partials/submission_employer_selector.html
+++ b/project/npda/templates/partials/submission_employer_selector.html
@@ -6,7 +6,7 @@
     <h3 class="font-bold">Important Information</h3>
     <div class="text-xs">
       You are about to upload data to the NPDA for <strong>{{ pdu.pz_code }} ({{ pdu.lead_organisation_name }})</strong>.
-      {% if request.session.pdu_choices|length > 1 %}
+      {% if not request.user.is_rcpch_audit_team_member and request.session.pdu_choices|length > 1 %}
         <p class="text-xs mt-2 mb-2">
           If this is incorrect, please select the correct employer below.
         </p>


### PR DESCRIPTION
RCPCH audit team members can upload to all PDUs so the list is massive