### PR TITLE
Reduce the number of queries the for patient_measurements endpoint

### DIFF
--- a/project/npda/views/dashboard/patient_measurements.py
+++ b/project/npda/views/dashboard/patient_measurements.py
@@ -23,7 +23,7 @@ def patient_measurements(request, audit_period, pdu):
         calculation_date=calculation_date, return_pt_querysets=True, is_jersey=pz_code == "PZ248"
     )
 
-    kpi_calculations_object = calculate_kpis.calculate_kpis_for_pdus(pz_codes=[pdu.pz_code])
+    calculate_kpis.set_patients_for_calculation(pz_codes=[pz_code])
 
 
     # {


### PR DESCRIPTION
Part of #1251. This is the slowest endpoint since I deployed Silk earlier on (#1252)


<img width="492" height="224" alt="Screenshot 2025-10-06 130746" src="https://github.com/user-attachments/assets/8c9d2917-3b0f-421b-bd86-56accf28b086" />

Originally we were calculating ALL the KPIs where in fact we only need to set the internal patient queryset for CalculateKPIs

Before: 100 queries
After: 37 queries

<img width="968" height="178" alt="Screenshot 2025-10-06 130448" src="https://github.com/user-attachments/assets/041f6060-e7ff-4404-a02b-4fde81e5bf21" />

