### PR TITLE
Skip selector page for users in only one unit

### DIFF
--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -1,9 +1,8 @@
 import re
-from datetime import datetime
 from django.conf import settings
 from django.core.cache import cache
-from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.banner import Banner
+from project.npda.views.npda_users import get_user_home_page
 
 def current_pz_code(request):
     pz_code = None
@@ -45,6 +44,7 @@ def session_data(request):
     # We are fine to trust it here as this is for rendering purposes
     pz_code = current_pz_code(request)
     audit_period_slug = current_audit_period_slug(request)
+    user_home_page = get_user_home_page(audit_period_slug, request.user)
 
     return {
         # Required for the url-data helper
@@ -53,6 +53,7 @@ def session_data(request):
         "audit_years": request.session.get("audit_years", []),
         # Required for switcher
         "selected_audit_year": current_audit_year(audit_period_slug),
+        "user_home_page": user_home_page
     }
 
 

--- a/project/npda/templates/navbar/nav.html
+++ b/project/npda/templates/navbar/nav.html
@@ -28,7 +28,7 @@
         {% include 'navbar/components/nav_links.html' %}
       </ul>
     </div>
-    <a class="btn btn-ghost text-xl h-full" href="{% if 'new_navigation' in request.session.feature_flags %}{% url 'new-home' audit_period=audit_period_slug %}{% else %}{% url 'home' %}{% endif %}">
+    <a class="btn btn-ghost text-xl h-full" href="{% if 'new_navigation' in request.session.feature_flags %}{{ user_home_page }}{% else %}{% url 'home' %}{% endif %}">
       {% comment %} DESKTOP {% endcomment %}
       <span class="hidden lg:flex lg:gap-6 lg:items-center">
         <img class="h-12"

--- a/project/npda/templates/two_factor/core/setup_complete.html
+++ b/project/npda/templates/two_factor/core/setup_complete.html
@@ -15,8 +15,8 @@
     </p>
     {% if request.user %}
       <p>
-        <a href="{% url 'home' %}"
-           class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">{% trans "Go to CSV Upload " %}</a>
+        <a href="{{ user_home_page }}"
+           class="bg-rcpch_light_blue text-white font-semibold hover:text-white py-2.5 px-3 mt-5 border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue">{% trans "Get started" %}</a>
       </p>
     {% endif %}
   </div>

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -120,8 +120,7 @@ class NPDAUserListView(
         if request.htmx:
             # filter the npdausers to only those in the same organisation as the user
             # trigger a GET request from the patient table to update the list of npdausers
-            # by calling the get_queryset method again with the new ods_code/p
-            # z_code stored in session
+            # by calling the get_queryset method again with the new ods_code/pz_code stored in session
 
             return render(
                 request,

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -66,6 +66,17 @@ def _unicode_ci_compare(s1, s2):
         == unicodedata.normalize("NFKC", s2).casefold()
     )
 
+def get_user_home_page(audit_period_slug, user):
+    if not user.is_authenticated:
+        return reverse("home")
+
+    if user.is_superuser or user.is_rcpch_audit_team_member or user.paediatric_diabetes_units.count() > 1:
+        return reverse("new-home", kwargs={"audit_period": audit_period_slug})
+    
+    return reverse("pdu-dashboard", kwargs={
+        "audit_period": audit_period_slug,
+        "pz_code": user.primary_pdu().pz_code,
+    })
 
 """
 NPDAUser list and NPDAUser creation, deletion and update
@@ -109,7 +120,8 @@ class NPDAUserListView(
         if request.htmx:
             # filter the npdausers to only those in the same organisation as the user
             # trigger a GET request from the patient table to update the list of npdausers
-            # by calling the get_queryset method again with the new ods_code/pz_code stored in session
+            # by calling the get_queryset method again with the new ods_code/p
+            # z_code stored in session
 
             return render(
                 request,
@@ -724,10 +736,7 @@ class RCPCHLoginView(TwoFactorLoginView):
                 # Override normal auth flow behaviour, redirect straight to home page
                 audit_period = AuditPeriod.objects.get_default_audit_period()
 
-                return redirect(reverse("pdu-dashboard", kwargs={
-                    "audit_period": audit_period.slug,
-                    "pz_code": user.primary_pdu().pz_code,
-                }))
+                return redirect(get_user_home_page(audit_period.slug, user))
 
         # Otherwise, continue with usual workflow
         response = super().post(*args, **kwargs)
@@ -776,9 +785,6 @@ class RCPCHLoginView(TwoFactorLoginView):
 
             audit_period = AuditPeriod.objects.get_default_audit_period()
 
-            return redirect(reverse("pdu-dashboard", kwargs={
-                "audit_period": audit_period.slug,
-                "pz_code": user.primary_pdu().pz_code,
-            }))
+            return redirect(get_user_home_page(audit_period.slug, user))
         
         return response

--- a/project/settings.py
+++ b/project/settings.py
@@ -239,7 +239,7 @@ AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)  # this
 
 AUTH_USER_MODEL = "npda.NPDAUser"
 LOGIN_URL = "two_factor:login"  # change LOGIN_URL to the 2fa one
-LOGIN_REDIRECT_URL = "two_factor:profile"
+LOGIN_REDIRECT_URL = "home" # not used in practice, see npda_users/get_user_home_page
 LOGOUT_REDIRECT_URL = "two_factor:login"
 
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
When users log in:

- Send them to the new unit selector page if they have more than one unit
  - Even without the new breadcrumb nav turned on, it's better UX
- Send them straight to the unit report if they are only in one unit
  - Unless the new nav feature preview is on, the "home" button still takes you to the old homepage

Once the flag is on by default (#1211) then the home button will take you to the same page you are sent to after you log in.

