### PR TITLE
Replace audit_years in session with context

### DIFF
--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.cache import cache
 from project.npda.general_functions.organisations_adapter import paediatric_diabetes_units_to_populate_select_field
 from project.npda.models.banner import Banner
+from project.npda.models.audit_period import AuditPeriod
 from project.npda.views.npda_users import get_user_home_page
 
 def current_pz_code(request):
@@ -31,31 +32,36 @@ def current_audit_period_slug(request):
 
     return audit_period_slug
 
-# Temporary hack until switcher removed so you can only change audit period by following links
-def current_audit_year(audit_period_slug):
-    if audit_period_slug:
-        start_year = int(audit_period_slug.split("-")[0])
-        return start_year
+
+def get_audit_periods_user_can_see(user):
+    audit_periods = []
+
+    for audit_period in AuditPeriod.objects.order_by("start_date").all():
+        if audit_period.is_visible or user.is_rcpch_audit_team_member or user.is_superuser:
+            audit_periods.append(audit_period)
     
-    return None
+    return audit_periods
 
 
-def session_data(request):
+def context_from_request(request):
     # Permission checking done in @check_data_permissions or PDUPermissionMixin
     # We are fine to trust it here as this is for rendering purposes
     pz_code = current_pz_code(request)
     audit_period_slug = current_audit_period_slug(request)
+
     user_home_page = get_user_home_page(audit_period_slug, request.user)
+
     pdu_choices = paediatric_diabetes_units_to_populate_select_field(request.user) if request.user.is_authenticated else []
+    audit_period_choices = get_audit_periods_user_can_see(request.user) if request.user.is_authenticated else []
 
     return {
         # Required for the url-data helper
         "pz_code": pz_code,
         "audit_period_slug": audit_period_slug,
-        "audit_years": request.session.get("audit_years", []),
-        # Required for switcher
-        "selected_audit_year": current_audit_year(audit_period_slug),
+        # Require for the nav
         "user_home_page": user_home_page,
+        # Required for switcher
+        "audit_period_choices": audit_period_choices,
         "pdu_choices": pdu_choices
     }
 

--- a/project/npda/general_functions/session.py
+++ b/project/npda/general_functions/session.py
@@ -10,24 +10,6 @@ from project.npda.general_functions import get_client_ip
 logger = logging.getLogger(__name__)
 
 
-def get_audit_period_session_data(audit_period, user):
-    AuditPeriod = apps.get_model("npda", "AuditPeriod")
-    audit_years = []
-
-    for audit_period in AuditPeriod.objects.order_by("start_date").all():
-        if audit_period.is_visible or user.is_rcpch_audit_team_member or user.is_superuser:
-            audit_years.append(
-                {
-                    "year": audit_period.audit_year(),
-                    "slug": audit_period.slug
-                }
-            )
-    
-    return {
-        "audit_years": audit_years
-    }
-
-
 def create_session_object(user):
     """
     Create a session object for the user, based on their permissions.
@@ -40,14 +22,10 @@ def create_session_object(user):
     # This is the year that that audit period starts in
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    audit_period_data = get_audit_period_session_data(audit_period, user)
-
-    session = {
+    return {
         "pz_code": pz_code,
         "selected_audit_year": audit_period.audit_year(),
-    } | audit_period_data
-
-    return session
+    }
 
 
 def refresh_session_filters(request, pz_code=None, audit_year=None):
@@ -59,11 +37,12 @@ def refresh_session_filters(request, pz_code=None, audit_year=None):
 
     audit_year = audit_year or request.session.get("selected_audit_year")
 
+    # Check it's a real audit period
     audit_period = AuditPeriod.objects.get(
         start_date__year=audit_year
     )
 
-    session["selected_audit_year"] = audit_year
+    session["selected_audit_year"] = audit_period.audit_year()
 
     if pz_code:
         user = request.user
@@ -80,8 +59,6 @@ def refresh_session_filters(request, pz_code=None, audit_year=None):
             raise PermissionDenied()
 
         session["pz_code"] = pz_code
-    
-    session |= get_audit_period_session_data(audit_period, request.user)
 
     request.session.update(session)
     request.session.modified = True

--- a/project/npda/templates/navbar/components/avatar_dropdown.html
+++ b/project/npda/templates/navbar/components/avatar_dropdown.html
@@ -24,10 +24,10 @@
         <li>
           <select title="Select audit year"
             _="on change go to url `$my.value`" >
-          {% for audit_year in request.session.audit_years %}
-            <option value="{% url 'new-home' audit_period=audit_year.slug %}"
-              {% if selected_audit_year|stringformat:"s" == audit_year.year|stringformat:"s" %} selected {% endif %}>
-              April {{ audit_year.year }} - March {{ audit_year.year|add:'1' }}
+          {% for audit_period in audit_period_choices %}
+            <option value="{% url 'new-home' audit_period=audit_period.slug %}"
+              {% if audit_period_slug == audit_period.slug %} selected {% endif %}>
+              {{audit_period.display_name}}
             </option>
           {% endfor %}
           </select>

--- a/project/npda/templates/navbar/components/filters.html
+++ b/project/npda/templates/navbar/components/filters.html
@@ -6,7 +6,7 @@
     <div class="modal-box">
       <div id="global_audit_year"
            class="join-item items-stretch flex-grow basis-1/5">
-        {% include 'partials/audit_year_select.html' with audit_years=request.session.audit_years selected_audit_year=selected_audit_year hx_target='#global_audit_year' %}
+        {% include 'partials/audit_year_select.html' with hx_target='#global_audit_year' %}
       </div>
       <div id="global_view_preference"
            class="join-item items-stretch flex-grow  basis-2/4">

--- a/project/npda/templates/partials/audit_year_select.html
+++ b/project/npda/templates/partials/audit_year_select.html
@@ -15,10 +15,11 @@
           hx-trigger="change"
           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
           hx-include="[name='audit_year_select_name']">
-    {% for audit_year in audit_years %}
-      <option value="{{ audit_year.year|stringformat:'s' }}"
-              {% if selected_audit_year|stringformat:"s" == audit_year.year|stringformat:"s" %} selected {% endif %}>
-        April {{ audit_year.year }} - March {{ audit_year.year|add:'1' }}
+    {% for audit_period in audit_period_choices %}
+      {% comment %}the value must be year for compat with old code. TODO MRB: can remove once we remove the old switcher{% endcomment %}
+      <option value="{{ audit_period.audit_year|stringformat:'s' }}"
+              {% if audit_period_slug == audit_period.slug %} selected {% endif %}>
+        {{audit_period.display_name}}
       </option>
     {% endfor %}
   </select>

--- a/project/settings.py
+++ b/project/settings.py
@@ -177,7 +177,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "project.npda.build_info.get_build_info",
-                "project.npda.context_processors.session_data",
+                "project.npda.context_processors.context_from_request",
                 "project.npda.context_processors.context_from_settings",
                 "project.npda.context_processors.banner",
                 # Autologout


### PR DESCRIPTION
Part of #1195 

We can replace `audit_years` in the session with looking up the audit periods the user can see when building the context.

Once we roll out the new navigation and remove the global filters switcher we can then remove it from the context entirely.

`selected_audit_year` and `pz_code` have to remain in the session until we do that, otherwise we won't know how to set the selected PDU and audit year in the switcher.