### PR TITLE
[new navigation feature flag] Move audit year switcher into user dropdown menu

### DIFF
--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -22,7 +22,8 @@ def get_audit_period_session_data(audit_period, user):
         if audit_period.is_visible or user.is_rcpch_audit_team_member or user.is_superuser:
             audit_years.append(
                 {
-                    "year": audit_period.audit_year()
+                    "year": audit_period.audit_year(),
+                    "slug": audit_period.slug
                 }
             )
     

--- a/project/npda/templates/navbar/components/avatar_dropdown.html
+++ b/project/npda/templates/navbar/components/avatar_dropdown.html
@@ -19,6 +19,20 @@
       <p class="text-center">
         Hello, <span class="font-mono">{{ user.get_full_name }}!</span>
       </p>
+      {% if 'new_navigation' in request.session.feature_flags %}
+        <hr class="my-2" />
+        <li>
+          <select title="Select audit year"
+            _="on change go to url `$my.value`" >
+          {% for audit_year in request.session.audit_years %}
+            <option value="{% url 'new-home' audit_period=audit_year.slug %}"
+              {% if selected_audit_year|stringformat:"s" == audit_year.year|stringformat:"s" %} selected {% endif %}>
+              April {{ audit_year.year }} - March {{ audit_year.year|add:'1' }}
+            </option>
+          {% endfor %}
+          </select>
+        </li>
+      {% endif %}
       <hr class="my-2" />
       <li>
         <a href="{% url 'two_factor:profile' %}"><i class="fa-solid fa-shield"></i>Two Factor Authentication</a>

--- a/project/npda/templates/new-home.html
+++ b/project/npda/templates/new-home.html
@@ -3,18 +3,11 @@
 {% load npda_tags %}
 {% block content %}
   <div class="text-center my-4">
-    <ul class="menu menu-horizontal bg-base-200 rounded-box">
-      {% for audit_period in audit_periods %}
-        <li>
-          <a href="{% url 'new-home' audit_period=audit_period.slug %}" class="{% if audit_period.selected %}active{% endif %}">
-            {{audit_period.display_name}}
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="text-center my-4">
-    <h1 class="text-xl">Select your paediatric diabetes unit</h1>
+    <h1 class="text-xl">
+      {{selected_audit_period_display_name}}
+      <br />
+      Select your paediatric diabetes unit
+    </h1>
   </div>
   <div class="flex flex-row flex-wrap justify-center gap-4 p-4">
     {% for pdu in pdu_choices %}

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -84,6 +84,7 @@ def new_home(request, audit_period):
     context = {
         "pdu_choices": pdu_choices,
         "audit_periods": audit_periods,
+        "selected_audit_period_display_name": audit_period.display_name
     }
 
     template = "new-home.html"


### PR DESCRIPTION
Fixes #1209 

<img width="2798" height="1016" alt="Screenshot 2025-09-02 102309" src="https://github.com/user-attachments/assets/71ce33b7-9cc8-438c-8d75-522081cecebf" />

This solves a problem with the current design where you need to click the audit year in the breadcrumbs to then change the audit year which isn't logical.

We don't really want to bother people with the year selector unless they need it anyway - definitely not at the moment since there's only one open audit year.