### PR TITLE
Make async route sync

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -43,21 +43,21 @@ from project.npda.models import (
     VisitActivity
 )
 
-async def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None, new_dataframe=None):
-    old_submission = await Submission.objects.filter(
+def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name, submission_active, user=None, ip_address=None, new_dataframe=None):
+    old_submission = Submission.objects.filter(
         paediatric_diabetes_unit=pdu,
         audit_period=audit_period,
         submission_active=True,
-    ).afirst()
+    ).first()
 
     if old_submission:
         old_submission.submission_active = False
-        await old_submission.asave()
-    
+        old_submission.save()
+
     # Gather unique patient and visit counts and update the submission
     patient_count, visit_per_patient_count, total_rows = gather_unique_patient_and_visit_counts(dataframe=new_dataframe, is_jersey=pdu.pz_code == "PZ248")
-    
-    submission = await Submission.objects.acreate(
+
+    submission = Submission.objects.create(
         submission_date=timezone.now(),
         submission_by=user,
         paediatric_diabetes_unit=pdu,
@@ -72,7 +72,7 @@ async def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name
     )
     
     if user:
-        await VisitActivity.objects.acreate(
+        VisitActivity.objects.create(
             activity=8,
             ip_address=ip_address,
             npdauser=user,
@@ -81,19 +81,19 @@ async def create_csv_submission(pdu, audit_period, csv_file_bytes, csv_file_name
     return submission
 
 
-async def tidy_up_old_submissions(pdu, new_submission):
+def tidy_up_old_submissions(pdu, new_submission):
     all_submissions = Submission.objects.filter(
         paediatric_diabetes_unit=pdu,
         audit_year=new_submission.audit_year, # compatibility
         audit_period=new_submission.audit_period,
     )
 
-    async for submission in all_submissions:
+    for submission in all_submissions:
         if submission.id != new_submission.id:
-            await Patient.objects.filter(submissions=submission).adelete()
+            Patient.objects.filter(submissions=submission).delete()
 
             submission.submission_active = False
-            await submission.asave()
+            submission.save()
 
 
 async def csv_upload(

--- a/project/npda/management/commands/upload_csv.py
+++ b/project/npda/management/commands/upload_csv.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             start_date__year=audit_year
         ).first()
 
-        submission = async_to_sync(create_csv_submission)(
+        submission = create_csv_submission(
             pdu=pdu,
             audit_year=audit_year, # compatibility
             audit_period=audit_period,
@@ -106,7 +106,7 @@ class Command(BaseCommand):
             submission=submission
         )
 
-        async_to_sync(tidy_up_old_submissions)(
+        tidy_up_old_submissions(
             pdu=pdu,
             new_submission=submission
         )

--- a/project/npda/tasks.py
+++ b/project/npda/tasks.py
@@ -34,7 +34,6 @@ def upload_csv_task(submission_id):
     )
 
     csv_upload_sync = async_to_sync(csv_upload)
-    tidy_up_old_submissions_sync = async_to_sync(tidy_up_old_submissions)
 
     csv_upload_sync(
         dataframe=parsed_csv.df,
@@ -47,7 +46,7 @@ def upload_csv_task(submission_id):
     submission.submission_active = True
     submission.save()
 
-    tidy_up_old_submissions_sync(
+    tidy_up_old_submissions(
         pdu=submission.paediatric_diabetes_unit,
         new_submission=submission,
     )

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -162,16 +162,15 @@ def test_rcpch_user(seed_groups_fixture, seed_users_fixture, seed_audit_periods_
 
 # The database is not rolled back if we used the built in async support for pytest
 # https://github.com/pytest-dev/pytest-asyncio/issues/226
-@async_to_sync
-async def csv_upload_sync(
+def csv_upload_sync(
     user, dataframe, pdu=None, errors_to_return=None, _audit_period=None
 ):
-    audit_period = _audit_period if _audit_period else await AuditPeriod.objects.afirst()
+    audit_period = _audit_period if _audit_period else AuditPeriod.objects.first()
 
     if not pdu:
-        pdu = await PaediatricDiabetesUnit.objects.aget(pz_code=ALDER_HEY_PZ_CODE)
+        pdu = PaediatricDiabetesUnit.objects.get(pz_code=ALDER_HEY_PZ_CODE)
 
-    new_submission = await create_csv_submission(
+    new_submission = create_csv_submission(
         pdu=pdu,
         audit_period=audit_period,
         csv_file_bytes=None,
@@ -182,7 +181,7 @@ async def csv_upload_sync(
         new_dataframe= dataframe
     )
 
-    return await csv_upload(
+    return async_to_sync(csv_upload)(
         dataframe,
         errors_to_return=(
             collections.defaultdict(lambda: collections.defaultdict(list))

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -50,16 +50,6 @@ def login_and_otp_required():
 
     def decorator(view):
         @wraps(view)
-        async def async_login_and_otp_required(request, *args, **kwargs):
-            async_check_otp = sync_to_async(check_otp)
-
-            if await async_check_otp(view, request):
-                response = await view(request, *args, **kwargs)
-                return response
-            else:
-                return redirect("two_factor:setup")
-
-        @wraps(view)
         def sync_login_and_otp_required(request, *args, **kwargs):
             if check_otp(view, request):
                 return view(request, *args, **kwargs)
@@ -68,10 +58,7 @@ def login_and_otp_required():
 
         login_required(view)
 
-        if asyncio.iscoroutinefunction(view):
-            return async_login_and_otp_required
-        else:
-            return sync_login_and_otp_required
+        return sync_login_and_otp_required
 
     return decorator
 
@@ -83,20 +70,6 @@ def check_data_permissions():
         return (audit_period, pdu)
 
     def decorator(view):
-        @wraps(view)
-        async def async_check_data_permissions(request, *args, **kwargs):
-            (audit_period, pdu) = await sync_to_async(_check_data_permissions)(request, *args, **kwargs)
-
-            next_kwargs = kwargs | {
-                "audit_period": audit_period,
-                "pdu": pdu
-            }
-
-            if "pz_code" in next_kwargs:
-                del next_kwargs["pz_code"]
-
-            return await view(request, *args, **next_kwargs)
-
         @wraps(view)
         def sync_check_data_permissions(request, *args, **kwargs):
             (audit_period, pdu) = _check_data_permissions(request, *args, **kwargs)
@@ -111,9 +84,6 @@ def check_data_permissions():
 
             return view(request, *args, **next_kwargs)
 
-        if asyncio.iscoroutinefunction(view):
-            return async_check_data_permissions
-        else:
-            return sync_check_data_permissions
+        return sync_check_data_permissions
 
     return decorator

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -50,7 +50,7 @@ def redirect_after_switcher(request):
 
 
 @login_and_otp_required()
-async def home(request):
+def home(request):
     """
     Home page view.
     Only verified users can access this page.

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -1,5 +1,4 @@
 # Python imports
-from asgiref.sync import sync_to_async
 from urllib.parse import urlparse
 import logging
 

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -6,8 +6,6 @@ import logging
 import io
 import itertools
 
-from asgiref.sync import sync_to_async
-
 # Django imports
 from django.apps import apps
 from django.contrib import messages
@@ -320,8 +318,8 @@ class SubmissionsListView(
 
 @login_and_otp_required()
 @check_data_permissions()
-async def upload_csv(request, audit_period, pdu):
-    previous_submission = await sync_to_async(Submission.objects.get_submission_for_request)(pdu, audit_period)
+def upload_csv(request, audit_period, pdu):
+    previous_submission = Submission.objects.get_submission_for_request(pdu, audit_period)
 
     if previous_submission and not previous_submission.csv_file_name:
         # PDU is submitting via questionnaire
@@ -331,7 +329,7 @@ async def upload_csv(request, audit_period, pdu):
         }))
 
     if request.method == "POST":
-        has_perm = await sync_to_async(request.user.has_perm)("npda.can_submit_csv")
+        has_perm = request.user.has_perm("npda.can_submit_csv")
         if not has_perm:
             raise PermissionDenied("You do not have permission to upload CSV files.")
         
@@ -398,7 +396,7 @@ async def upload_csv(request, audit_period, pdu):
         if not audit_period.is_open and not (request.user.is_superuser or request.user.is_rcpch_audit_team_member):
             raise PermissionDenied(f"Upload is closed for {audit_period}.")
 
-        new_submission = await create_csv_submission(
+        new_submission = create_csv_submission(
             pdu=pdu,
             audit_period=audit_period,
             csv_file_bytes=user_csv_bytes,
@@ -412,7 +410,7 @@ async def upload_csv(request, audit_period, pdu):
         
         upload_csv_task.delay(new_submission.id)
 
-        await sync_to_async(save_csv_uploading_user_to_visitactivity)(request=request)
+        save_csv_uploading_user_to_visitactivity(request=request)
         
         return redirect("pdu-upload-csv-in-progress",
             pz_code=pdu.pz_code,


### PR DESCRIPTION
This was left over from migrating to Celery, where the functionality could be called directly from the route (and therefore had to be async compatible) or from the Celery task (sync).

The csv_upload function remains async as it runs external validators (eg dGC API calls) in parallel. (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/974 was raised to replace this with a Celery task per patient and use the inherent parallelism of multiple Celery workers rather than async juggling).

By doing this we unblock #562 (and #1201) - all of the routes will be sync so context processors can happily call sync APIs.