### PR TITLE
Upgrade Django to fix dependabot warning

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ httpx==0.27.2
 ## django and misc
 channels==4.2.0
 dj_database_url==2.1.0
-django==5.2.3
+django==5.2.6
 django-filter==23.5
 django-htmx==1.17.3
 django-two-factor-auth==1.16.0


### PR DESCRIPTION
https://github.com/rcpch/national-paediatric-diabetes-audit/security/dependabot/12