### PR TITLE
Fix crash in unit report before submission

### DIFF
--- a/project/npda/tests/view_tests/dashboard/test_partials.py
+++ b/project/npda/tests/view_tests/dashboard/test_partials.py
@@ -171,3 +171,37 @@ def test_moved_out_of_area_includes_patients_without_visits(
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 1
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        pytest.param("pdu-get-new-diagnoses-partial"),
+        pytest.param("pdu-get-transitioned-to-adult-service-partial"),
+        pytest.param("pdu-get-moved-out-of-area-partial"),
+    ],
+)
+@pytest.mark.django_db
+def test_partials_before_submission(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    route
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+
+    client = login_and_verify_user(client, user)
+
+    response = client.get(reverse(route, kwargs={
+        "audit_period": audit_period.slug,
+        "pz_code": ALDER_HEY_PZ_CODE
+    }))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.context["number"] == 0

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -242,7 +242,11 @@ def get_new_diagnoses_partial(request, audit_period, pdu):
     """HTMX view that returns the number of new diagnoses for the current submission"""
 
     sub = Submission.objects.get_submission_for_request(pdu, audit_period)
-    count = sub.patients.filter(diagnosis_date__gte=audit_period.start_date).count()
+
+    if sub:
+        count = sub.patients.filter(diagnosis_date__gte=audit_period.start_date).count()
+    else:
+        count = 0
 
     context = {
         "number": count,
@@ -289,7 +293,11 @@ def get_transitioned_to_adult_service_partial(request, audit_period, pdu):
     """HTMX view that returns the number of patients who have been transitioned to the adult service"""
 
     sub = Submission.objects.get_submission_for_request(pdu, audit_period)
-    count = sub.patients.filter(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[0][0]).count()
+
+    if sub:
+        count = sub.patients.filter(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[0][0]).count()
+    else:
+        count = 0
 
     context = {
         "number": count,
@@ -310,7 +318,11 @@ def get_moved_out_of_area_partial(request, audit_period, pdu):
     """HTMX view that returns the number of patients who have been moved out of area"""
 
     sub = Submission.objects.get_submission_for_request(pdu, audit_period)
-    count = sub.patients.filter(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[1][0]).count()
+
+    if sub:
+        count = sub.patients.filter(paediatric_diabetes_units__reason_leaving_service=LEAVE_PDU_REASONS[1][0]).count()
+    else:
+        count = 0
 
     context = {"number": count, "units": "children"}
 


### PR DESCRIPTION
Follow up to #1225 where I forgot that units might not have a submission if they have never submitted before!