### PR TITLE
Check PDU level permissions when downloading data

### DIFF
--- a/project/npda/general_functions/csv/csv_download.py
+++ b/project/npda/general_functions/csv/csv_download.py
@@ -38,6 +38,6 @@ def download_xlsx(request, submission_id):
 
     xlsx_file = write_errors_to_xlsx(errors or {}, submission.csv_file)
 
-    response = HttpResponse(xlsx_file, content_type="text/csv")
+    response = HttpResponse(xlsx_file, content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     response["Content-Disposition"] = f'attachment; filename="{xlsx_file_name}"'
     return response

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -751,7 +751,7 @@ def test_users_can_download_csv(
     assert response.has_header("Content-Disposition")
     assert "attachment" in response["Content-Disposition"]
     assert "filename" in response["Content-Disposition"]
-    assert response["Content-Type"] == "text/csv"
+    assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 @pytest.mark.django_db
@@ -870,7 +870,7 @@ def test_users_can_download_report(
     assert response.has_header("Content-Disposition")
     assert "attachment" in response["Content-Disposition"]
     assert "filename" in response["Content-Disposition"]
-    assert response["Content-Type"] == "text/csv"
+    assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -751,7 +751,7 @@ def test_users_can_download_csv(
     assert response.has_header("Content-Disposition")
     assert "attachment" in response["Content-Disposition"]
     assert "filename" in response["Content-Disposition"]
-    assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert response["Content-Type"] == "text/csv"
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/utils.py
+++ b/project/npda/tests/utils.py
@@ -41,6 +41,7 @@ def create_submission(
     audit_start_date_or_audit_period: date | AuditPeriod,
     pz_code: str,
     csv_file_name: str | None = None,
+    csv_file: bytes | None = None
 ) -> Submission:
     """
 
@@ -77,4 +78,5 @@ def create_submission(
         submission_by=npda_user,
         submission_active=True,
         csv_file_name=csv_file_name,
+        csv_file=csv_file
     )

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -2,17 +2,37 @@ import pytest
 
 from django.urls import reverse
 
-from project.npda.models import NPDAUser, Submission
+from project.npda.models import NPDAUser, Submission, AuditPeriod
 from project.npda.tests.test_csv_upload import mock_remote_calls
 from project.npda.tests.model_tests.test_submissions import ALDER_HEY_PZ_CODE, GOSH_PZ_CODE
 from project.npda.tests.UserDataClasses import AUDIT_CENTRE_EDITOR, AUDIT_CENTRE_COORDINATOR, AUDIT_CENTRE_READER, RCPCH_AUDIT_TEAM
 from project.npda.tests.utils import login_and_verify_user
-from project.npda.general_functions.csv import csv_parse
+from project.npda.tests.utils import create_submission
+from project.npda.tests.factories.csv_file_fixtures import dummy_sheet_csv
 
-@pytest.fixture
-def valid_df(dummy_sheets_folder):
-    file = dummy_sheets_folder / "dummy_sheet_test.csv"
-    return csv_parse(file).df
+
+@pytest.mark.django_db
+@pytest.fixture(scope="module", autouse=True)
+def setup(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    django_db_setup,
+    django_db_blocker,
+    request
+):
+    file = request.config.rootdir / 'project' / 'npda' / 'dummy_sheets' / 'dummy_sheet_test.csv'
+    with open(file, 'r') as f:
+        csv_file_data = f.read()
+
+    with django_db_blocker.unblock():
+        for pz_code in [ALDER_HEY_PZ_CODE, GOSH_PZ_CODE]:
+            create_submission(
+                AuditPeriod.objects.get_default_audit_period(),
+                pz_code=pz_code,
+                csv_file_name="test_download.csv",
+                csv_file=csv_file_data.encode("utf-8")
+            )
 
 
 @pytest.mark.parametrize(
@@ -26,49 +46,30 @@ def valid_df(dummy_sheets_folder):
 )
 @pytest.mark.django_db
 def test_uploaders_can_download_data_for_their_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
     client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df,
+    setup,
     role,
     action
 ):
-    ah_coordinator_user = NPDAUser.objects.filter(
+    coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=role,
     ).first()
 
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
+    client = login_and_verify_user(client, coordinator_user)
 
-    client = login_and_verify_user(client, ah_coordinator_user)
+    sub = Submission.objects.filter(
+        csv_file_name="test_download.csv",
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
 
-    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
-
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 1
-
-    sub_id = Submission.objects.first().id
     download_url = reverse("submissions")
 
     response = client.post(
         download_url,
         {
             'submit-data': action,
-            'audit_id': sub_id,
+            'audit_id': sub.id,
         }
     )
 
@@ -77,11 +78,11 @@ def test_uploaders_can_download_data_for_their_pdu(
     match action:
         case "download-report":
             assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
+            assert response["Content-Disposition"] == 'attachment; filename="test_download_data_quality_report.xlsx"'
 
         case "download-data":
             assert response["Content-Type"] == "text/csv"
-            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test.csv"'
+            assert response["Content-Disposition"] == 'attachment; filename="test_download.csv"'
 
 
 @pytest.mark.parametrize(
@@ -95,13 +96,8 @@ def test_uploaders_can_download_data_for_their_pdu(
 )
 @pytest.mark.django_db
 def test_uploaders_cannot_download_data_for_other_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
     client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df,
+    setup,
     role,
     action,
 ):
@@ -115,28 +111,11 @@ def test_uploaders_cannot_download_data_for_other_pdu(
         role=role,
     ).first()
 
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
+    sub = Submission.objects.filter(
+        csv_file_name="test_download.csv",
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
 
-    client = login_and_verify_user(client, ah_coordinator_user)
-
-    ah_upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
-
-    # Send POST request with CSV file
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            ah_upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 1
-
-    sub_id = Submission.objects.first().id
     download_url = reverse("submissions")
 
     client = login_and_verify_user(client, gosh_coordinator_user)
@@ -145,7 +124,7 @@ def test_uploaders_cannot_download_data_for_other_pdu(
         download_url,
         {
             'submit-data': action,
-            'audit_id': sub_id,
+            'audit_id': sub.id,
         }
     )
 
@@ -174,13 +153,8 @@ def test_uploaders_cannot_download_data_for_other_pdu(
 )
 @pytest.mark.django_db
 def test_readers_cannot_download_data_for_any_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
     client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df,
+    setup,
     action,
     home_pdu,
     requested_pdu,
@@ -200,29 +174,11 @@ def test_readers_cannot_download_data_for_any_pdu(
         role=AUDIT_CENTRE_READER,
     ).first()
 
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
+    sub = Submission.objects.filter(
+        csv_file_name="test_download.csv",
+        paediatric_diabetes_unit__pz_code=requested_pdu,
+    ).first()
 
-    client = login_and_verify_user(client, requested_pdu_editor)
-    pz_code = requested_pdu_editor.organisation_employers.first().pz_code
-
-    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": pz_code, "audit_period": "2025-2026"})
-
-    # Send POST request with CSV file
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 1
-
-    sub_id = Submission.objects.first().id
     download_url = reverse("submissions")
 
     client = login_and_verify_user(client, home_pdu_user)
@@ -231,7 +187,7 @@ def test_readers_cannot_download_data_for_any_pdu(
         download_url,
         {
             'submit-data': action,
-            'audit_id': sub_id,
+            'audit_id': sub.id,
         }
     )
 
@@ -244,7 +200,7 @@ def test_readers_cannot_download_data_for_any_pdu(
         download_url,
         {
             'submit-data': action,
-            'audit_id': sub_id,
+            'audit_id': sub.id,
         }
     )
 
@@ -253,78 +209,32 @@ def test_readers_cannot_download_data_for_any_pdu(
 
 
 @pytest.mark.parametrize(
-    "action",
+    "action,pz_code",
     [
-        pytest.param("download-report"),
-        pytest.param("download-data")
+        pytest.param("download-report", ALDER_HEY_PZ_CODE),
+        pytest.param("download-data", ALDER_HEY_PZ_CODE),
+        pytest.param("download-report", GOSH_PZ_CODE),
+        pytest.param("download-data", GOSH_PZ_CODE)
     ]
 )
 @pytest.mark.django_db
 def test_rcpch_audit_team_can_download_data_for_any_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
     client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df,
-    action
+    setup,
+    action,
+    pz_code
 ):
-    ah_coordinator_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=AUDIT_CENTRE_COORDINATOR,
-    ).first()
-
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
-
-    client = login_and_verify_user(client, ah_coordinator_user)
-
-    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
-
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    gosh_coordinator_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=GOSH_PZ_CODE,
-        role=AUDIT_CENTRE_COORDINATOR,
-    ).first()
-
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
-
-    client = login_and_verify_user(client, gosh_coordinator_user)
-
-    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": GOSH_PZ_CODE, "audit_period": "2025-2026"})
-
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 2
-    sub_id = Submission.objects.first().id
-
     rcpch_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=GOSH_PZ_CODE,
+        organisation_employers__pz_code=pz_code,
         role=RCPCH_AUDIT_TEAM,
     ).first()
 
     client = login_and_verify_user(client, rcpch_user)
+
+    sub = Submission.objects.filter(
+        csv_file_name="test_download.csv",
+        paediatric_diabetes_unit__pz_code=pz_code,
+    ).first()
 
     download_url = reverse("submissions")
 
@@ -332,7 +242,7 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
         download_url,
         {
             'submit-data': action,
-            'audit_id': sub_id,
+            'audit_id': sub.id,
         }
     )
 
@@ -341,8 +251,8 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
     match action:
         case "download-report":
             assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
+            assert response["Content-Disposition"] == 'attachment; filename="test_download_data_quality_report.xlsx"'
 
         case "download-data":
             assert response["Content-Type"] == "text/csv"
-            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test.csv"'
+            assert response["Content-Disposition"] == 'attachment; filename="test_download.csv"'

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -16,25 +16,12 @@ def valid_df(dummy_sheets_folder):
 
 
 @pytest.mark.parametrize(
-    "role,action,filename,content_disposition,content_type",
+    "role,action",
     [
-        pytest.param(*list([role] + params)) for params in [
-            [
-                "download-report",
-                "dummy_sheet_test.csv",
-                'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            ],
-            [
-                "download-data",
-                "dummy_sheet_test.csv",
-                'attachment; filename="dummy_sheet_test.csv"',
-                "text/csv",
-            ]
-        ] for role in [
-            AUDIT_CENTRE_EDITOR,
-            AUDIT_CENTRE_COORDINATOR
-        ]
+        pytest.param(f"{AUDIT_CENTRE_EDITOR}", "download-report"),
+        pytest.param(f"{AUDIT_CENTRE_EDITOR}", "download-data"),
+        pytest.param(f"{AUDIT_CENTRE_COORDINATOR}", "download-report"),
+        pytest.param(f"{AUDIT_CENTRE_COORDINATOR}", "download-data"),
     ]
 )
 @pytest.mark.django_db
@@ -47,17 +34,14 @@ def test_uploaders_can_download_data_for_their_pdu(
     tmp_path,
     valid_df,
     role,
-    action,
-    filename,
-    content_disposition,
-    content_type
+    action
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=role,
     ).first()
 
-    tmp_csv_path = tmp_path / filename
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     valid_df.to_csv(tmp_csv_path, index=False)
 
     client = login_and_verify_user(client, ah_coordinator_user)
@@ -89,9 +73,15 @@ def test_uploaders_can_download_data_for_their_pdu(
     )
 
     assert response.status_code == 200
-
-    assert response['Content-Disposition'] == content_disposition
-    assert response['Content-Type'] == content_type
+    
+    match action:
+        case "download-report":
+            assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
+            
+        case "download-data":
+            assert response["Content-Type"] == "text/csv"
+            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test.csv"'
 
 
 @pytest.mark.parametrize(
@@ -263,20 +253,10 @@ def test_readers_cannot_download_data_for_any_pdu(
 
 
 @pytest.mark.parametrize(
-    "action,filename,content_disposition,content_type",
+    "action",
     [
-        pytest.param(
-            "download-report",
-            "dummy_sheet_test.csv",
-            'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        ),
-        pytest.param(
-            "download-data",
-            "dummy_sheet_test.csv",
-            'attachment; filename="dummy_sheet_test.csv"',
-            "text/csv",
-        )
+        pytest.param("download-report"),
+        pytest.param("download-data")
     ]
 )
 @pytest.mark.django_db
@@ -288,17 +268,14 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
     mock_remote_calls,
     tmp_path,
     valid_df,
-    action,
-    filename,
-    content_disposition,
-    content_type
+    action
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=AUDIT_CENTRE_COORDINATOR,
     ).first()
 
-    tmp_csv_path = tmp_path / filename
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     valid_df.to_csv(tmp_csv_path, index=False)
 
     client = login_and_verify_user(client, ah_coordinator_user)
@@ -321,7 +298,7 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
         role=AUDIT_CENTRE_COORDINATOR,
     ).first()
 
-    tmp_csv_path = tmp_path / filename
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     valid_df.to_csv(tmp_csv_path, index=False)
 
     client = login_and_verify_user(client, gosh_coordinator_user)
@@ -359,5 +336,11 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
 
     assert response.status_code == 200
 
-    assert response['Content-Disposition'] == content_disposition
-    assert response['Content-Type'] == content_type
+    match action:
+        case "download-report":
+            assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
+
+        case "download-data":
+            assert response["Content-Type"] == "text/csv"
+            assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test.csv"'

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from project.npda.models import NPDAUser, Submission
 from project.npda.tests.test_csv_upload import mock_remote_calls
 from project.npda.tests.model_tests.test_submissions import ALDER_HEY_PZ_CODE, GOSH_PZ_CODE
-from project.npda.tests.UserDataClasses import test_user_audit_centre_coordinator_data
+from project.npda.tests.UserDataClasses import AUDIT_CENTRE_EDITOR, AUDIT_CENTRE_COORDINATOR, AUDIT_CENTRE_READER, RCPCH_AUDIT_TEAM
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.general_functions.csv import csv_parse
 
@@ -16,22 +16,29 @@ def valid_df(dummy_sheets_folder):
 
 
 @pytest.mark.parametrize(
-    "action,filename,content_disposition,content_type",
+    "role,action,filename,content_disposition,content_type",
     [
-        pytest.param(
-            "download-report",
-            "dummy_sheet_test.csv",
-            'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
-        pytest.param(
-            "download-data",
-            "dummy_sheet_test.csv",
-            'attachment; filename="dummy_sheet_test.csv"',
-            "text/csv"),
-    ],
+        pytest.param(*list([role] + params)) for params in [
+            [
+                "download-report",
+                "dummy_sheet_test.csv",
+                'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ],
+            [
+                "download-data",
+                "dummy_sheet_test.csv",
+                'attachment; filename="dummy_sheet_test.csv"',
+                "text/csv",
+            ]
+        ] for role in [
+            AUDIT_CENTRE_EDITOR,
+            AUDIT_CENTRE_COORDINATOR
+        ]
+    ]
 )
 @pytest.mark.django_db
-def test_coordinator_can_download_data_for_their_pdu(
+def test_uploaders_can_download_data_for_their_pdu(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
@@ -39,6 +46,7 @@ def test_coordinator_can_download_data_for_their_pdu(
     mock_remote_calls,
     tmp_path,
     valid_df,
+    role,
     action,
     filename,
     content_disposition,
@@ -46,7 +54,7 @@ def test_coordinator_can_download_data_for_their_pdu(
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
+        role=role,
     ).first()
 
     tmp_csv_path = tmp_path / filename
@@ -87,14 +95,16 @@ def test_coordinator_can_download_data_for_their_pdu(
 
 
 @pytest.mark.parametrize(
-    "action,",
+    "role,action",
     [
-        pytest.param("download-report"),
-        pytest.param("download-data"),
-    ],
+        pytest.param(f"{AUDIT_CENTRE_EDITOR}", "download-report"),
+        pytest.param(f"{AUDIT_CENTRE_EDITOR}", "download-data"),
+        pytest.param(f"{AUDIT_CENTRE_COORDINATOR}", "download-report"),
+        pytest.param(f"{AUDIT_CENTRE_COORDINATOR}", "download-data"),
+    ]
 )
 @pytest.mark.django_db
-def test_coordinator_cannot_download_report_for_other_pdu(
+def test_uploaders_cannot_download_data_for_other_pdu(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
@@ -102,16 +112,17 @@ def test_coordinator_cannot_download_report_for_other_pdu(
     mock_remote_calls,
     tmp_path,
     valid_df,
+    role,
     action,
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
+        role=role,
     ).first()
 
     gosh_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=GOSH_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
+        role=role,
     ).first()
 
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
@@ -151,3 +162,202 @@ def test_coordinator_cannot_download_report_for_other_pdu(
     assert response.status_code == 403
     assert "Content-Disposition" not in response
 
+
+
+@pytest.mark.parametrize(
+    "action,home_pdu,requested_pdu",
+    [
+        pytest.param(*list([action] + params)) for params in [
+            [
+                ALDER_HEY_PZ_CODE,
+                ALDER_HEY_PZ_CODE,
+            ],
+            [
+                ALDER_HEY_PZ_CODE,
+                GOSH_PZ_CODE
+            ]
+        ] for action in [
+            "download-report",
+            "download-data"
+        ]
+    ]
+)
+@pytest.mark.django_db
+def test_readers_cannot_download_data_for_any_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df,
+    action,
+    home_pdu,
+    requested_pdu,
+):
+    home_pdu_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=home_pdu,
+        role=AUDIT_CENTRE_READER,
+    ).first()
+
+    requested_pdu_editor = NPDAUser.objects.filter(
+        organisation_employers__pz_code=requested_pdu,
+        role=AUDIT_CENTRE_EDITOR,
+    ).first()
+
+    requested_pdu_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=requested_pdu,
+        role=AUDIT_CENTRE_READER,
+    ).first()
+
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    client = login_and_verify_user(client, requested_pdu_editor)
+    pz_code = requested_pdu_editor.organisation_employers.first().pz_code
+
+    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": pz_code, "audit_period": "2025-2026"})
+
+    # Send POST request with CSV file
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 1
+
+    sub_id = Submission.objects.first().id
+    download_url = reverse("submissions")
+
+    client = login_and_verify_user(client, home_pdu_user)
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': action,
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 403
+    assert "Content-Disposition" not in response
+
+    client = login_and_verify_user(client, requested_pdu_user)
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': action,
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 403
+    assert "Content-Disposition" not in response
+
+
+@pytest.mark.parametrize(
+    "action,filename,content_disposition,content_type",
+    [
+        pytest.param(
+            "download-report",
+            "dummy_sheet_test.csv",
+            'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+        pytest.param(
+            "download-data",
+            "dummy_sheet_test.csv",
+            'attachment; filename="dummy_sheet_test.csv"',
+            "text/csv",
+        )
+    ]
+)
+@pytest.mark.django_db
+def test_rcpch_audit_team_can_download_data_for_any_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df,
+    action,
+    filename,
+    content_disposition,
+    content_type
+):
+    ah_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR,
+    ).first()
+
+    tmp_csv_path = tmp_path / filename
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    gosh_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR,
+    ).first()
+
+    tmp_csv_path = tmp_path / filename
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    client = login_and_verify_user(client, gosh_coordinator_user)
+
+    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": GOSH_PZ_CODE, "audit_period": "2025-2026"})
+
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 2
+    sub_id = Submission.objects.first().id
+
+    gosh_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=AUDIT_CENTRE_COORDINATOR,
+    ).first()
+
+    download_url = reverse("submissions")
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': action,
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 200
+
+    assert response['Content-Disposition'] == content_disposition
+    assert response['Content-Type'] == content_type

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -78,7 +78,7 @@ def test_uploaders_can_download_data_for_their_pdu(
         case "download-report":
             assert response["Content-Type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
-            
+
         case "download-data":
             assert response["Content-Type"] == "text/csv"
             assert response["Content-Disposition"] == 'attachment; filename="dummy_sheet_test.csv"'
@@ -319,10 +319,12 @@ def test_rcpch_audit_team_can_download_data_for_any_pdu(
     assert Submission.objects.count() == 2
     sub_id = Submission.objects.first().id
 
-    gosh_coordinator_user = NPDAUser.objects.filter(
+    rcpch_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=GOSH_PZ_CODE,
-        role=AUDIT_CENTRE_COORDINATOR,
+        role=RCPCH_AUDIT_TEAM,
     ).first()
+
+    client = login_and_verify_user(client, rcpch_user)
 
     download_url = reverse("submissions")
 

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -1,0 +1,131 @@
+import pytest
+
+from django.urls import reverse
+
+from project.npda.models import NPDAUser, Submission
+from project.npda.tests.test_csv_upload import mock_remote_calls
+from project.npda.tests.model_tests.test_submissions import ALDER_HEY_PZ_CODE
+from project.npda.tests.UserDataClasses import test_user_audit_centre_coordinator_data
+from project.npda.tests.utils import login_and_verify_user
+from project.npda.general_functions.csv import csv_parse
+
+@pytest.fixture
+def valid_df(dummy_sheets_folder):
+    file = dummy_sheets_folder / "dummy_sheet_test.csv"
+    return csv_parse(file).df
+
+
+@pytest.mark.django_db
+def test_coordinator_can_download_report_for_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df
+):
+    # Get a user
+    ah_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Send POST request with CSV file
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    # Assert the response to ensure no error
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 1
+
+    sub_id = Submission.objects.first().id
+    download_url = reverse("submissions")
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': "download-report",
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 200
+
+    assert response['Content-Disposition'] == f'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
+    assert response['Content-Type'] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+@pytest.mark.django_db
+def test_coordinator_can_download_original_for_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df
+):
+    # Get a user
+    ah_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Send POST request with CSV file
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    # Assert the response to ensure no error
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 1
+
+    sub_id = Submission.objects.first().id
+    download_url = reverse("submissions")
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': "download-data",
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 200
+
+    assert response['Content-Disposition'] == f'attachment; filename="dummy_sheet_test.csv"'
+    assert response['Content-Type'] == "text/csv"

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -15,22 +15,41 @@ def valid_df(dummy_sheets_folder):
     return csv_parse(file).df
 
 
+@pytest.mark.parametrize(
+    "action,filename,content_disposition,content_type",
+    [
+        pytest.param(
+            "download-report",
+            "dummy_sheet_test.csv",
+            'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"',
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        pytest.param(
+            "download-data",
+            "dummy_sheet_test.csv",
+            'attachment; filename="dummy_sheet_test.csv"',
+            "text/csv"),
+    ],
+)
 @pytest.mark.django_db
-def test_coordinator_can_download_report_for_their_pdu(
+def test_coordinator_can_download_data_for_their_pdu(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
     mock_remote_calls,
     tmp_path,
-    valid_df
+    valid_df,
+    action,
+    filename,
+    content_disposition,
+    content_type
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=test_user_audit_centre_coordinator_data.role,
     ).first()
 
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    tmp_csv_path = tmp_path / filename
     valid_df.to_csv(tmp_csv_path, index=False)
 
     client = login_and_verify_user(client, ah_coordinator_user)
@@ -56,69 +75,24 @@ def test_coordinator_can_download_report_for_their_pdu(
     response = client.post(
         download_url,
         {
-            'submit-data': "download-report",
+            'submit-data': action,
             'audit_id': sub_id,
         }
     )
 
     assert response.status_code == 200
 
-    assert response['Content-Disposition'] == f'attachment; filename="dummy_sheet_test_data_quality_report.xlsx"'
-    assert response['Content-Type'] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    assert response['Content-Disposition'] == content_disposition
+    assert response['Content-Type'] == content_type
 
 
-@pytest.mark.django_db
-def test_coordinator_can_download_original_for_their_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df
-):
-    ah_coordinator_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
-    ).first()
-
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
-
-    client = login_and_verify_user(client, ah_coordinator_user)
-
-    upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
-
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 1
-
-    sub_id = Submission.objects.first().id
-    download_url = reverse("submissions")
-
-    response = client.post(
-        download_url,
-        {
-            'submit-data': "download-data",
-            'audit_id': sub_id,
-        }
-    )
-
-    assert response.status_code == 200
-
-    assert response['Content-Disposition'] == f'attachment; filename="dummy_sheet_test.csv"'
-    assert response['Content-Type'] == "text/csv"
-
-
+@pytest.mark.parametrize(
+    "action,",
+    [
+        pytest.param("download-report"),
+        pytest.param("download-data"),
+    ],
+)
 @pytest.mark.django_db
 def test_coordinator_cannot_download_report_for_other_pdu(
     seed_groups_fixture,
@@ -127,7 +101,8 @@ def test_coordinator_cannot_download_report_for_other_pdu(
     client,
     mock_remote_calls,
     tmp_path,
-    valid_df
+    valid_df,
+    action,
 ):
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -168,66 +143,11 @@ def test_coordinator_cannot_download_report_for_other_pdu(
     response = client.post(
         download_url,
         {
-            'submit-data': "download-report",
+            'submit-data': action,
             'audit_id': sub_id,
         }
     )
 
     assert response.status_code == 403
+    assert "Content-Disposition" not in response
 
-
-@pytest.mark.django_db
-def test_coordinator_cannot_download_data_for_other_pdu(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client,
-    mock_remote_calls,
-    tmp_path,
-    valid_df
-):
-    ah_coordinator_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
-    ).first()
-
-    gosh_coordinator_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=GOSH_PZ_CODE,
-        role=test_user_audit_centre_coordinator_data.role,
-    ).first()
-
-    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
-    valid_df.to_csv(tmp_csv_path, index=False)
-
-    client = login_and_verify_user(client, ah_coordinator_user)
-
-    ah_upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
-
-    # Send POST request with CSV file
-    with open(tmp_csv_path, "rb") as csv_file:
-        response = client.post(
-            ah_upload_url,
-            {
-                'csv_upload': csv_file
-            },
-            format='multipart'
-        )
-
-    assert response.status_code == 302
-
-    assert Submission.objects.count() == 1
-
-    sub_id = Submission.objects.first().id
-    download_url = reverse("submissions")
-
-    client = login_and_verify_user(client, gosh_coordinator_user)
-
-    response = client.post(
-        download_url,
-        {
-            'submit-data': "download-data",
-            'audit_id': sub_id,
-        }
-    )
-
-    assert response.status_code == 403

--- a/project/npda/tests/view_tests/test_download.py
+++ b/project/npda/tests/view_tests/test_download.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from project.npda.models import NPDAUser, Submission
 from project.npda.tests.test_csv_upload import mock_remote_calls
-from project.npda.tests.model_tests.test_submissions import ALDER_HEY_PZ_CODE
+from project.npda.tests.model_tests.test_submissions import ALDER_HEY_PZ_CODE, GOSH_PZ_CODE
 from project.npda.tests.UserDataClasses import test_user_audit_centre_coordinator_data
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.general_functions.csv import csv_parse
@@ -25,23 +25,18 @@ def test_coordinator_can_download_report_for_their_pdu(
     tmp_path,
     valid_df
 ):
-    # Get a user
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=test_user_audit_centre_coordinator_data.role,
     ).first()
-    client = login_and_verify_user(client, ah_coordinator_user)
 
-    # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     valid_df.to_csv(tmp_csv_path, index=False)
 
-    # Log in user
     client = login_and_verify_user(client, ah_coordinator_user)
 
     upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
 
-    # Send POST request with CSV file
     with open(tmp_csv_path, "rb") as csv_file:
         response = client.post(
             upload_url,
@@ -51,7 +46,6 @@ def test_coordinator_can_download_report_for_their_pdu(
             format='multipart'
         )
 
-    # Assert the response to ensure no error
     assert response.status_code == 302
 
     assert Submission.objects.count() == 1
@@ -83,23 +77,18 @@ def test_coordinator_can_download_original_for_their_pdu(
     tmp_path,
     valid_df
 ):
-    # Get a user
     ah_coordinator_user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
         role=test_user_audit_centre_coordinator_data.role,
     ).first()
-    client = login_and_verify_user(client, ah_coordinator_user)
 
-    # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
     valid_df.to_csv(tmp_csv_path, index=False)
 
-    # Log in user
     client = login_and_verify_user(client, ah_coordinator_user)
 
     upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
 
-    # Send POST request with CSV file
     with open(tmp_csv_path, "rb") as csv_file:
         response = client.post(
             upload_url,
@@ -109,7 +98,6 @@ def test_coordinator_can_download_original_for_their_pdu(
             format='multipart'
         )
 
-    # Assert the response to ensure no error
     assert response.status_code == 302
 
     assert Submission.objects.count() == 1
@@ -129,3 +117,117 @@ def test_coordinator_can_download_original_for_their_pdu(
 
     assert response['Content-Disposition'] == f'attachment; filename="dummy_sheet_test.csv"'
     assert response['Content-Type'] == "text/csv"
+
+
+@pytest.mark.django_db
+def test_coordinator_cannot_download_report_for_other_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df
+):
+    ah_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+
+    gosh_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    ah_upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Send POST request with CSV file
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            ah_upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 1
+
+    sub_id = Submission.objects.first().id
+    download_url = reverse("submissions")
+
+    client = login_and_verify_user(client, gosh_coordinator_user)
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': "download-report",
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_coordinator_cannot_download_data_for_other_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    mock_remote_calls,
+    tmp_path,
+    valid_df
+):
+    ah_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+
+    gosh_coordinator_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+
+    tmp_csv_path = tmp_path / "dummy_sheet_test.csv"
+    valid_df.to_csv(tmp_csv_path, index=False)
+
+    client = login_and_verify_user(client, ah_coordinator_user)
+
+    ah_upload_url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Send POST request with CSV file
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            ah_upload_url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    assert Submission.objects.count() == 1
+
+    sub_id = Submission.objects.first().id
+    download_url = reverse("submissions")
+
+    client = login_and_verify_user(client, gosh_coordinator_user)
+
+    response = client.post(
+        download_url,
+        {
+            'submit-data': "download-data",
+            'audit_id': sub_id,
+        }
+    )
+
+    assert response.status_code == 403

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -274,6 +274,10 @@ class SubmissionsListView(
             submission = Submission.objects.filter(
                 pk=request.POST.get("audit_id")
             ).get()
+            if not request.user.is_rcpch_audit_team_member and not submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+                raise PermissionDenied(
+                    f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
+                )
             return download_csv(request, submission.id)
 
         if button_name == "download-report":
@@ -285,6 +289,10 @@ class SubmissionsListView(
             submission = Submission.objects.filter(
                 pk=request.POST.get("audit_id")
             ).get()
+            if not request.user.is_rcpch_audit_team_member and not submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+                raise PermissionDenied(
+                    f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
+                )
             return download_xlsx(request, submission.id)
 
         # POST is not supported for this view

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -274,11 +274,13 @@ class SubmissionsListView(
             submission = Submission.objects.filter(
                 pk=request.POST.get("audit_id")
             ).get()
-            if not request.user.is_rcpch_audit_team_member and not submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+            if request.user.is_rcpch_audit_team_member or submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+                return download_csv(request, submission.id)
+            else:
                 raise PermissionDenied(
                     f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
                 )
-            return download_csv(request, submission.id)
+            
 
         if button_name == "download-report":
             # check if the user has permission to download submissions
@@ -289,11 +291,13 @@ class SubmissionsListView(
             submission = Submission.objects.filter(
                 pk=request.POST.get("audit_id")
             ).get()
-            if not request.user.is_rcpch_audit_team_member and not submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+            if request.user.is_rcpch_audit_team_member or submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
+                return download_xlsx(request, submission.id)
+            else:
                 raise PermissionDenied(
                     f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
                 )
-            return download_xlsx(request, submission.id)
+            
 
         # POST is not supported for this view
         # Must therefore return the queryset as an obect_list and context


### PR DESCRIPTION
Fixes a security issue where you can guess the primary key of a submission and download the associated data quality report and original data.