### PR TITLE
Fix crash in fake patient data with diagnosis date at the end of a quarter 

### DIFF
--- a/project/npda/general_functions/data_generator_extended.py
+++ b/project/npda/general_functions/data_generator_extended.py
@@ -154,8 +154,9 @@ class FakePatientCreator:
                 usable_visit_periods = []
 
                 for period in visit_periods:
-                    # patient.diagnosis_date >= period.start_date and patient.diagnosis_date < period.end_date
-                    if patient.diagnosis_date >= period[0] and patient.diagnosis_date < period[1]:
+                    # patient.diagnosis_date >= period.start_date and patient.diagnosis_date <= period.end_date
+                    # NB dates are inclusive! (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1248)
+                    if patient.diagnosis_date >= period[0] and patient.diagnosis_date <= period[1]:
                         start = max(patient.diagnosis_date, period[0])
                         usable_visit_periods.append((start, period[1]))
 
@@ -165,7 +166,8 @@ class FakePatientCreator:
 
             for visit_type in visit_types:
                 visit_period = visit_periods[visit_period_ix]
-                visit_date = get_random_date(visit_period[0], visit_period[1])
+                # get_random_date is exclusive of end date (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1248)
+                visit_date = get_random_date(visit_period[0], visit_period[1] + timedelta(days=1))
 
                 # Get the correct kwarg measurements for the visit type
                 # These will be fed into this VisitFactory's.build() call

--- a/project/npda/tests/factories/test_fake_patient_builder.py
+++ b/project/npda/tests/factories/test_fake_patient_builder.py
@@ -252,10 +252,6 @@ def test_finding_usable_visit_period_for_all_diagnoses_dates_within_audit_year()
 
     try:
         while diagnosis_date <= audit_end_date:
-            diagnosis_date += timedelta(days=1)
-
-            print(f"!! diagnosis_date = {diagnosis_date}")
-
             [patient] = fake_patient_creator.build_fake_patients(
                 n=1,
                 age_range=AgeRange.AGE_0_4,
@@ -268,5 +264,7 @@ def test_finding_usable_visit_period_for_all_diagnoses_dates_within_audit_year()
                 hb1ac_target_range=HbA1cTargetRange.WELL_ABOVE,
                 age_range=AgeRange.AGE_0_4,
             )
+
+            diagnosis_date += timedelta(days=1)
     except Exception as err:
         pytest.fail(f"Failed to create visit for diagnosis date {diagnosis_date}: {err}")

--- a/project/npda/tests/factories/test_fake_patient_builder.py
+++ b/project/npda/tests/factories/test_fake_patient_builder.py
@@ -235,3 +235,38 @@ def test_performance_check_for_fake_patient_creator(
         for patients, time_taken in time_results.items():
             print(f"| {patients:<23} | {time_taken:<16.2f} |")
         print("+-------------------------+------------------+")
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1248
+@pytest.mark.django_db
+def test_finding_usable_visit_period_for_all_diagnoses_dates_within_audit_year():
+    # Set necessary attributes to calibrate all dates
+    DATE_IN_AUDIT = date(2024, 4, 1)
+    audit_start_date, audit_end_date = get_audit_period_for_date(DATE_IN_AUDIT)
+
+    fake_patient_creator = FakePatientCreator(
+        audit_start_date=audit_start_date,
+        audit_end_date=audit_end_date,
+    )
+
+    diagnosis_date = audit_start_date
+
+    try:
+        while diagnosis_date <= audit_end_date:
+            diagnosis_date += timedelta(days=1)
+
+            print(f"!! diagnosis_date = {diagnosis_date}")
+
+            [patient] = fake_patient_creator.build_fake_patients(
+                n=1,
+                age_range=AgeRange.AGE_0_4,
+                diagnosis_date=diagnosis_date,    
+            )
+
+            fake_patient_creator.build_fake_visits(
+                patients=[patient],
+                visit_types=[VisitType.CLINIC],
+                hb1ac_target_range=HbA1cTargetRange.WELL_ABOVE,
+                age_range=AgeRange.AGE_0_4,
+            )
+    except Exception as err:
+        pytest.fail(f"Failed to create visit for diagnosis date {diagnosis_date}: {err}")


### PR DESCRIPTION
Fixes https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1248

The code that worked out what quarters included and came after the diagnosis date (to work out what date range to use for visits) was not inclusive of the end date for each quarter.

This manifested itself as random unit test crashes on unrelated PRs.