### PR TITLE
Set default number of gunicorn workers in prod

### DIFF
--- a/s/start-prod
+++ b/s/start-prod
@@ -8,4 +8,5 @@ python manage.py seed --mode=seed_groups_and_permissions
 gunicorn \
     --bind=0.0.0.0:8000 \
     --timeout 600 \
+    --workers 5 \
     project.wsgi


### PR DESCRIPTION
Part of #1251 

Following their guidance: https://docs.gunicorn.org/en/latest/design.html#how-many-workers

2 CPU cores => (2 * 2) + 1 = 5

The default was 1! No wonder we had reports of the platform slowing down - some operations like generating a patient report or rendering the dashboard would have been starving out other requests to the worker.