### PR TITLE
Remove KPI calculation from main dashboard load

### DIFF
--- a/project/npda/templates/dashboard/components/cards/audit_details_card.html
+++ b/project/npda/templates/dashboard/components/cards/audit_details_card.html
@@ -7,14 +7,14 @@ Audit Details
 
   <div class="flex flex-col justify-center">
     <p class="font-bold">Start Date</p>
-    <p>{{ kpi_calculations_object.audit_start_date }}</p>
+    <p>{{ audit_period.start_date }}</p>
   </div>
   <div class="flex">
     <p>-</p>
   </div>
   <div class="flex flex-col justify-center">
     <p class="font-bold">End Date</p>
-    <p>{{ kpi_calculations_object.audit_end_date }}</p>
+    <p>{{ audit_period.end_date }}</p>
   </div>
 </div>
 {% if current_quarter %}

--- a/project/npda/templates/dashboard/dashboard_base.html
+++ b/project/npda/templates/dashboard/dashboard_base.html
@@ -6,7 +6,7 @@
      hx-swap="innerHTML">
   <div class="my-6">
     <p class="text-center text-gray-500 mt-2">
-      Calculated at {{ kpi_calculations_object.calculation_datetime }}
+      Calculated at {{ current_datetime }}
     </p>
     <p class="text-center">This data has not been validated by the NPDA team.</p>
   </div>
@@ -18,7 +18,7 @@
     </div>
     <div class="col-span-12 xl:col-span-3">
       <!-- Audit Details Card -->
-      {% include 'dashboard/components/cards/audit_details_card.html' with kpi_calculations_object=kpi_calculations_object current_quarter=current_quarter current_date=current_date days_remaining_until_audit_end_date=days_remaining_until_audit_end_date %}
+      {% include 'dashboard/components/cards/audit_details_card.html' with audit_period=audit_period current_quarter=current_quarter current_date=current_date days_remaining_until_audit_end_date=days_remaining_until_audit_end_date %}
     </div>
     <div class="col-span-12 xl:col-span-6">
       <!-- Patient Measurements Card -->

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -1,7 +1,6 @@
 # Python imports
-import json
 import logging
-from datetime import date
+from datetime import datetime, date
 
 from django.shortcuts import render
 
@@ -25,6 +24,8 @@ def dashboard(request, audit_period, pdu):
         template = "dashboard/dashboard_base.html"
     
     current_date = date.today()
+    current_datetime = datetime.now()
+
     calculation_date = audit_period.kpi_calculation_date()
 
     if audit_period.start_date > current_date:
@@ -40,36 +41,14 @@ def dashboard(request, audit_period, pdu):
         current_quarter = retrieve_quarter_for_date(current_date)
         days_remaining_until_audit_end_date = (audit_period.end_date - current_date).days
 
-    calculate_kpis = CalculateKPIS(
-        calculation_date=calculation_date, return_pt_querysets=True
-    )
-
-    kpi_calculations_object = calculate_kpis.calculate_kpis_for_pdus(pz_codes=[pdu.pz_code])
-
-    # From this, gather specific chart data required
-
-    # new diagnoses
-    new_diagnosis_per_quarter_value_counts_pct = (
-        calculate_kpis.calculate_kpi_2_total_new_diagnoses_stratified_by_quarter()
-    )
-
     context = {
         "scatter_plot_select_list": _scatter_plot_select_list("new_diagnoses"),
         "pdu_object": pdu,
-        # "pdu_lead_organisation": pdu_lead_organisation,
-        "kpi_calculations_object": kpi_calculations_object,
         "current_date": calculation_date,
+        "current_datetime": current_datetime,
         "current_quarter": current_quarter,
+        "audit_period": audit_period,
         "days_remaining_until_audit_end_date": days_remaining_until_audit_end_date,
-        "charts": {
-            "new_diagnoses_per_quarter_value_counts_pct": {
-                "no_eligible_patients": kpi_calculations_object[
-                    "calculated_kpi_values"
-                ]["kpi_1_total_eligible"]["total_eligible"]
-                == 0,
-                "data": json.dumps(new_diagnosis_per_quarter_value_counts_pct),
-            }
-        },
         # TODO: this should be an enum but we're currently not doing benchmarking so can update
         # at that point
         "aggregation_level": "pdu",

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -1,5 +1,6 @@
 # Python imports
 import logging
+import json
 from datetime import datetime, date
 
 from django.shortcuts import render
@@ -40,6 +41,21 @@ def dashboard(request, audit_period, pdu):
         # Current audit period
         current_quarter = retrieve_quarter_for_date(current_date)
         days_remaining_until_audit_end_date = (audit_period.end_date - current_date).days
+    
+    calculate_kpis = CalculateKPIS(
+        calculation_date=calculation_date, return_pt_querysets=True
+    )
+
+    calculate_kpis.set_patients_for_calculation(pz_codes=[pdu.pz_code])
+
+    no_eligible_patients = calculate_kpis.calculate_kpi_1_total_eligible()
+
+    # From this, gather specific chart data required
+
+    # new diagnoses
+    new_diagnosis_per_quarter_value_counts_pct = (
+        calculate_kpis.calculate_kpi_2_total_new_diagnoses_stratified_by_quarter()
+    )
 
     context = {
         "scatter_plot_select_list": _scatter_plot_select_list("new_diagnoses"),
@@ -49,6 +65,12 @@ def dashboard(request, audit_period, pdu):
         "current_quarter": current_quarter,
         "audit_period": audit_period,
         "days_remaining_until_audit_end_date": days_remaining_until_audit_end_date,
+        "charts": {
+            "new_diagnoses_per_quarter_value_counts_pct": {
+                "no_eligible_patients": no_eligible_patients == 0,
+                "data": json.dumps(new_diagnosis_per_quarter_value_counts_pct),
+            }
+        },
         # TODO: this should be an enum but we're currently not doing benchmarking so can update
         # at that point
         "aggregation_level": "pdu",


### PR DESCRIPTION
Part of #1251 

We don't need to calculate all the KPIs on the initial dashboard load any more.

<img width="810" height="199" alt="Screenshot 2025-10-06 141025" src="https://github.com/user-attachments/assets/362a4fd6-928d-46a0-bc71-7d06138340dc" />
