### PR TITLE
Allow carb counting date outside of audit year

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -624,6 +624,9 @@ class VisitForm(forms.ModelForm):
 
     def clean_carbohydrate_counting_level_three_education_date(self):
         data = self.cleaned_data["carbohydrate_counting_level_three_education_date"]
+
+        # Don't pass audit_period - carb counting is required within 14 days of diagnosis
+        # so can fall outside of the outside of the audit period
         valid, error = validate_date(
             date_under_examination_field_name="carbohydrate_counting_level_three_education_date",
             date_under_examination_label_name="Date of Level 3 carbohydrate counting education received",
@@ -631,8 +634,8 @@ class VisitForm(forms.ModelForm):
             date_of_birth=self.patient.date_of_birth,
             date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
+
         if valid == False:
             raise ValidationError(error)
 

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -2243,28 +2243,3 @@ def test_carb_counting_date_outside_of_audit_year_passes_validation_if_patient_d
 
     assert form.is_valid()
 
-
-@pytest.mark.django_db
-def test_missing_carb_counting_date_fails_validation_if_deadline_falls_within_audit_year():
-    audit_period = AuditPeriod.objects.create(
-        start_date=datetime.date(2024, 4, 1),
-        end_date=datetime.date(2025, 3, 31),
-        is_open=True,
-        is_visible=True
-    )
-
-    patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2024, 3, 31)
-    patient.save()
-
-    form = VisitForm(
-        data={
-            "visit_date": "2025-01-01",  # Required for validation
-            "carbohydrate_counting_level_three_education_date": None,
-        },
-        initial={"patient": patient},
-        audit_period=audit_period
-    )
-
-    assert not form.is_valid()
-    assert "carbohydrate_counting_level_three_education_date" in form.errors

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -2217,3 +2217,54 @@ def test_visit_form_dates_outside_of_audit_period(test_case_index, test_data):
     # Verify that visit_date is always in errors (since all test cases have dates outside audit period)
     assert "visit_date" in form.errors, f"Test case {i+1} ({tested_field}): visit_date should be in form errors"
     assert tested_field in form.errors, f"Test case {i+1} ({tested_field}): {tested_field} should be in form errors"
+
+
+@pytest.mark.django_db
+def test_carb_counting_date_outside_of_audit_year_passes_validation_if_patient_diagnosed_before_audit_year():
+    audit_period = AuditPeriod.objects.create(
+        start_date=datetime.date(2024, 4, 1),
+        end_date=datetime.date(2025, 3, 31),
+        is_open=True,
+        is_visible=True
+    )
+
+    patient = PatientFactory()
+    patient.diagnosis_date = datetime.date(2023, 1, 1)
+    patient.save()
+
+    form = VisitForm(
+        data={
+            "visit_date": "2025-01-01",  # Required for validation
+            "carbohydrate_counting_level_three_education_date": "2024-01-01",
+        },
+        initial={"patient": patient},
+        audit_period=audit_period
+    )
+
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_missing_carb_counting_date_fails_validation_if_deadline_falls_within_audit_year():
+    audit_period = AuditPeriod.objects.create(
+        start_date=datetime.date(2024, 4, 1),
+        end_date=datetime.date(2025, 3, 31),
+        is_open=True,
+        is_visible=True
+    )
+
+    patient = PatientFactory()
+    patient.diagnosis_date = datetime.date(2024, 3, 31)
+    patient.save()
+
+    form = VisitForm(
+        data={
+            "visit_date": "2025-01-01",  # Required for validation
+            "carbohydrate_counting_level_three_education_date": None,
+        },
+        initial={"patient": patient},
+        audit_period=audit_period
+    )
+
+    assert not form.is_valid()
+    assert "carbohydrate_counting_level_three_education_date" in form.errors

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4113,7 +4113,7 @@ def test_visit_form_dates_outside_of_audit_period(test_user, single_row_valid_df
         coeliac_screen_date
         psychological_screening_assessment_date
         smoking_cessation_referral_date
-        carbohydrate_counting_level_three_education_date
+        carbohydrate_counting_level_three_education_date NOT INCLUDED (https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1237)
         dietician_additional_appointment_date
         flu_immunisation_recommended_date
         sick_day_rules_training_date
@@ -4134,7 +4134,8 @@ def test_visit_form_dates_outside_of_audit_period(test_user, single_row_valid_df
     for date_field in ALL_VISIT_DATES:
         single_row_valid_df.loc[0, date_field] = "01/01/2020"
     
-    # REMOVE the hospital discharge date as this is not included in the test
+    # Remove the dates not included in the test
+    ALL_VISIT_DATES.remove(("carbohydrate_counting_level_three_education_date", "Date of Level 3 carbohydrate counting education received"))
     ALL_VISIT_DATES.remove(("hospital_discharge_date", "Discharge date (Hospital provider spell)"))
 
     assert Visit.objects.count() == 0, "Expected no visits to be created before the test"


### PR DESCRIPTION
Feedback from NPDA webinar - we flag carb counting date outside of the audit year as a data quality error but some CSV files are generated with it in regardless of whether the deadline for carb counting falls within the audit year.

This PR changes the validation to no longer consider the audit year. It's still flagged as an error if the date is before date of diagnosis etc.