### PR TITLE
Fix health checks and additional care processes in patient report for patients with incomplete year of care

### DIFF
--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -2114,6 +2114,7 @@ class CalculateKPIS:
 
     def calculate_kpi_25_hba1c(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 25: HbA1c (%)
@@ -2123,9 +2124,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2156,6 +2157,7 @@ class CalculateKPIS:
 
     def calculate_kpi_26_bmi(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 26: BMI (%)
@@ -2164,9 +2166,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2199,6 +2201,7 @@ class CalculateKPIS:
 
     def calculate_kpi_27_thyroid_screen(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 27: Thyroid Screen (%)
@@ -2207,9 +2210,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2240,6 +2243,7 @@ class CalculateKPIS:
 
     def calculate_kpi_28_blood_pressure(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 28: Blood Pressure (%)
@@ -2250,9 +2254,9 @@ class CalculateKPIS:
 
         # NOTE: Does not need a valid diastolic measurement
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -2284,6 +2288,7 @@ class CalculateKPIS:
 
     def calculate_kpi_29_urinary_albumin(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 29: Urinary Albumin (%)
@@ -2292,9 +2297,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -2327,6 +2332,7 @@ class CalculateKPIS:
 
     def calculate_kpi_30_retinal_screening(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 30: Retinal Screening (%)
@@ -2335,9 +2341,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -2374,6 +2380,7 @@ class CalculateKPIS:
 
     def calculate_kpi_31_foot_examination(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 31: Foot Examination (%)
@@ -2382,9 +2389,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -2856,6 +2863,7 @@ class CalculateKPIS:
 
     def calculate_kpi_33_hba1c_4plus(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 33: HbA1c 4+ (%)
@@ -2864,9 +2872,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2908,6 +2916,7 @@ class CalculateKPIS:
 
     def calculate_kpi_34_psychological_assessment(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 34: Psychological assessment (%)
@@ -2916,9 +2925,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2959,6 +2968,7 @@ class CalculateKPIS:
 
     def calculate_kpi_35_smoking_status_screened(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 35: Smoking status screened (%)
@@ -2967,9 +2977,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -3016,6 +3026,7 @@ class CalculateKPIS:
 
     def calculate_kpi_36_referral_to_smoking_cessation_service(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 36: Referral to smoking cessation service (%)
@@ -3024,9 +3035,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = (
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+
+        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
 
         eligible_patients = kpi_6_total_eligible_query_set
         total_eligible = total_eligible_kpi_6
@@ -3066,6 +3077,7 @@ class CalculateKPIS:
 
     def calculate_kpi_37_additional_dietetic_appointment_offered(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 37: Additional dietetic appointment offered (%)
@@ -3074,9 +3086,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -3115,6 +3127,7 @@ class CalculateKPIS:
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 38: Patients attending additional dietetic appointment (%)
@@ -3123,9 +3136,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -3167,6 +3180,7 @@ class CalculateKPIS:
 
     def calculate_kpi_39_influenza_immunisation_recommended(
         self,
+        denominatorFn = None
     ) -> KPIResult:
         """
         Calculates KPI 39: Influenza immunisation recommended (%)
@@ -3175,9 +3189,9 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
-        )
+        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -397,7 +397,7 @@ class CalculateKPIS:
         """
 
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         # This is same as KPI1 but with an additional filter for diagnosis date
@@ -443,7 +443,7 @@ class CalculateKPIS:
 
         # Denominator - eligible pts
         total_kpi_1_eligible_pts_base_query_set, total_eligible_kpi_1 = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         # Get quarter dates
@@ -528,7 +528,7 @@ class CalculateKPIS:
         the returned KPIResult object.
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -567,7 +567,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def _get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count(
+    def _get_kpi_3_total_t1dm_pts_and_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """
@@ -598,7 +598,7 @@ class CalculateKPIS:
         """
 
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -657,7 +657,7 @@ class CalculateKPIS:
         """
         # If we have not already calculated KPI 1, do so now to set
         total_kpi_1_eligible_pts_base_query_set, total_eligible_kpi_1 = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = total_kpi_1_eligible_pts_base_query_set.filter(
@@ -732,7 +732,7 @@ class CalculateKPIS:
         """
 
         base_eligible_patients, total_eligible = (
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count()
         )
 
         # Gte 12yo
@@ -920,7 +920,7 @@ class CalculateKPIS:
         the returned KPIResult object.
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -967,7 +967,7 @@ class CalculateKPIS:
         the returned KPIResult object.
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -1019,7 +1019,7 @@ class CalculateKPIS:
         the returned KPIResult object.
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -1074,7 +1074,7 @@ class CalculateKPIS:
 
         # Denominator - eligible pts
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -1143,7 +1143,7 @@ class CalculateKPIS:
         KPI 9 + transitioned to adult service + this month
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         today = date.today()
@@ -1173,7 +1173,7 @@ class CalculateKPIS:
         KPI 9 + moved out of area + this month
         """
         base_eligible_patients, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = base_eligible_patients.filter(
@@ -1224,7 +1224,7 @@ class CalculateKPIS:
 
         # Filter the Patient queryset based on the subquery
         base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         eligible_patients = base_query_set.filter(
             Q(
@@ -1284,7 +1284,7 @@ class CalculateKPIS:
 
         # Filter the Patient queryset based on the subquery
         base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         eligible_patients = base_query_set.filter(
             Q(
@@ -1342,7 +1342,7 @@ class CalculateKPIS:
 
         # Filter the Patient queryset based on the subquery
         base_query_set, _ = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         eligible_patients = base_query_set.filter(
             Q(
@@ -1392,7 +1392,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
             if eligible_patients is None
             else (eligible_patients, eligible_patients.count())
         )
@@ -1447,7 +1447,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
             if eligible_patients is None
             else (eligible_patients, eligible_patients.count())
         )
@@ -1502,14 +1502,14 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients  - all patients with T1DM (including those with incomplete year of care)
         """
         # eligible_patients, total_eligible = (
-        #     self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+        #     self._get_total_kpi_1_pts_and_count()
         #     if eligible_patients is None
         #     else (eligible_patients, eligible_patients.count())
         # )
 
         # Denominator
         total_kpi_3_eligible_pts_base_query_set, _ = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
 
         total_eligible_kpi_t1dm = total_kpi_3_eligible_pts_base_query_set.count()
@@ -1560,7 +1560,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         total_ineligible = self.total_patients_count - total_eligible
@@ -1611,7 +1611,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1659,7 +1659,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients with type 1 diabetes (measure 3)
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1709,7 +1709,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1759,7 +1759,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1809,7 +1809,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1855,7 +1855,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients with Type 1 diabetes (measure 3)
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1901,7 +1901,7 @@ class CalculateKPIS:
         Denominator: Number of eligible patients whose most recent entry (based on visit date) for blood glucose monitoring (item 22) is 4 = Real time continuous glucose monitor with alarms
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
 
         total_ineligible = self.total_patients_count - total_eligible
@@ -1956,7 +1956,7 @@ class CalculateKPIS:
         """
         # Denominator
         total_kpi_3_eligible_pts_base_query_set, _ = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
 
         
@@ -2031,7 +2031,7 @@ class CalculateKPIS:
 
         # Denominator - eligible pts
         total_kpi_3_eligible_pts_base_query_set, total_eligible_kpi_3 = (
-            self._total_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._total_kpi_3_pts_and_count()
         )
         
         total_eligible_kpi_t1dm = total_kpi_3_eligible_pts_base_query_set.count()
@@ -2114,12 +2114,12 @@ class CalculateKPIS:
 
     def calculate_kpi_25_hba1c(self):
         return self._calculate_kpi_25_hba1c(
-            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_25_hba1c_for_patient_report_table(self):
         return self._calculate_kpi_25_hba1c(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_25_hba1c(
@@ -2162,12 +2162,12 @@ class CalculateKPIS:
 
     def calculate_kpi_26_bmi(self) -> KPIResult:
         return self._calculate_kpi_26_bmi(
-            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_26_bmi_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_26_bmi(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_26_bmi(
@@ -2211,12 +2211,12 @@ class CalculateKPIS:
 
     def calculate_kpi_27_thyroid_screen(self) -> KPIResult:
         return self._calculate_kpi_27_thyroid_screen(
-            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_27_thyroid_screen_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_27_thyroid_screen(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_27_thyroid_screen(
@@ -2258,12 +2258,12 @@ class CalculateKPIS:
 
     def calculate_kpi_28_blood_pressure(self) -> KPIResult:
         return self._calculate_kpi_28_blood_pressure(
-            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_28_blood_pressure_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_28_blood_pressure(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_28_blood_pressure(
@@ -2308,12 +2308,12 @@ class CalculateKPIS:
 
     def calculate_kpi_29_urinary_albumin(self) -> KPIResult:
         return self._calculate_kpi_29_urinary_albumin(
-            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_29_urinary_albumin_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_29_urinary_albumin(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_29_urinary_albumin(
@@ -2357,12 +2357,12 @@ class CalculateKPIS:
 
     def calculate_kpi_30_retinal_screening(self) -> KPIResult:
         return self._calculate_kpi_30_retinal_screening(
-            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_30_retinal_screening_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_30_retinal_screening(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_30_retinal_screening(
@@ -2410,12 +2410,12 @@ class CalculateKPIS:
 
     def calculate_kpi_31_foot_examination(self) -> KPIResult:
         return self._calculate_kpi_31_foot_examination(
-            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_31_foot_examination_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_31_foot_examination(
-            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_31_foot_examination(
@@ -2485,7 +2485,7 @@ class CalculateKPIS:
         # Get the eligible patients
         base_eligible_query_set, base_total_eligible = (
             # Pts with T1DM and a complete year of care
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count()
         )
         total_ineligible = self.total_patients_count - base_total_eligible
 
@@ -2870,7 +2870,7 @@ class CalculateKPIS:
             return self.eligible_pts_lt_12yo
 
         base_eligible_query_set, _ = (
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count()
         )
 
         self.eligible_patients_lt_12yo = base_eligible_query_set.filter(
@@ -2887,7 +2887,7 @@ class CalculateKPIS:
             return self.eligible_patients_gte_12yo
 
         base_eligible_query_set, _ = (
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count()
         )
 
         self.eligible_patients_gte_12yo = base_eligible_query_set.filter(
@@ -2898,12 +2898,12 @@ class CalculateKPIS:
 
     def calculate_kpi_33_hba1c_4plus(self) -> KPIResult:
         return self._calculate_kpi_33_hba1c_4plus(
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_33_hba1c_4plus_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_33_hba1c_4plus(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_33_hba1c_4plus(
@@ -2956,12 +2956,12 @@ class CalculateKPIS:
 
     def calculate_kpi_34_psychological_assessment(self) -> KPIResult:
         return self._calculate_kpi_34_psychological_assessment(
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_34_psychological_assessment_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_34_psychological_assessment(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_34_psychological_assessment(
@@ -3013,12 +3013,12 @@ class CalculateKPIS:
 
     def calculate_kpi_35_smoking_status_screened(self) -> KPIResult:
         return self._calculate_kpi_35_smoking_status_screened(
-            self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_35_smoking_status_screened_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_35_smoking_status_screened(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_35_smoking_status_screened(
@@ -3076,12 +3076,12 @@ class CalculateKPIS:
 
     def calculate_kpi_36_referral_to_smoking_cessation_service(self) -> KPIResult:
         return self._calculate_kpi_36_referral_to_smoking_cessation_service(
-            self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
     def calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_36_referral_to_smoking_cessation_service(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_36_referral_to_smoking_cessation_service(
@@ -3132,12 +3132,12 @@ class CalculateKPIS:
 
     def calculate_kpi_37_additional_dietetic_appointment_offered(self) -> KPIResult:
         return self._calculate_kpi_37_additional_dietetic_appointment_offered(
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_37_additional_dietetic_appointment_offered(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_37_additional_dietetic_appointment_offered(
@@ -3190,12 +3190,12 @@ class CalculateKPIS:
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment(self) -> KPIResult:
         return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_38_patients_attending_additional_dietetic_appointment(
@@ -3251,12 +3251,12 @@ class CalculateKPIS:
 
     def calculate_kpi_39_influenza_immunisation_recommended(self) -> KPIResult:
         return self._calculate_kpi_39_influenza_immunisation_recommended(
-            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
     def calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_39_influenza_immunisation_recommended(
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_39_influenza_immunisation_recommended(
@@ -3322,7 +3322,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         kpi_1_total_eligible_query_set, total_eligible_kpi_1 = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         eligible_patients = kpi_1_total_eligible_query_set
@@ -3478,7 +3478,7 @@ class CalculateKPIS:
         # Eligible patients are measure 7 with
         # diagnosis date < (AUDIT_END_DATE - 14 days)
         base_eligible_patients, _ = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
         eligible_patients = base_eligible_patients.filter(
             diagnosis_date__lt=self.audit_end_date - relativedelta(days=14)
@@ -3543,7 +3543,7 @@ class CalculateKPIS:
             others should be discarded.
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -3665,7 +3665,7 @@ class CalculateKPIS:
             others should be discarded.
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -3733,7 +3733,7 @@ class CalculateKPIS:
         Can't re-use the existing methods as they don't stratify.
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         # Filter eligible patients to just relevant diabetes types
@@ -3887,7 +3887,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -3945,7 +3945,7 @@ class CalculateKPIS:
 
         # Denominator - eligible pts
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
 
         # Find patients with at least one valid admission
@@ -4104,7 +4104,7 @@ class CalculateKPIS:
         KPI 46 calculation, but for now keeping separate
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -4184,7 +4184,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -4237,7 +4237,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients (measure 1)
         """
         eligible_patients, total_eligible = (
-            self._get_total_kpi_1_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_1_pts_and_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -4294,7 +4294,7 @@ class CalculateKPIS:
 
         logger.debug(f"====================")
 
-    def _get_total_kpi_1_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_1_pts_and_count(
         self,
     ) -> Tuple[QuerySet[Patient], int]:
         """Enables reuse of the base query set for KPI 1
@@ -4316,7 +4316,7 @@ class CalculateKPIS:
             self.kpi_1_total_eligible,
         )
 
-    def _get_total_kpi_2_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_2_pts_and_count(
         self,
     ) -> Tuple[QuerySet[Patient], int]:
         """Enables reuse of the base query set for KPI 2
@@ -4338,7 +4338,7 @@ class CalculateKPIS:
             self.kpi_2_total_eligible,
         )
 
-    def _get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_5_total_t1dm_complete_year_pts_and_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """Enables reuse of the base query set for KPI 5
@@ -4360,7 +4360,7 @@ class CalculateKPIS:
             self.kpi_5_total_eligible,
         )
 
-    def _get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """Enables reuse of the base query set for KPI 6
@@ -4382,7 +4382,7 @@ class CalculateKPIS:
             self.kpi_6_total_eligible,
         )
 
-    def _get_total_kpi_7_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_7_pts_and_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """Enables reuse of the base query set for KPI 7
@@ -4425,7 +4425,7 @@ class CalculateKPIS:
 
         # First get new T1DM diagnoses pts
         base_query_set, _ = (
-            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_pts_and_count()
         )
 
         # Filter for those diagnoses at least 90 days before audit end date

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -567,7 +567,7 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def _get_kpi_3_eligible_pts_base_query_set_and_total_count(
+    def _get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """
@@ -732,7 +732,7 @@ class CalculateKPIS:
         """
 
         base_eligible_patients, total_eligible = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
         )
 
         # Gte 12yo
@@ -1509,7 +1509,7 @@ class CalculateKPIS:
 
         # Denominator
         total_kpi_3_eligible_pts_base_query_set, _ = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
 
         total_eligible_kpi_t1dm = total_kpi_3_eligible_pts_base_query_set.count()
@@ -1659,7 +1659,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients with type 1 diabetes (measure 3)
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1855,7 +1855,7 @@ class CalculateKPIS:
         Denominator: Total number of eligible patients with Type 1 diabetes (measure 3)
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1901,7 +1901,7 @@ class CalculateKPIS:
         Denominator: Number of eligible patients whose most recent entry (based on visit date) for blood glucose monitoring (item 22) is 4 = Real time continuous glucose monitor with alarms
         """
         eligible_patients, total_eligible = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
 
         total_ineligible = self.total_patients_count - total_eligible
@@ -1956,7 +1956,7 @@ class CalculateKPIS:
         """
         # Denominator
         total_kpi_3_eligible_pts_base_query_set, _ = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
 
         
@@ -2114,17 +2114,17 @@ class CalculateKPIS:
 
     def calculate_kpi_25_hba1c(self):
         return self._calculate_kpi_25_hba1c(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_25_hba1c_for_patient_report_table(self):
         return self._calculate_kpi_25_hba1c(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_25_hba1c(
         self,
-        denominator_fn
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 25: HbA1c (%)
@@ -2134,10 +2134,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = denominator_fn()
-
-        eligible_patients = kpi_5_total_eligible_query_set
-        total_eligible = total_eligible_kpi_5
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid entry for HbA1c value (item 17) with an observation date (item 19) within the audit period
@@ -2165,12 +2162,12 @@ class CalculateKPIS:
 
     def calculate_kpi_26_bmi(self) -> KPIResult:
         return self._calculate_kpi_26_bmi(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_26_bmi_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_26_bmi(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_26_bmi(
@@ -2214,12 +2211,12 @@ class CalculateKPIS:
 
     def calculate_kpi_27_thyroid_screen(self) -> KPIResult:
         return self._calculate_kpi_27_thyroid_screen(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_27_thyroid_screen_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_27_thyroid_screen(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_27_thyroid_screen(
@@ -2261,12 +2258,12 @@ class CalculateKPIS:
 
     def calculate_kpi_28_blood_pressure(self) -> KPIResult:
         return self._calculate_kpi_28_blood_pressure(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_28_blood_pressure_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_28_blood_pressure(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_28_blood_pressure(
@@ -2311,12 +2308,12 @@ class CalculateKPIS:
 
     def calculate_kpi_29_urinary_albumin(self) -> KPIResult:
         return self._calculate_kpi_29_urinary_albumin(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_29_urinary_albumin_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_29_urinary_albumin(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_29_urinary_albumin(
@@ -2360,12 +2357,12 @@ class CalculateKPIS:
 
     def calculate_kpi_30_retinal_screening(self) -> KPIResult:
         return self._calculate_kpi_30_retinal_screening(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_30_retinal_screening_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_30_retinal_screening(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_30_retinal_screening(
@@ -2413,12 +2410,12 @@ class CalculateKPIS:
 
     def calculate_kpi_31_foot_examination(self) -> KPIResult:
         return self._calculate_kpi_31_foot_examination(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_31_foot_examination_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_31_foot_examination(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            denominator=self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_31_foot_examination(
@@ -2488,7 +2485,7 @@ class CalculateKPIS:
         # Get the eligible patients
         base_eligible_query_set, base_total_eligible = (
             # Pts with T1DM and a complete year of care
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
         )
         total_ineligible = self.total_patients_count - base_total_eligible
 
@@ -2873,7 +2870,7 @@ class CalculateKPIS:
             return self.eligible_pts_lt_12yo
 
         base_eligible_query_set, _ = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
         )
 
         self.eligible_patients_lt_12yo = base_eligible_query_set.filter(
@@ -2890,7 +2887,7 @@ class CalculateKPIS:
             return self.eligible_patients_gte_12yo
 
         base_eligible_query_set, _ = (
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count()
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count()
         )
 
         self.eligible_patients_gte_12yo = base_eligible_query_set.filter(
@@ -2901,12 +2898,12 @@ class CalculateKPIS:
 
     def calculate_kpi_33_hba1c_4plus(self) -> KPIResult:
         return self._calculate_kpi_33_hba1c_4plus(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_33_hba1c_4plus_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_33_hba1c_4plus(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_33_hba1c_4plus(
@@ -2959,12 +2956,12 @@ class CalculateKPIS:
 
     def calculate_kpi_34_psychological_assessment(self) -> KPIResult:
         return self._calculate_kpi_34_psychological_assessment(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_34_psychological_assessment_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_34_psychological_assessment(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_34_psychological_assessment(
@@ -3016,12 +3013,12 @@ class CalculateKPIS:
 
     def calculate_kpi_35_smoking_status_screened(self) -> KPIResult:
         return self._calculate_kpi_35_smoking_status_screened(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_35_smoking_status_screened_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_35_smoking_status_screened(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_35_smoking_status_screened(
@@ -3079,12 +3076,12 @@ class CalculateKPIS:
 
     def calculate_kpi_36_referral_to_smoking_cessation_service(self) -> KPIResult:
         return self._calculate_kpi_36_referral_to_smoking_cessation_service(
-            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_36_referral_to_smoking_cessation_service(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_36_referral_to_smoking_cessation_service(
@@ -3135,12 +3132,12 @@ class CalculateKPIS:
 
     def calculate_kpi_37_additional_dietetic_appointment_offered(self) -> KPIResult:
         return self._calculate_kpi_37_additional_dietetic_appointment_offered(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_37_additional_dietetic_appointment_offered(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_37_additional_dietetic_appointment_offered(
@@ -3193,12 +3190,12 @@ class CalculateKPIS:
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment(self) -> KPIResult:
         return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_38_patients_attending_additional_dietetic_appointment(
@@ -3254,12 +3251,12 @@ class CalculateKPIS:
 
     def calculate_kpi_39_influenza_immunisation_recommended(self) -> KPIResult:
         return self._calculate_kpi_39_influenza_immunisation_recommended(
-            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+            self._get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count
         )
 
     def calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table(self) -> KPIResult:
         return self._calculate_kpi_39_influenza_immunisation_recommended(
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count
         )
 
     def _calculate_kpi_39_influenza_immunisation_recommended(
@@ -3481,7 +3478,7 @@ class CalculateKPIS:
         # Eligible patients are measure 7 with
         # diagnosis date < (AUDIT_END_DATE - 14 days)
         base_eligible_patients, _ = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
         eligible_patients = base_eligible_patients.filter(
             diagnosis_date__lt=self.audit_end_date - relativedelta(days=14)
@@ -4341,7 +4338,7 @@ class CalculateKPIS:
             self.kpi_2_total_eligible,
         )
 
-    def _get_total_kpi_5_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_5_total_t1dm_complete_year_eligible_pts_base_query_set_and_total_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """Enables reuse of the base query set for KPI 5
@@ -4363,7 +4360,7 @@ class CalculateKPIS:
             self.kpi_5_total_eligible,
         )
 
-    def _get_total_kpi_6_eligible_pts_base_query_set_and_total_count(
+    def _get_total_kpi_6_total_t1dm_complete_year_gte_12yo_eligible_pts_base_query_set_and_total_count(
         self,
     ) -> Tuple[QuerySet, int]:
         """Enables reuse of the base query set for KPI 6
@@ -4428,7 +4425,7 @@ class CalculateKPIS:
 
         # First get new T1DM diagnoses pts
         base_query_set, _ = (
-            self._get_kpi_3_eligible_pts_base_query_set_and_total_count()
+            self._get_kpi_3_total_t1dm_eligible_pts_base_query_set_and_total_count()
         )
 
         # Filter for those diagnoses at least 90 days before audit end date

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -2112,9 +2112,19 @@ class CalculateKPIS:
 
         return result
 
-    def calculate_kpi_25_hba1c(
+    def calculate_kpi_25_hba1c(self):
+        return self._calculate_kpi_25_hba1c(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_25_hba1c_for_patient_report_table(self):
+        return self._calculate_kpi_25_hba1c(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_25_hba1c(
         self,
-        denominatorFn = None
+        denominator_fn
     ) -> KPIResult:
         """
         Calculates KPI 25: HbA1c (%)
@@ -2124,9 +2134,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = denominator_fn()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -2155,9 +2163,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_26_bmi(
+    def calculate_kpi_26_bmi(self) -> KPIResult:
+        return self._calculate_kpi_26_bmi(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_26_bmi_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_26_bmi(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_26_bmi(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 26: BMI (%)
@@ -2166,12 +2184,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_5_total_eligible_query_set
-        total_eligible = total_eligible_kpi_5
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid entry for ht & wt within audit period
@@ -2199,9 +2212,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_27_thyroid_screen(
+    def calculate_kpi_27_thyroid_screen(self) -> KPIResult:
+        return self._calculate_kpi_27_thyroid_screen(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_27_thyroid_screen_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_27_thyroid_screen(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_27_thyroid_screen(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 27: Thyroid Screen (%)
@@ -2210,12 +2233,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_5_total_eligible_query_set
-        total_eligible = total_eligible_kpi_5
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid entry for thyroid screen within audit period
@@ -2241,9 +2259,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_28_blood_pressure(
+    def calculate_kpi_28_blood_pressure(self) -> KPIResult:
+        return self._calculate_kpi_28_blood_pressure(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_28_blood_pressure_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_28_blood_pressure(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_28_blood_pressure(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 28: Blood Pressure (%)
@@ -2254,12 +2282,7 @@ class CalculateKPIS:
 
         # NOTE: Does not need a valid diastolic measurement
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid entry for systolic measurement within audit period
@@ -2286,9 +2309,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_29_urinary_albumin(
+    def calculate_kpi_29_urinary_albumin(self) -> KPIResult:
+        return self._calculate_kpi_29_urinary_albumin(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_29_urinary_albumin_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_29_urinary_albumin(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_29_urinary_albumin(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 29: Urinary Albumin (%)
@@ -2297,12 +2330,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid entry for Urinary Albumin Level (item 29)
@@ -2330,9 +2358,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_30_retinal_screening(
+    def calculate_kpi_30_retinal_screening(self) -> KPIResult:
+        return self._calculate_kpi_30_retinal_screening(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_30_retinal_screening_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_30_retinal_screening(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_30_retinal_screening(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 30: Retinal Screening (%)
@@ -2341,12 +2379,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one for Retinal Screening Result (item 28) is either 1 = Normal or 2 = Abnormal AND the observation date (item 27) is within the audit period
@@ -2378,9 +2411,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_31_foot_examination(
+    def calculate_kpi_31_foot_examination(self) -> KPIResult:
+        return self._calculate_kpi_31_foot_examination(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_31_foot_examination_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_31_foot_examination(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_31_foot_examination(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 31: Foot Examination (%)
@@ -2389,12 +2432,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one for Foot Examination Date (item 26) within the audit period
@@ -2861,9 +2899,19 @@ class CalculateKPIS:
 
         return self.eligible_patients_gte_12yo
 
-    def calculate_kpi_33_hba1c_4plus(
+    def calculate_kpi_33_hba1c_4plus(self) -> KPIResult:
+        return self._calculate_kpi_33_hba1c_4plus(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_33_hba1c_4plus_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_33_hba1c_4plus(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_33_hba1c_4plus(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 33: HbA1c 4+ (%)
@@ -2872,12 +2920,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_5_total_eligible_query_set
-        total_eligible = total_eligible_kpi_5
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least 4 entries for HbA1c value with associated
@@ -2914,9 +2957,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_34_psychological_assessment(
+    def calculate_kpi_34_psychological_assessment(self) -> KPIResult:
+        return self._calculate_kpi_34_psychological_assessment(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_34_psychological_assessment_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_34_psychological_assessment(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_34_psychological_assessment(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 34: Psychological assessment (%)
@@ -2925,12 +2978,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_5_total_eligible_query_set
-        total_eligible = total_eligible_kpi_5
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with an entry for Psychological Screening Date
@@ -2966,9 +3014,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_35_smoking_status_screened(
+    def calculate_kpi_35_smoking_status_screened(self) -> KPIResult:
+        return self._calculate_kpi_35_smoking_status_screened(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_35_smoking_status_screened_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_35_smoking_status_screened(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_35_smoking_status_screened(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 35: Smoking status screened (%)
@@ -2977,12 +3035,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with a valid entry for Smoking status
@@ -3024,9 +3077,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_36_referral_to_smoking_cessation_service(
+    def calculate_kpi_36_referral_to_smoking_cessation_service(self) -> KPIResult:
+        return self._calculate_kpi_36_referral_to_smoking_cessation_service(
+            self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_36_referral_to_smoking_cessation_service(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_36_referral_to_smoking_cessation_service(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 36: Referral to smoking cessation service (%)
@@ -3035,12 +3098,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in audit period (measure 6)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_6_eligible_pts_base_query_set_and_total_count
-
-        kpi_6_total_eligible_query_set, total_eligible_kpi_6 = effectiveDenominatorFn()
-
-        eligible_patients = kpi_6_total_eligible_query_set
-        total_eligible = total_eligible_kpi_6
+        eligible_patients, total_eligible = denominator()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Get the visits that match the valid Smoking Cessation Referral date
@@ -3075,9 +3133,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_37_additional_dietetic_appointment_offered(
+    def calculate_kpi_37_additional_dietetic_appointment_offered(self) -> KPIResult:
+        return self._calculate_kpi_37_additional_dietetic_appointment_offered(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_37_additional_dietetic_appointment_offered(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_37_additional_dietetic_appointment_offered(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 37: Additional dietetic appointment offered (%)
@@ -3086,9 +3154,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = denominator()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -3125,9 +3191,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+    def calculate_kpi_38_patients_attending_additional_dietetic_appointment(self) -> KPIResult:
+        return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_38_patients_attending_additional_dietetic_appointment(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 38: Patients attending additional dietetic appointment (%)
@@ -3136,9 +3212,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = denominator()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5
@@ -3178,9 +3252,19 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_39_influenza_immunisation_recommended(
+    def calculate_kpi_39_influenza_immunisation_recommended(self) -> KPIResult:
+        return self._calculate_kpi_39_influenza_immunisation_recommended(
+            self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
+        )
+
+    def calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table(self) -> KPIResult:
+        return self._calculate_kpi_39_influenza_immunisation_recommended(
+            self._get_kpi_3_eligible_pts_base_query_set_and_total_count
+        )
+
+    def _calculate_kpi_39_influenza_immunisation_recommended(
         self,
-        denominatorFn = None
+        denominator
     ) -> KPIResult:
         """
         Calculates KPI 39: Influenza immunisation recommended (%)
@@ -3189,9 +3273,7 @@ class CalculateKPIS:
 
         Denominator: Number of patients with Type 1 diabetes with a complete year of care in the audit period (measure 5)
         """
-        effectiveDenominatorFn = denominatorFn or self._get_total_kpi_5_eligible_pts_base_query_set_and_total_count
-
-        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = effectiveDenominatorFn()
+        kpi_5_total_eligible_query_set, total_eligible_kpi_5 = denominator()
 
         eligible_patients = kpi_5_total_eligible_query_set
         total_eligible = total_eligible_kpi_5

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -658,3 +658,133 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
     assert response.status_code == HTTPStatus.OK
 
     assert len(response.context["patients"]) == 0
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
+@pytest.mark.django_db
+def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        hba1c=50,  # 50 mmol/mol
+        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_date=visit_date,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse("pdu-patient-report", kwargs={
+        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+        "pz_code": ALDER_HEY_PZ_CODE
+    })
+
+    response = client.get(
+        url + f"?category={TableCategories.HEALTH_CHECKS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+    
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["passed_hba1c"] is True
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
+@pytest.mark.django_db
+def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenza_immunisation_recommended(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        flu_immunisation_recommended_date=visit_date,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse("pdu-patient-report", kwargs={
+        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+        "pz_code": ALDER_HEY_PZ_CODE
+    })
+
+    response = client.get(
+        url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+    
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["influenza_immunisation_recommended"] is True

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -5,6 +5,7 @@ import logging
 from http import HTTPStatus
 
 # Python imports
+from project.constants.smoking_status import SMOKING_STATUS
 import pytest
 from django.db.models import Count
 
@@ -788,3 +789,131 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     
     assert patient["patient_identifier"] == "4444444444"
     assert patient["influenza_immunisation_recommended"] is True
+
+
+@pytest.mark.django_db
+def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        hba1c=50,  # 50 mmol/mol
+        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_date=visit_date,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse("pdu-patient-report", kwargs={
+        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+        "pz_code": ALDER_HEY_PZ_CODE
+    })
+
+    response = client.get(
+        url + f"?category={TableCategories.HEALTH_CHECKS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+    
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["passed_hba1c"] is True
+
+
+@pytest.mark.django_db
+def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=10)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        smoking_status=SMOKING_STATUS[0][0], # non smoker
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse("pdu-patient-report", kwargs={
+        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+        "pz_code": ALDER_HEY_PZ_CODE
+    })
+
+    response = client.get(
+        url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+    
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["smoking_status"] is True

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -842,8 +842,6 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
     return pt_qs, calculate_kpis, patient_identifier
 
 
-PATIENT_REPORT_PAGE_SIZE = 50
-
 class PatientReportView(
     LoginAndOTPRequiredMixin,
     PDUPermissionMixin,
@@ -856,7 +854,7 @@ class PatientReportView(
     model = Patient
     template_name = "patient_report/patient_report.html"
     context_object_name = "patients"
-    paginate_by = PATIENT_REPORT_PAGE_SIZE
+    paginate_by = 50
 
     def get_queryset(self):
         request = self.request

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -174,7 +174,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_hba1c=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_25_hba1c()
+                        calculate_kpis.calculate_kpi_25_hba1c(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -186,7 +188,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_bmi=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_26_bmi()
+                        calculate_kpis.calculate_kpi_26_bmi(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -198,7 +202,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_thyroid_screen=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_27_thyroid_screen()
+                        calculate_kpis.calculate_kpi_27_thyroid_screen(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -210,7 +216,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_blood_pressure=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_28_blood_pressure()
+                        calculate_kpis.calculate_kpi_28_blood_pressure(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -226,7 +234,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_urinary_albumin=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_29_urinary_albumin()
+                        calculate_kpis.calculate_kpi_29_urinary_albumin(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -242,7 +252,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_retinal_screening=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_30_retinal_screening()
+                        calculate_kpis.calculate_kpi_30_retinal_screening(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -258,7 +270,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_foot_exam=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_31_foot_examination()
+                        calculate_kpis.calculate_kpi_31_foot_examination(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -320,7 +334,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             hba1c_4plus=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_33_hba1c_4plus()
+                        calculate_kpis.calculate_kpi_33_hba1c_4plus(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -332,7 +348,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             psychological_assessment=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_34_psychological_assessment()
+                        calculate_kpis.calculate_kpi_34_psychological_assessment(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -347,7 +365,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             smoking_status=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_35_smoking_status_screened()
+                        calculate_kpis.calculate_kpi_35_smoking_status_screened(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -363,7 +383,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             smoking_cessation_referral=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service()
+                        calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -379,7 +401,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             additional_dietetic_appt_offered=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered()
+                        calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -391,7 +415,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             pts_attending_additional_dietetic_appt=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment()
+                        calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -403,7 +429,9 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             influenza_immunisation_recommended=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended()
+                        calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended(
+                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
+                        )
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -814,6 +842,8 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
     return pt_qs, calculate_kpis, patient_identifier
 
 
+PATIENT_REPORT_PAGE_SIZE = 50
+
 class PatientReportView(
     LoginAndOTPRequiredMixin,
     PDUPermissionMixin,
@@ -826,7 +856,7 @@ class PatientReportView(
     model = Patient
     template_name = "patient_report/patient_report.html"
     context_object_name = "patients"
-    paginate_by = 50
+    paginate_by = PATIENT_REPORT_PAGE_SIZE
 
     def get_queryset(self):
         request = self.request

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -174,9 +174,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_hba1c=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_25_hba1c(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_25_hba1c_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -188,9 +186,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_bmi=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_26_bmi(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_26_bmi_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -202,9 +198,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_thyroid_screen=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_27_thyroid_screen(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_27_thyroid_screen_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -216,9 +210,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_blood_pressure=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_28_blood_pressure(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_28_blood_pressure_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -234,9 +226,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_urinary_albumin=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_29_urinary_albumin(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_29_urinary_albumin_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -252,9 +242,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_retinal_screening=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_30_retinal_screening(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_30_retinal_screening_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -270,9 +258,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             passed_foot_exam=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_31_foot_examination(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_31_foot_examination_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -334,9 +320,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             hba1c_4plus=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_33_hba1c_4plus(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_33_hba1c_4plus_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -348,9 +332,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             psychological_assessment=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_34_psychological_assessment(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_34_psychological_assessment_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -365,9 +347,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             smoking_status=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_35_smoking_status_screened(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_35_smoking_status_screened_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -383,9 +363,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             smoking_cessation_referral=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -401,9 +379,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             additional_dietetic_appt_offered=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -415,9 +391,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             pts_attending_additional_dietetic_appt=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),
@@ -429,9 +403,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             influenza_immunisation_recommended=Case(
                 When(
                     Exists(
-                        calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended(
-                            denominatorFn=calculate_kpis._get_kpi_3_eligible_pts_base_query_set_and_total_count
-                        )
+                        calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table()
                         .patient_querysets["passed"]
                         .filter(pk=OuterRef("pk"))
                     ),


### PR DESCRIPTION
Fixes #1242

Previously patients with an incomplete year of care would always fail the measures in health checks and additional care processes. This was because passing those measures depended on them being in the denominator sets used internally, which required a complete year of care.

Now we pass in a more permissive denominator set that includes all T1 patients. Measures only affecting patients >12yo still work, with those below marked as Not Required.

Note this bug only affected the checkboxes in the table rows themselves. The health check completion percentages at the top already worked correctly.