### PR TITLE
Remove pdu_choices from session

### DIFF
--- a/project/npda/admin.py
+++ b/project/npda/admin.py
@@ -121,8 +121,6 @@ class SessionAdmin(admin.ModelAdmin):
         "session_key",
         "user_id",
         "pz_code",
-        "organisation_choices",
-        "pdu_choices",
         "expire_date",
     ]
 
@@ -138,16 +136,8 @@ class SessionAdmin(admin.ModelAdmin):
     def pz_code(self, obj):
         return self.session_data(obj).get("pz_code", "N/A")
 
-    def organisation_choices(self, obj):
-        return self.session_data(obj).get("organisation_choices", "N/A")
-
-    def pdu_choices(self, obj):
-        return self.session_data(obj).get("pdu_choices", "N/A")
-
     user_id.short_description = "User ID"
     pz_code.short_description = "PZ Code"
-    organisation_choices.short_description = "Organisation Choices"
-    pdu_choices.short_description = "PDU Choices"
 
 
 admin.site.site_header = "RCPCH National Paediatric Diabetes Audit Admin"

--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -1,6 +1,7 @@
 import re
 from django.conf import settings
 from django.core.cache import cache
+from project.npda.general_functions.organisations_adapter import paediatric_diabetes_units_to_populate_select_field
 from project.npda.models.banner import Banner
 from project.npda.views.npda_users import get_user_home_page
 
@@ -45,6 +46,7 @@ def session_data(request):
     pz_code = current_pz_code(request)
     audit_period_slug = current_audit_period_slug(request)
     user_home_page = get_user_home_page(audit_period_slug, request.user)
+    pdu_choices = paediatric_diabetes_units_to_populate_select_field(request.user) if request.user.is_authenticated else []
 
     return {
         # Required for the url-data helper
@@ -53,7 +55,8 @@ def session_data(request):
         "audit_years": request.session.get("audit_years", []),
         # Required for switcher
         "selected_audit_year": current_audit_year(audit_period_slug),
-        "user_home_page": user_home_page
+        "user_home_page": user_home_page,
+        "pdu_choices": pdu_choices
     }
 
 

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -1,4 +1,3 @@
-from asgiref.sync import sync_to_async
 import logging
 
 from django.apps import apps
@@ -6,10 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 
 # NPDA Imports
-from project.npda.general_functions import (
-    organisations_adapter,
-    get_client_ip,
-)
+from project.npda.general_functions import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +36,6 @@ def create_session_object(user):
     AuditPeriod = apps.get_model("npda", "AuditPeriod")
     
     pz_code = user.primary_pdu().pz_code
-    pdu_choices = (
-        organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
-            requesting_user=user, user_instance=None
-        )
-    )
 
     # This is the year that that audit period starts in
     audit_period = AuditPeriod.objects.get_default_audit_period()
@@ -53,7 +44,6 @@ def create_session_object(user):
 
     session = {
         "pz_code": pz_code,
-        "pdu_choices": list(pdu_choices),
         "selected_audit_year": audit_period.audit_year(),
     } | audit_period_data
 
@@ -90,11 +80,6 @@ def refresh_session_filters(request, pz_code=None, audit_year=None):
             raise PermissionDenied()
 
         session["pz_code"] = pz_code
-        session["pdu_choices"] = list(
-            organisations_adapter.paediatric_diabetes_units_to_populate_select_field(
-                requesting_user=user, user_instance=None
-            )
-        )
     
     session |= get_audit_period_session_data(audit_period, request.user)
 

--- a/project/npda/templates/navbar/components/filters.html
+++ b/project/npda/templates/navbar/components/filters.html
@@ -10,7 +10,7 @@
       </div>
       <div id="global_view_preference"
            class="join-item items-stretch flex-grow  basis-2/4">
-        {% include 'partials/view_preference.html' with view_preference=request.user.view_preference pdu_choices=request.session.pdu_choices chosen_pdu=pz_code hx_target='#global_view_preference' %}
+        {% include 'partials/view_preference.html' with view_preference=request.user.view_preference chosen_pdu=pz_code hx_target='#global_view_preference' %}
       </div>
       <div class="modal-action">
         <form method="dialog">

--- a/project/npda/templates/partials/submission_employer_selector.html
+++ b/project/npda/templates/partials/submission_employer_selector.html
@@ -6,12 +6,12 @@
     <h3 class="font-bold">Important Information</h3>
     <div class="text-xs">
       You are about to upload data to the NPDA for <strong>{{ pdu.pz_code }} ({{ pdu.lead_organisation_name }})</strong>.
-      {% if not request.user.is_rcpch_audit_team_member and request.session.pdu_choices|length > 1 %}
+      {% if not request.user.is_rcpch_audit_team_member and pdu_choices|length > 1 %}
         <p class="text-xs mt-2 mb-2">
           If this is incorrect, please select the correct employer below.
         </p>
         <form class="filter">
-          {% for pdu_choice in request.session.pdu_choices %}
+          {% for pdu_choice in pdu_choices %}
             {% if pdu_choice.0 != pdu.pz_code %}
             <a class="btn text-xs" href="{% data_url 'pdu-upload-csv' pz_code=pdu_choice.0 %}">
               {{ pdu_choice.0 }} ({{ pdu_choice.1 }})

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse
 
 from project.constants.feature_flags import FEATURE_FLAGS
 from project.npda.general_functions.csv import csv_header
+from project.npda.general_functions.organisations_adapter import paediatric_diabetes_units_to_populate_select_field
 from ..general_functions.session import refresh_session_filters
 
 # RCPCH imports
@@ -54,20 +55,13 @@ def home(request):
     Home page view.
     Only verified users can access this page.
     """
-    pdu_choices = request.session.get("pdu_choices", [])
-    pdu_choices.sort(key=lambda pdu: pdu[0])
-
-    context = {
-        "pdu_choices": pdu_choices,
-    }
-    
     template = "home.html"
-    return render(request=request, template_name=template, context=context)
+    return render(request=request, template_name=template, context={})
 
 
 @login_and_otp_required()
 def new_home(request, audit_period):
-    pdu_choices = request.session.get("pdu_choices", [])
+    pdu_choices = paediatric_diabetes_units_to_populate_select_field(request.user)
 
     # Put the test PZ999 at the top of the list otherwise it's hard to find!
     pdu_choices.sort(key=lambda pdu: "" if pdu[0] == "PZ999" else pdu[0])


### PR DESCRIPTION
Part of #1195. This does mean a database query to load the PDU choices on every page but that will go once we roll out the new navigation and the switcher is on a separate page.

Doing this for tech debt reasons but has the nice side benefit that users don't need to log out and back in again when they're granted access to a new PDU to select it.