### PR TITLE
Enhance KPI tests and ineligibility tooltips

### DIFF
--- a/documentation/docs/developer/kpis/additional_processes.md
+++ b/documentation/docs/developer/kpis/additional_processes.md
@@ -42,7 +42,7 @@
 
 **Numerator**: Number of eligible patients with an entry for Date of Smoking Cessation Referral (item 41) within the audit period
 
-**Denominator**: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in the audit period (measure 6)
+**Denominator**: Number of patients with Type 1 diabetes aged 12+ with a complete year of care in the audit period (measure 6) who screen as smokers
 
 **Data Items**: 41
 

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -396,9 +396,7 @@ class CalculateKPIS:
         the returned KPIResult object.
         """
 
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         # This is same as KPI1 but with an additional filter for diagnosis date
         self.total_kpi_2_eligible_pts_base_query_set = base_eligible_patients.filter(
@@ -462,7 +460,7 @@ class CalculateKPIS:
             # This is for a previous audit period: we need to get the quarter for the whole year
             current_quarter = retrieve_quarter_for_date(self.audit_end_date)
         quarter_end_dates = quarter_end_dates[:current_quarter]
-        
+
         result = {}
         eligible_patients_kpi_2 = total_kpi_1_eligible_pts_base_query_set.filter(
             diagnosis_date__range=(self.AUDIT_DATE_RANGE)
@@ -527,9 +525,7 @@ class CalculateKPIS:
         discarded as they're set to the same value as eligible/ineligible in
         the returned KPIResult object.
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # is type 1 diabetes
@@ -597,9 +593,7 @@ class CalculateKPIS:
         discarded as they're set to None
         """
 
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # Diagnosis of Type 1 diabetes
@@ -919,9 +913,7 @@ class CalculateKPIS:
         discarded as they're set to the same value as eligible/ineligible in
         the returned KPIResult object.
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # Date of death within the audit period"
@@ -966,9 +958,7 @@ class CalculateKPIS:
         discarded as they're set to the same value as eligible/ineligible in
         the returned KPIResult object.
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # a leaving date in the audit period
@@ -1018,9 +1008,7 @@ class CalculateKPIS:
         discarded as they're set to the same value as eligible/ineligible in
         the returned KPIResult object.
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # a leaving date in the audit period
@@ -1073,9 +1061,7 @@ class CalculateKPIS:
         """This is not a KPI - total patients transitioning specifically to adults by quarter"""
 
         # Denominator - eligible pts
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             # a leaving date in the audit period
@@ -1142,9 +1128,7 @@ class CalculateKPIS:
 
         KPI 9 + transitioned to adult service + this month
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         today = date.today()
         current_month_start = date(today.year, today.month, 1)
@@ -1172,9 +1156,7 @@ class CalculateKPIS:
 
         KPI 9 + moved out of area + this month
         """
-        base_eligible_patients, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_total_kpi_1_pts_and_count()
 
         eligible_patients = base_eligible_patients.filter(
             Q(
@@ -1223,9 +1205,7 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_pts_and_count()
         eligible_patients = base_query_set.filter(
             Q(
                 id__in=Subquery(
@@ -1283,9 +1263,7 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_pts_and_count()
         eligible_patients = base_query_set.filter(
             Q(
                 id__in=Subquery(
@@ -1341,9 +1319,7 @@ class CalculateKPIS:
         )
 
         # Filter the Patient queryset based on the subquery
-        base_query_set, _ = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        base_query_set, _ = self._get_total_kpi_1_pts_and_count()
         eligible_patients = base_query_set.filter(
             Q(
                 id__in=Subquery(
@@ -1559,9 +1535,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
 
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1610,9 +1584,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit
@@ -1658,9 +1630,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients with type 1 diabetes (measure 3)
         """
-        eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_kpi_3_total_t1dm_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit
@@ -1708,9 +1678,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit
@@ -1758,9 +1726,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit
@@ -1808,9 +1774,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit where blood glucose monitoring (item 22) is either 2 = Flash glucose monitor or 3 = Modified flash glucose monitor (e.g. with MiaoMiao, Blucon etc.)
@@ -1854,9 +1818,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients with Type 1 diabetes (measure 3)
         """
-        eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_kpi_3_total_t1dm_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Define the subquery to find the latest visit where blood glucose monitoring (item 22) is 4 = Real time continuous glucose monitor with alarms
@@ -1900,9 +1862,7 @@ class CalculateKPIS:
 
         Denominator: Number of eligible patients whose most recent entry (based on visit date) for blood glucose monitoring (item 22) is 4 = Real time continuous glucose monitor with alarms
         """
-        eligible_patients, total_eligible = (
-            self._get_kpi_3_total_t1dm_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_kpi_3_total_t1dm_pts_and_count()
 
         total_ineligible = self.total_patients_count - total_eligible
 
@@ -1959,7 +1919,6 @@ class CalculateKPIS:
             self._get_kpi_3_total_t1dm_pts_and_count()
         )
 
-        
         total_eligible_kpi_t1dm = total_kpi_3_eligible_pts_base_query_set.count()
 
         # Eligible kpi24 patients are those who are either on an insulin pump or insulin pump therapy
@@ -2033,7 +1992,7 @@ class CalculateKPIS:
         total_kpi_3_eligible_pts_base_query_set, total_eligible_kpi_3 = (
             self._total_kpi_3_pts_and_count()
         )
-        
+
         total_eligible_kpi_t1dm = total_kpi_3_eligible_pts_base_query_set.count()
 
         # Get quarter dates
@@ -2122,10 +2081,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_25_hba1c(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_25_hba1c(self, denominator) -> KPIResult:
         """
         Calculates KPI 25: HbA1c (%)
 
@@ -2170,10 +2126,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_26_bmi(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_26_bmi(self, denominator) -> KPIResult:
         """
         Calculates KPI 26: BMI (%)
 
@@ -2219,10 +2172,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_27_thyroid_screen(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_27_thyroid_screen(self, denominator) -> KPIResult:
         """
         Calculates KPI 27: Thyroid Screen (%)
 
@@ -2266,10 +2216,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_28_blood_pressure(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_28_blood_pressure(self, denominator) -> KPIResult:
         """
         Calculates KPI 28: Blood Pressure (%)
 
@@ -2316,10 +2263,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_29_urinary_albumin(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_29_urinary_albumin(self, denominator) -> KPIResult:
         """
         Calculates KPI 29: Urinary Albumin (%)
 
@@ -2365,10 +2309,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_30_retinal_screening(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_30_retinal_screening(self, denominator) -> KPIResult:
         """
         Calculates KPI 30: Retinal Screening (%)
 
@@ -2418,10 +2359,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_31_foot_examination(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_31_foot_examination(self, denominator) -> KPIResult:
         """
         Calculates KPI 31: Foot Examination (%)
 
@@ -2906,10 +2844,7 @@ class CalculateKPIS:
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_33_hba1c_4plus(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_33_hba1c_4plus(self, denominator) -> KPIResult:
         """
         Calculates KPI 33: HbA1c 4+ (%)
 
@@ -2959,15 +2894,14 @@ class CalculateKPIS:
             denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
-    def calculate_kpi_34_psychological_assessment_for_patient_report_table(self) -> KPIResult:
+    def calculate_kpi_34_psychological_assessment_for_patient_report_table(
+        self,
+    ) -> KPIResult:
         return self._calculate_kpi_34_psychological_assessment(
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_34_psychological_assessment(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_34_psychological_assessment(self, denominator) -> KPIResult:
         """
         Calculates KPI 34: Psychological assessment (%)
 
@@ -3016,15 +2950,14 @@ class CalculateKPIS:
             denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
-    def calculate_kpi_35_smoking_status_screened_for_patient_report_table(self) -> KPIResult:
+    def calculate_kpi_35_smoking_status_screened_for_patient_report_table(
+        self,
+    ) -> KPIResult:
         return self._calculate_kpi_35_smoking_status_screened(
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
-    def _calculate_kpi_35_smoking_status_screened(
-        self,
-        denominator
-    ) -> KPIResult:
+    def _calculate_kpi_35_smoking_status_screened(self, denominator) -> KPIResult:
         """
         Calculates KPI 35: Smoking status screened (%)
 
@@ -3079,14 +3012,15 @@ class CalculateKPIS:
             denominator=self._get_total_kpi_6_total_t1dm_complete_year_gte_12yo_pts_and_count
         )
 
-    def calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table(self) -> KPIResult:
+    def calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table(
+        self,
+    ) -> KPIResult:
         return self._calculate_kpi_36_referral_to_smoking_cessation_service(
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_36_referral_to_smoking_cessation_service(
-        self,
-        denominator
+        self, denominator
     ) -> KPIResult:
         """
         Calculates KPI 36: Referral to smoking cessation service (%)
@@ -3102,6 +3036,7 @@ class CalculateKPIS:
         smoke_cessation_visits = Visit.objects.filter(
             patient=OuterRef("pk"),
             visit_date__range=self.AUDIT_DATE_RANGE,
+            smoking_status=2,  # Current smoker
             smoking_cessation_referral_date__range=self.AUDIT_DATE_RANGE,
         )
         # Find patients with a valid entry for Smoking Cessation Referral
@@ -3135,14 +3070,15 @@ class CalculateKPIS:
             denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
-    def calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table(self) -> KPIResult:
+    def calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table(
+        self,
+    ) -> KPIResult:
         return self._calculate_kpi_37_additional_dietetic_appointment_offered(
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_37_additional_dietetic_appointment_offered(
-        self,
-        denominator
+        self, denominator
     ) -> KPIResult:
         """
         Calculates KPI 37: Additional dietetic appointment offered (%)
@@ -3188,19 +3124,26 @@ class CalculateKPIS:
             patient_querysets=patient_querysets,
         )
 
-    def calculate_kpi_38_patients_attending_additional_dietetic_appointment(self) -> KPIResult:
-        return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
+    def calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+        self,
+    ) -> KPIResult:
+        return (
+            self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+                denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
+            )
         )
 
-    def calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table(self) -> KPIResult:
-        return self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-            denominator=self._get_kpi_3_total_t1dm_pts_and_count
+    def calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table(
+        self,
+    ) -> KPIResult:
+        return (
+            self._calculate_kpi_38_patients_attending_additional_dietetic_appointment(
+                denominator=self._get_kpi_3_total_t1dm_pts_and_count
+            )
         )
 
     def _calculate_kpi_38_patients_attending_additional_dietetic_appointment(
-        self,
-        denominator
+        self, denominator
     ) -> KPIResult:
         """
         Calculates KPI 38: Patients attending additional dietetic appointment (%)
@@ -3254,14 +3197,15 @@ class CalculateKPIS:
             denominator=self._get_total_kpi_5_total_t1dm_complete_year_pts_and_count
         )
 
-    def calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table(self) -> KPIResult:
+    def calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table(
+        self,
+    ) -> KPIResult:
         return self._calculate_kpi_39_influenza_immunisation_recommended(
             denominator=self._get_kpi_3_total_t1dm_pts_and_count
         )
 
     def _calculate_kpi_39_influenza_immunisation_recommended(
-        self,
-        denominator
+        self, denominator
     ) -> KPIResult:
         """
         Calculates KPI 39: Influenza immunisation recommended (%)
@@ -3477,9 +3421,7 @@ class CalculateKPIS:
 
         # Eligible patients are measure 7 with
         # diagnosis date < (AUDIT_END_DATE - 14 days)
-        base_eligible_patients, _ = (
-            self._get_kpi_3_total_t1dm_pts_and_count()
-        )
+        base_eligible_patients, _ = self._get_kpi_3_total_t1dm_pts_and_count()
         eligible_patients = base_eligible_patients.filter(
             diagnosis_date__lt=self.audit_end_date - relativedelta(days=14)
         )
@@ -3542,9 +3484,7 @@ class CalculateKPIS:
         NOTE: for pt querysets, only `eligible` and `ineligible` are valid, the
             others should be discarded.
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         hba1c_values_by_patient = self.get_median_hba1c_values_by_patient(
@@ -3597,7 +3537,11 @@ class CalculateKPIS:
         # Calculate median HBa1c for each patient
         if self.is_jersey:
             # Jersey patients have unique_reference_number instead of nhs_number
-            visit_value_cols = ["patient__pk", "hba1c", "patient__unique_reference_number"]
+            visit_value_cols = [
+                "patient__pk",
+                "hba1c",
+                "patient__unique_reference_number",
+            ]
         else:
             visit_value_cols = ["patient__pk", "hba1c", "patient__nhs_number"]
         # Retrieve all visits with valid HbA1c values
@@ -3619,16 +3563,16 @@ class CalculateKPIS:
             hba1c_values_by_patient = defaultdict(
                 lambda: {"hb1ac_values": [], "nhs_number": ""}
             )
-        
+
         for visit in valid_visits:
             hba1c_values_by_patient[visit["patient__pk"]]["hb1ac_values"].append(
                 visit["hba1c"]
             )
             if self.is_jersey:
-                hba1c_values_by_patient[visit["patient__pk"]]["unique_reference_number"] = visit[
-                    "patient__unique_reference_number"
-                ]
-            else: 
+                hba1c_values_by_patient[visit["patient__pk"]][
+                    "unique_reference_number"
+                ] = visit["patient__unique_reference_number"]
+            else:
                 hba1c_values_by_patient[visit["patient__pk"]]["nhs_number"] = visit[
                     "patient__nhs_number"
                 ]
@@ -3664,9 +3608,7 @@ class CalculateKPIS:
         NOTE: for pt querysets, only `eligible` and `ineligible` are valid, the
             others should be discarded.
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Calculate median HBa1c for each patient
@@ -3732,9 +3674,7 @@ class CalculateKPIS:
 
         Can't re-use the existing methods as they don't stratify.
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
 
         # Filter eligible patients to just relevant diabetes types
         eligible_patients_t1dm = eligible_patients.filter(
@@ -3886,9 +3826,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid admission
@@ -3944,9 +3882,7 @@ class CalculateKPIS:
         """KPI46's calculate_() method doesn't do this per quarter, so separate method"""
 
         # Denominator - eligible pts
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
 
         # Find patients with at least one valid admission
         # Get the visits that match the valid admission criteria
@@ -4103,9 +4039,7 @@ class CalculateKPIS:
         NOTE: possible refactor could just be applying additional filter checking DKA to the
         KPI 46 calculation, but for now keeping separate
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid DKA admission criteria
@@ -4183,9 +4117,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid psych support criteria
@@ -4236,9 +4168,7 @@ class CalculateKPIS:
 
         Denominator: Total number of eligible patients (measure 1)
         """
-        eligible_patients, total_eligible = (
-            self._get_total_kpi_1_pts_and_count()
-        )
+        eligible_patients, total_eligible = self._get_total_kpi_1_pts_and_count()
         total_ineligible = self.total_patients_count - total_eligible
 
         # Find patients with at least one valid albuminuria stage criteria
@@ -4424,9 +4354,7 @@ class CalculateKPIS:
             )
 
         # First get new T1DM diagnoses pts
-        base_query_set, _ = (
-            self._get_kpi_3_total_t1dm_pts_and_count()
-        )
+        base_query_set, _ = self._get_kpi_3_total_t1dm_pts_and_count()
 
         # Filter for those diagnoses at least 90 days before audit end date
         self.t1dm_pts_diagnosed_90D_before_end_base_query_set = base_query_set.filter(

--- a/project/npda/templates/patient_report/components/pt_identifier_value.html
+++ b/project/npda/templates/patient_report/components/pt_identifier_value.html
@@ -3,7 +3,7 @@
       data-tip="View patient's visits"
       style="display: inline-flex;
              align-items: center">
-  <a href="{% data_url 'pdu-patient-visits' patient_id=patient_pk %}"
+  <a href="{% url 'pdu-patient-visits' patient_id=patient_pk audit_period=audit_period pz_code=pz_code %}"
      class="w-full h-full flex flex-row items-center">
     <span class="text-lg">{{ patient_identifier }}</span>
     <i class="fa-solid fa-arrow-up-right-from-square text-rcpch_strong_blue ml-1"></i>

--- a/project/npda/templates/patient_report/components/true_false_incomplete_icons.html
+++ b/project/npda/templates/patient_report/components/true_false_incomplete_icons.html
@@ -1,14 +1,20 @@
-{% if result is True %}
+{% if result is True or result == "True" %}
 {% comment %} PASS {% endcomment %}
   <i class="fa-solid fa-circle-check text-success text-xl"></i>
-{% elif result is False %}
+{% elif result is False or result == "False" %}
 {% comment %} FAIL {% endcomment %}
 <i class="fa-solid fa-circle-exclamation text-error text-xl"></i>
 {% else %}
 {% comment %} INELIGIBLE {% endcomment %}
   <div class="tooltip tooltip-bottom" data-tip="
   {% if ineligible_reason %}
-    {{ ineligible_reason }}
+    {% if result == "non_smoker_no_referral" %}
+      {{ ineligible_reason.non_smoker_no_referral }}
+    {% elif result == "under_12" %}
+      {{ ineligible_reason.under_12 }}
+    {% else %}
+      {{ ineligible_reason }}
+    {% endif %}
   {% else %}
     Not required
   {% endif %}

--- a/project/npda/templates/patient_report/health_checks_table_partial.html
+++ b/project/npda/templates/patient_report/health_checks_table_partial.html
@@ -148,7 +148,7 @@
     {% endif %}
     <tr class="{% if not patient.is_complete_year_of_care %}bg-rcpch_orange_light_tint3{% endif %}">
       <td>
-        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patient.pk is_complete_year_of_care=patient.is_complete_year_of_care patient_identifier=patient.patient_identifier %}
+        {% include "patient_report/components/pt_identifier_value.html" with patient_pk=patient.pk is_complete_year_of_care=patient.is_complete_year_of_care patient_identifier=patient.patient_identifier audit_period=audit_period pz_code=pz_code %}
       </td>
       <td>
         {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_hba1c %}

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -30,8 +30,10 @@ from project.npda.tests.factories import (
     dummy_sheets_folder,
     dummy_sheet_csv,
     dummy_sheet_csv_jersey,
-    dummy_sheet_csv_old_headers
+    dummy_sheet_csv_old_headers,
 )
+
+from project.npda.models import AuditPeriod
 
 logger = logging.getLogger(__name__)
 # register factories to be used across test directory
@@ -65,3 +67,15 @@ def test_pz_codes_fixture():
 @pytest.fixture(scope="function")
 def test_pz_codes_function_fixture():
     return ["PZ196", "PZ074", "PZ248"]  # GOSH  # Alder Hey  # Jersey
+
+
+@pytest.fixture(autouse=True)
+def ensure_audit_period(db, AUDIT_START_DATE, AUDIT_END_DATE):
+    """Ensure an AuditPeriod exists for each test."""
+    AuditPeriod.objects.get_or_create(
+        start_date=AUDIT_START_DATE,
+        end_date=AUDIT_END_DATE,
+        is_open=True,
+        is_visible=True,
+        slug=f"{AUDIT_START_DATE.year}-{AUDIT_END_DATE.year}",
+    )

--- a/project/npda/tests/kpi_calculations/test_kpis_33_40.py
+++ b/project/npda/tests/kpi_calculations/test_kpis_33_40.py
@@ -12,12 +12,15 @@ from project.npda.models import Patient
 from project.npda.tests import utils
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-from project.npda.tests.kpi_calculations.test_calculate_kpis import \
-    assert_kpi_result_equal
+from project.npda.tests.kpi_calculations.test_calculate_kpis import (
+    assert_kpi_result_equal,
+)
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_33(AUDIT_START_DATE):
+def test_kpi_calculation_33(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI33 is calculated correctly.
 
     Calculates KPI 33: HbA1c 4+ (%)
@@ -187,7 +190,9 @@ def test_kpi_calculation_33(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_34(AUDIT_START_DATE):
+def test_kpi_calculation_34(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI34 is calculated correctly.
 
     Numerator: Number of eligible patients with an entry for Psychological Screening Date (item 38) within the audit period
@@ -221,7 +226,8 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 34 specific
-        visit__psychological_screening_assessment_date=AUDIT_START_DATE + relativedelta(days=2),
+        visit__psychological_screening_assessment_date=AUDIT_START_DATE
+        + relativedelta(days=2),
     )
     # second visit has a valid psychological screening date
     passing_patient_2 = PatientFactory(
@@ -235,7 +241,8 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
     VisitFactory(
         patient=passing_patient_2,
         visit_date=AUDIT_START_DATE + relativedelta(days=5),
-        psychological_screening_assessment_date=AUDIT_START_DATE + relativedelta(days=5),
+        psychological_screening_assessment_date=AUDIT_START_DATE
+        + relativedelta(days=5),
     )
 
     # Failing patients
@@ -245,7 +252,8 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 34 specific
-        visit__psychological_screening_assessment_date=AUDIT_START_DATE - relativedelta(days=2),
+        visit__psychological_screening_assessment_date=AUDIT_START_DATE
+        - relativedelta(days=2),
     )
     # No psychological screening
     failing_patient_2 = PatientFactory(
@@ -329,7 +337,9 @@ def test_kpi_calculation_34(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_35(AUDIT_START_DATE):
+def test_kpi_calculation_35(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI35 is calculated correctly.
 
     Numerator: Number of eligible patients with at least one entry for Smoking Status (item 40) that is either 1 = Non-smoker or 2 = Curent smoker within the audit period (based on visit date)
@@ -348,7 +358,8 @@ def test_kpi_calculation_35(AUDIT_START_DATE):
         # Diagnosis of Type 1 diabetes
         "diabetes_type": DIABETES_TYPES[0][0],
         # KPI 6 specific = an observation within the audit period
-        "visit__height_weight_observation_date": AUDIT_START_DATE + relativedelta(days=2),
+        "visit__height_weight_observation_date": AUDIT_START_DATE
+        + relativedelta(days=2),
         # Also has same exclusions as KPI 5
         # Date of diagnosis NOT within the audit period
         "diagnosis_date": AUDIT_START_DATE - relativedelta(days=2),
@@ -466,7 +477,9 @@ def test_kpi_calculation_35(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_36(AUDIT_START_DATE):
+def test_kpi_calculation_36(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI36 is calculated correctly.
 
     Numerator: Number of eligible patients with an entry for Date of Smoking Cessation Referral (item 41) within the audit period
@@ -485,7 +498,8 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
         # Diagnosis of Type 1 diabetes
         "diabetes_type": DIABETES_TYPES[0][0],
         # KPI 6 specific = an observation within the audit period
-        "visit__height_weight_observation_date": AUDIT_START_DATE + relativedelta(days=2),
+        "visit__height_weight_observation_date": AUDIT_START_DATE
+        + relativedelta(days=2),
         "visit__visit_date": AUDIT_START_DATE + relativedelta(days=5),
         # Also has same exclusions as KPI 5
         # Date of diagnosis NOT within the audit period
@@ -503,6 +517,7 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 35 specific
+        visit__smoking_status=2,  # current smoker
         visit__smoking_cessation_referral_date=AUDIT_START_DATE + relativedelta(days=2),
     )
     # only second visit has a valid smoking cessation referral
@@ -517,6 +532,7 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
     VisitFactory(
         patient=passing_patient_2,
         visit_date=AUDIT_START_DATE + relativedelta(days=5),
+        smoking_status=2,  # current smoker
         smoking_cessation_referral_date=AUDIT_START_DATE + relativedelta(days=32),
     )
 
@@ -527,6 +543,7 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 35 specific
+        visit__smoking_status=2,  # current smoker
         visit__smoking_cessation_referral_date=None,
     )
 
@@ -590,7 +607,9 @@ def test_kpi_calculation_36(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_37(AUDIT_START_DATE):
+def test_kpi_calculation_37(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI37 is calculated correctly.
 
     Numerator: Numer of eligible patients with at least one entry for Additional Dietitian Appointment Offered (item 43) that is 1 = Yes within the audit period (based on visit date)
@@ -724,7 +743,9 @@ def test_kpi_calculation_37(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_38(AUDIT_START_DATE):
+def test_kpi_calculation_38(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI38 is calculated correctly.
 
     Numerator: Number of eligible patients with at least one entry for Additional Dietitian Appointment Date (item 44) within the audit year
@@ -758,7 +779,8 @@ def test_kpi_calculation_38(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 38 specific
-        visit__dietician_additional_appointment_date=AUDIT_START_DATE + relativedelta(days=30),
+        visit__dietician_additional_appointment_date=AUDIT_START_DATE
+        + relativedelta(days=30),
     )
     # only second visit has a valid additional dietician appt
     passing_patient_2 = PatientFactory(
@@ -858,7 +880,9 @@ def test_kpi_calculation_38(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_39(AUDIT_START_DATE):
+def test_kpi_calculation_39(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI39 is calculated correctly.
 
     Numerator: Number of eligible patients with at least one entry for Influzena Immunisation Recommended (item 24) within the audit period
@@ -892,7 +916,8 @@ def test_kpi_calculation_39(AUDIT_START_DATE):
         # KPI5 eligible
         **eligible_criteria,
         # KPI 39 specific
-        visit__flu_immunisation_recommended_date=AUDIT_START_DATE + relativedelta(days=30),
+        visit__flu_immunisation_recommended_date=AUDIT_START_DATE
+        + relativedelta(days=30),
     )
     # only second visit has a valid influenza immunisation recommended
     passing_patient_2 = PatientFactory(
@@ -992,7 +1017,9 @@ def test_kpi_calculation_39(AUDIT_START_DATE):
 
 
 @pytest.mark.django_db
-def test_kpi_calculation_40(AUDIT_START_DATE):
+def test_kpi_calculation_40(
+    seed_groups_fixture, seed_users_fixture, AUDIT_START_DATE, AUDIT_END_DATE
+):
     """Tests that KPI40 is calculated correctly.
 
     Numerator:Number of eligible patients with at least one entry for Sick

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -879,7 +879,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
 
 
 @pytest.mark.django_db
-def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
+def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screened(
     seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
@@ -938,7 +938,7 @@ def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
     patient = response.context["patients"][0]
 
     assert patient["patient_identifier"] == "4444444444"
-    assert patient["smoking_status"] is True
+    assert patient["smoking_status"] is None
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -27,7 +27,7 @@ from project.npda.models.submission import Submission
 from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
 from project.npda.tests.factories import (
     test_user_rcpch_audit_team_data,
-    test_user_audit_centre_editor_data
+    test_user_audit_centre_editor_data,
 )
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.urls import patient_report_urlpatterns
@@ -49,10 +49,10 @@ def test_anonymous_user_cannot_access_patient_report(
 
     for url in patient_report_urlpatterns:
         if url.name.startswith("pdu-"):
-            resolved_url = reverse(url.name, kwargs={
-                "audit_period": "2023-2024",
-                "pz_code": ALDER_HEY_PZ_CODE
-            })
+            resolved_url = reverse(
+                url.name,
+                kwargs={"audit_period": "2023-2024", "pz_code": ALDER_HEY_PZ_CODE},
+            )
         else:
             resolved_url = reverse(url.name)
 
@@ -111,10 +111,12 @@ def test_no_duplicate_patients_in_report(
     new_submission.patients.add(*new_pts)
 
     # Get the patient report
-    response = client.get(reverse("pdu-patient-report", kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            "pdu-patient-report",
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
     assert response.status_code == HTTPStatus.OK
 
     assert isinstance(response.context["patients"], list)
@@ -199,10 +201,13 @@ def test_outcomes_no_hba1c_measurements(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     # Get the patient report with outcomes category
     response = client.get(
@@ -267,10 +272,13 @@ def test_outcomes_single_hba1c_measurement(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     # Get the patient report with outcomes category
     response = client.get(
@@ -347,10 +355,13 @@ def test_outcomes_multiple_hba1c_measurements(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     # Get the patient report with outcomes category
     response = client.get(
@@ -384,10 +395,7 @@ def test_outcomes_multiple_hba1c_measurements(
 
 @pytest.mark.django_db
 def test_report_for_patients_turning_12_in_audit_year(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -406,7 +414,8 @@ def test_report_for_patients_turning_12_in_audit_year(
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=2), # complete year of care
+        diagnosis_date=audit_period.start_date
+        - relativedelta(days=2),  # complete year of care
     )
 
     # Need a visit in the audit period to be eligible
@@ -427,10 +436,13 @@ def test_report_for_patients_turning_12_in_audit_year(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.HEALTH_CHECKS.value}",
@@ -451,10 +463,13 @@ def test_report_for_patients_turning_12_in_audit_year(
     assert response.context["total_eligible_urinary_albumin"] == 0
     assert response.context["total_eligible_foot_exam"] == 0
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
@@ -468,16 +483,13 @@ def test_report_for_patients_turning_12_in_audit_year(
 
     assert patient["patient_identifier"] == "4444444444"
     assert patient["smoking_status"] is None
-    assert patient["smoking_cessation_referral"] is None
+    assert patient["smoking_cessation_referral"] == "under_12"
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1197
 @pytest.mark.django_db
 def test_report_for_sick_day_rules(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -496,7 +508,8 @@ def test_report_for_sick_day_rules(
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=2), # complete year of care
+        diagnosis_date=audit_period.start_date
+        - relativedelta(days=2),  # complete year of care
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -516,10 +529,13 @@ def test_report_for_sick_day_rules(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
@@ -538,10 +554,7 @@ def test_report_for_sick_day_rules(
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1199
 @pytest.mark.django_db
 def test_care_at_diagnosis_for_type_1_patient(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -560,7 +573,8 @@ def test_care_at_diagnosis_for_type_1_patient(
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+        diagnosis_date=audit_period.start_date
+        + relativedelta(days=2),  # diagnosed within the audit year
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -580,10 +594,13 @@ def test_care_at_diagnosis_for_type_1_patient(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.CARE_AT_DIAGNOSIS.value}",
@@ -606,10 +623,7 @@ def test_care_at_diagnosis_for_type_1_patient(
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1199
 @pytest.mark.django_db
 def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -628,7 +642,8 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[1][0],  # T2DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+        diagnosis_date=audit_period.start_date
+        + relativedelta(days=2),  # diagnosed within the audit year
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -648,10 +663,13 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.CARE_AT_DIAGNOSIS.value}",
@@ -665,10 +683,7 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -687,7 +702,8 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+        diagnosis_date=audit_period.start_date
+        + relativedelta(days=2),  # diagnosed within the audit year
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -709,10 +725,13 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.HEALTH_CHECKS.value}",
@@ -723,7 +742,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     assert len(response.context["patients"]) == 1
 
     patient = response.context["patients"][0]
-    
+
     assert patient["patient_identifier"] == "4444444444"
     assert patient["passed_hba1c"] is True
 
@@ -731,10 +750,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenza_immunisation_recommended(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -753,7 +769,8 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+        diagnosis_date=audit_period.start_date
+        + relativedelta(days=2),  # diagnosed within the audit year
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -773,10 +790,13 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
@@ -787,17 +807,14 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     assert len(response.context["patients"]) == 1
 
     patient = response.context["patients"][0]
-    
+
     assert patient["patient_identifier"] == "4444444444"
     assert patient["influenza_immunisation_recommended"] is True
 
 
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -816,7 +833,8 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date + relativedelta(days=2), # diagnosed within the audit year
+        diagnosis_date=audit_period.start_date
+        + relativedelta(days=2),  # diagnosed within the audit year
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -838,10 +856,13 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.HEALTH_CHECKS.value}",
@@ -852,17 +873,14 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     assert len(response.context["patients"]) == 1
 
     patient = response.context["patients"][0]
-    
+
     assert patient["patient_identifier"] == "4444444444"
     assert patient["passed_hba1c"] is True
 
 
 @pytest.mark.django_db
 def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -889,7 +907,7 @@ def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
     VisitFactory(
         patient=patient,
         visit_date=visit_date,
-        smoking_status=SMOKING_STATUS[0][0], # non smoker
+        smoking_status=SMOKING_STATUS[0][0],  # non smoker
     )
 
     submission = Submission.objects.create(
@@ -901,10 +919,13 @@ def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
     )
     submission.patients.add(patient)
 
-    url = reverse("pdu-patient-report", kwargs={
-        "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
 
     response = client.get(
         url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
@@ -915,6 +936,71 @@ def test_patient_under_12yo_can_still_show_as_passing_smoking_status_screened(
     assert len(response.context["patients"]) == 1
 
     patient = response.context["patients"][0]
-    
+
     assert patient["patient_identifier"] == "4444444444"
     assert patient["smoking_status"] is True
+
+
+@pytest.mark.django_db
+def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessation_referral(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        smoking_status=SMOKING_STATUS[0][0],  # non smoker
+        smoking_cessation_referral_date=None,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["smoking_status"] is True
+    assert patient["smoking_cessation_referral"] == "non_smoker_no_referral"

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -360,12 +360,29 @@ def calculate_queryset(
                 ),
                 smoking_status=Case(
                     When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_35_smoking_status_screened_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
+                        Q(visit__smoking_status__in=[1, 2])  # smoker
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
                         ),
                         then=True,
+                    ),
+                    When(
+                        Q(visit__smoking_status=99)  # not known
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=False,
+                    ),
+                    When(
+                        Q(
+                            date_of_birth__gt=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=None,
                     ),
                     default=Case(
                         When(is_gte_12yo=True, then=False),

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -963,6 +963,8 @@ class PatientReportView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        context["audit_period"] = self.audit_period.slug
+        context["pz_code"] = self.pdu.pz_code
         context["is_jersey"] = self.pdu.pz_code == "PZ248"
 
         # Add table categories to the context

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -72,6 +72,7 @@ class TableCategories(Enum):
     def default(cls):
         return cls.HEALTH_CHECKS.value
 
+
 def calculate_hba1c_values(pt_qs: QuerySet[Patient], calculate_kpis: CalculateKPIS):
     """Helper function to calculate HbA1c values for a queryset."""
     patient_ids = set(pt_qs.values_list("pk", flat=True))
@@ -88,8 +89,7 @@ def calculate_hba1c_values(pt_qs: QuerySet[Patient], calculate_kpis: CalculateKP
                 ),
                 When(
                     Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                    then=(F("hba1c") - Round(Decimal("2.152")))
-                    / Decimal("0.09148"),
+                    then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
                 ),
                 default=None,
                 output_field=DecimalField(max_digits=5, decimal_places=2),
@@ -100,9 +100,7 @@ def calculate_hba1c_values(pt_qs: QuerySet[Patient], calculate_kpis: CalculateKP
     )
     hba1c_values_by_patient = defaultdict(list)
     for visit in valid_visits_with_hba1c:
-        hba1c_values_by_patient[visit["patient__pk"]].append(
-            visit["hba1c_mmol_mol"]
-        )
+        hba1c_values_by_patient[visit["patient__pk"]].append(visit["hba1c_mmol_mol"])
     for patient in pt_qs:
         hba1c_values = hba1c_values_by_patient.get(patient["pk"], [])
         if hba1c_values:
@@ -127,15 +125,19 @@ def calculate_hba1c_values(pt_qs: QuerySet[Patient], calculate_kpis: CalculateKP
             patient["kpi_45_median_hba1c"] = None
             patient["mean_hba1c_pct"] = None
             patient["median_hba1c_pct"] = None
-    
+
     return pt_qs
 
 
-def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_category: str) -> QuerySet[Patient]:
+def calculate_queryset(
+    pz_code: str, audit_period: AuditPeriod, selected_category: str
+) -> QuerySet[Patient]:
     calculation_date = audit_period.kpi_calculation_date()
 
     calculate_kpis = CalculateKPIS(
-        calculation_date=calculation_date, return_pt_querysets=True, is_jersey=pz_code == "PZ248"
+        calculation_date=calculation_date,
+        return_pt_querysets=True,
+        is_jersey=pz_code == "PZ248",
     )
     calculate_kpis.set_patients_for_calculation(pz_codes=[pz_code])
     patient_identifier = (
@@ -155,288 +157,333 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
         is_complete_year_of_care=Case(
             When(
                 Exists(
-                    all_t1dm_pts_with_complete_year_of_care.filter(
-                        pk=OuterRef("pk")
-                    )
+                    all_t1dm_pts_with_complete_year_of_care.filter(pk=OuterRef("pk"))
                 ),
                 then=True,
             ),
             default=False,
             output_field=BooleanField(),
         )
-    ) 
-        
-    if selected_category == TableCategories.HEALTH_CHECKS.value:    
-        pt_qs = pt_qs.annotate(
-            is_gte_12yo=Q(
-                date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
-            ),
-            passed_hba1c=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_25_hba1c_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
+    )
+
+    if selected_category == TableCategories.HEALTH_CHECKS.value:
+        pt_qs = (
+            pt_qs.annotate(
+                is_gte_12yo=Q(
+                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            passed_bmi=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_26_bmi_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                passed_hba1c=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_25_hba1c_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            passed_thyroid_screen=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_27_thyroid_screen_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
-                ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            passed_blood_pressure=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_28_blood_pressure_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=False,
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            passed_urinary_albumin=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_29_urinary_albumin_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                passed_bmi=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_26_bmi_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=False,
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            passed_retinal_screening=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_30_retinal_screening_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                passed_thyroid_screen=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_27_thyroid_screen_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=False,
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            passed_foot_exam=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_31_foot_examination_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                passed_blood_pressure=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_28_blood_pressure_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=Case(
+                        When(is_gte_12yo=True, then=False),
+                        default=None,
+                        output_field=BooleanField(),
+                    ),
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            num_passed=Case(
-                When(
-                    is_gte_12yo=True,
-                    then=(
-                        Case(When(passed_hba1c=True, then=1), default=0)
-                        + Case(When(passed_bmi=True, then=1), default=0)
-                        + Case(When(passed_thyroid_screen=True, then=1), default=0)
-                        + Case(When(passed_blood_pressure=True, then=1), default=0)
-                        + Case(When(passed_urinary_albumin=True, then=1), default=0)
-                        + Case(When(passed_foot_exam=True, then=1), default=0)
+                passed_urinary_albumin=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_29_urinary_albumin_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                ),
-                When(
-                    is_gte_12yo=False,
-                    then=(
-                        Case(When(passed_hba1c=True, then=1), default=0)
-                        + Case(When(passed_bmi=True, then=1), default=0)
-                        + Case(When(passed_thyroid_screen=True, then=1), default=0)
+                    default=Case(
+                        When(is_gte_12yo=True, then=False),
+                        default=None,
+                        output_field=BooleanField(),
                     ),
+                    output_field=BooleanField(),
                 ),
-                default=0,
-                output_field=IntegerField(),
-            ),
-            num_total=Case(
-                When(is_gte_12yo=True, then=6),
-                When(is_gte_12yo=False, then=3),
-                default=0,
-                output_field=IntegerField(),
-            ),
-        ).order_by("-is_complete_year_of_care", "-passed_hba1c", "-passed_bmi", "-passed_thyroid_screen", "-passed_blood_pressure", "-passed_urinary_albumin", "-passed_foot_exam", "patient_identifier").values(
-            "pk",
-            "patient_identifier",
-            "is_gte_12yo",
-            "is_complete_year_of_care",
-            "passed_hba1c",
-            "passed_bmi",
-            "passed_thyroid_screen",
-            "passed_blood_pressure",
-            "passed_urinary_albumin",
-            "passed_foot_exam",
-            "num_passed",
-            "num_total",
-            "passed_retinal_screening",
+                passed_retinal_screening=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_30_retinal_screening_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=Case(
+                        When(is_gte_12yo=True, then=False),
+                        default=None,
+                        output_field=BooleanField(),
+                    ),
+                    output_field=BooleanField(),
+                ),
+                passed_foot_exam=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_31_foot_examination_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=Case(
+                        When(is_gte_12yo=True, then=False),
+                        default=None,
+                        output_field=BooleanField(),
+                    ),
+                    output_field=BooleanField(),
+                ),
+                num_passed=Case(
+                    When(
+                        is_gte_12yo=True,
+                        then=(
+                            Case(When(passed_hba1c=True, then=1), default=0)
+                            + Case(When(passed_bmi=True, then=1), default=0)
+                            + Case(When(passed_thyroid_screen=True, then=1), default=0)
+                            + Case(When(passed_blood_pressure=True, then=1), default=0)
+                            + Case(When(passed_urinary_albumin=True, then=1), default=0)
+                            + Case(When(passed_foot_exam=True, then=1), default=0)
+                        ),
+                    ),
+                    When(
+                        is_gte_12yo=False,
+                        then=(
+                            Case(When(passed_hba1c=True, then=1), default=0)
+                            + Case(When(passed_bmi=True, then=1), default=0)
+                            + Case(When(passed_thyroid_screen=True, then=1), default=0)
+                        ),
+                    ),
+                    default=0,
+                    output_field=IntegerField(),
+                ),
+                num_total=Case(
+                    When(is_gte_12yo=True, then=6),
+                    When(is_gte_12yo=False, then=3),
+                    default=0,
+                    output_field=IntegerField(),
+                ),
+            )
+            .order_by(
+                "-is_complete_year_of_care",
+                "-passed_hba1c",
+                "-passed_bmi",
+                "-passed_thyroid_screen",
+                "-passed_blood_pressure",
+                "-passed_urinary_albumin",
+                "-passed_foot_exam",
+                "patient_identifier",
+            )
+            .values(
+                "pk",
+                "patient_identifier",
+                "is_gte_12yo",
+                "is_complete_year_of_care",
+                "passed_hba1c",
+                "passed_bmi",
+                "passed_thyroid_screen",
+                "passed_blood_pressure",
+                "passed_urinary_albumin",
+                "passed_foot_exam",
+                "num_passed",
+                "num_total",
+                "passed_retinal_screening",
+            )
         )
     elif selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
-        pt_qs = pt_qs.annotate(
-            hba1c_4plus=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_33_hba1c_4plus_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+        pt_qs = (
+            pt_qs.annotate(
+                hba1c_4plus=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_33_hba1c_4plus_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            psychological_assessment=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_34_psychological_assessment_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
-                ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            is_gte_12yo=Q(
-                date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
-            ),
-            smoking_status=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_35_smoking_status_screened_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=False,
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            smoking_cessation_referral=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                psychological_assessment=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_34_psychological_assessment_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=Case(
-                    When(is_gte_12yo=True, then=False),
-                    default=None,
+                    default=False,
                     output_field=BooleanField(),
                 ),
-                output_field=BooleanField(),
-            ),
-            additional_dietetic_appt_offered=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=True,
+                is_gte_12yo=Q(
+                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            pts_attending_additional_dietetic_appt=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                smoking_status=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_35_smoking_status_screened_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
-                ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            influenza_immunisation_recommended=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                    default=Case(
+                        When(is_gte_12yo=True, then=False),
+                        default=None,
+                        output_field=BooleanField(),
                     ),
-                    then=True,
+                    output_field=BooleanField(),
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            sick_day_rules_advice=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_40_sick_day_rules_advice()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                smoking_cessation_referral=Case(
+                    When(  # Smoker with referral over 12 years old during audit period
+                        Q(visit__smoking_status=2)  # smoker
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(visit__smoking_cessation_referral_date__isnull=False)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=Value("True"),
                     ),
-                    then=True,
+                    When(  # Non-smoker during audit period over 12 years old no referral needed
+                        Q(visit__smoking_status=1)  # non-smoker
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
+                        )
+                        & Q(visit__smoking_cessation_referral_date__isnull=True),
+                        then=Value("non_smoker_no_referral"),
+                    ),
+                    When(  # Under 12 years old no eligible
+                        Q(
+                            date_of_birth__gt=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=Value("under_12"),
+                    ),
+                    default=Case(
+                        When(is_gte_12yo=True, then=Value("False")),
+                        default=None,
+                        output_field=CharField(),
+                    ),
+                    output_field=CharField(),
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-        ).order_by("-is_complete_year_of_care", "-hba1c_4plus", "-psychological_assessment", "-smoking_status", "-smoking_cessation_referral", "-additional_dietetic_appt_offered", "-pts_attending_additional_dietetic_appt", "-influenza_immunisation_recommended", "-sick_day_rules_advice", "patient_identifier").values(
-            "pk",
-            "patient_identifier",
-            "is_complete_year_of_care",
-            "is_gte_12yo",
-            "hba1c_4plus",
-            "psychological_assessment",
-            "smoking_status",
-            "smoking_cessation_referral",
-            "additional_dietetic_appt_offered",
-            "pts_attending_additional_dietetic_appt",
-            "influenza_immunisation_recommended",
-            "sick_day_rules_advice",
+                additional_dietetic_appt_offered=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+                pts_attending_additional_dietetic_appt=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+                influenza_immunisation_recommended=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+                sick_day_rules_advice=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_40_sick_day_rules_advice()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
+                    ),
+                    default=False,
+                    output_field=BooleanField(),
+                ),
+            )
+            .order_by(
+                "-is_complete_year_of_care",
+                "-hba1c_4plus",
+                "-psychological_assessment",
+                "-smoking_status",
+                "-smoking_cessation_referral",
+                "-additional_dietetic_appt_offered",
+                "-pts_attending_additional_dietetic_appt",
+                "-influenza_immunisation_recommended",
+                "-sick_day_rules_advice",
+                "patient_identifier",
+            )
+            .values(
+                "pk",
+                "patient_identifier",
+                "is_complete_year_of_care",
+                "is_gte_12yo",
+                "hba1c_4plus",
+                "psychological_assessment",
+                "smoking_status",
+                "smoking_cessation_referral",
+                "additional_dietetic_appt_offered",
+                "pts_attending_additional_dietetic_appt",
+                "influenza_immunisation_recommended",
+                "sick_day_rules_advice",
+            )
         )
     elif selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
         pt_qs = calculate_kpis.calculate_kpi_2_total_new_diagnoses().patient_querysets[
@@ -445,51 +492,60 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
         pt_qs = pt_qs.filter(
             diabetes_type=DIABETES_TYPES[0][0]  # T1DM
         )
-        pt_qs = pt_qs.annotate(
-            patient_identifier=F(patient_identifier),
-            coeliac_disease_screening=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_41_coeliac_disease_screening()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+        pt_qs = (
+            pt_qs.annotate(
+                patient_identifier=F(patient_identifier),
+                coeliac_disease_screening=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_41_coeliac_disease_screening()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
+                    default=False,
+                    output_field=BooleanField(),
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            thyroid_disease_screening=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_42_thyroid_disease_screening()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                thyroid_disease_screening=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_42_thyroid_disease_screening()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
+                    default=False,
+                    output_field=BooleanField(),
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-            carbohydrate_counting_education=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_43_carbohydrate_counting_education()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
+                carbohydrate_counting_education=Case(
+                    When(
+                        Exists(
+                            calculate_kpis.calculate_kpi_43_carbohydrate_counting_education()
+                            .patient_querysets["passed"]
+                            .filter(pk=OuterRef("pk"))
+                        ),
+                        then=True,
                     ),
-                    then=True,
+                    default=False,
+                    output_field=BooleanField(),
                 ),
-                default=False,
-                output_field=BooleanField(),
-            ),
-        ).order_by("-coeliac_disease_screening", "-thyroid_disease_screening", "-carbohydrate_counting_education", "patient_identifier").values(
-            "pk",
-            "patient_identifier",
-            "diagnosis_date",
-            "coeliac_disease_screening",
-            "thyroid_disease_screening",
-            "carbohydrate_counting_education",
+            )
+            .order_by(
+                "-coeliac_disease_screening",
+                "-thyroid_disease_screening",
+                "-carbohydrate_counting_education",
+                "patient_identifier",
+            )
+            .values(
+                "pk",
+                "patient_identifier",
+                "diagnosis_date",
+                "coeliac_disease_screening",
+                "thyroid_disease_screening",
+                "carbohydrate_counting_education",
+            )
         )
     elif selected_category == TableCategories.ADMISSIONS.value:
         pt_qs = (
@@ -523,17 +579,15 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
                         )
                     )
                     & Q(
-                        visit__hospital_admission_reason=HOSPITAL_ADMISSION_REASONS[
-                            1
-                        ][0]
+                        visit__hospital_admission_reason=HOSPITAL_ADMISSION_REASONS[1][
+                            0
+                        ]
                     )
                     & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE),
                     distinct=True,
                 ),
             )
-            .filter(
-                Q(number_of_admissions__gt=0) | Q(number_of_dka_admissions__gt=0)
-            )
+            .filter(Q(number_of_admissions__gt=0) | Q(number_of_dka_admissions__gt=0))
             .values(
                 "pk",
                 "patient_identifier",
@@ -583,16 +637,18 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
                 ),
                 days_delta_between_latest_and_previous_hba1c=Case(
                     When(
-                        Q(latest_hba1c_date__isnull=False) & Q(previous_to_latest_hba1c_date__isnull=False),
+                        Q(latest_hba1c_date__isnull=False)
+                        & Q(previous_to_latest_hba1c_date__isnull=False),
                         then=Func(
                             ExpressionWrapper(
-                                F("latest_hba1c_date") - F("previous_to_latest_hba1c_date"),
-                                output_field=DurationField()
+                                F("latest_hba1c_date")
+                                - F("previous_to_latest_hba1c_date"),
+                                output_field=DurationField(),
                             ),
-                            function='EXTRACT',
+                            function="EXTRACT",
                             template="EXTRACT(DAY FROM %(expressions)s)",
-                            output_field=IntegerField()
-                        )
+                            output_field=IntegerField(),
+                        ),
                     ),
                     default=None,
                     output_field=IntegerField(),
@@ -660,8 +716,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
                         Q(previous_to_latest_hba1c_mmol_mol__isnull=False)
                         & Q(previous_to_latest_hba1c_mmol_mol__gt=0),
                         then=(
-                            Decimal("0.09148")
-                            * F("previous_to_latest_hba1c_mmol_mol")
+                            Decimal("0.09148") * F("previous_to_latest_hba1c_mmol_mol")
                         )
                         + Decimal("2.152"),
                     ),
@@ -810,7 +865,7 @@ def calculate_queryset(pz_code: str, audit_period: AuditPeriod, selected_categor
             "glucose_monitoring",
             "hcl",
         )
-    
+
     return pt_qs, calculate_kpis, patient_identifier
 
 
@@ -839,9 +894,7 @@ class PatientReportView(
         pz_code = self.pdu.pz_code
 
         pt_qs, calculate_kpis, patient_identifier = calculate_queryset(
-            pz_code,
-            self.audit_period,
-            category
+            pz_code, self.audit_period, category
         )
 
         # Save to use later in get_context_data
@@ -851,7 +904,9 @@ class PatientReportView(
         if sort_field:
             # Handle sort direction
             if sort_field == "unique_identifier":
-                sort_field = "unique_reference_number" if pz_code == "PZ248" else "nhs_number"
+                sort_field = (
+                    "unique_reference_number" if pz_code == "PZ248" else "nhs_number"
+                )
             if sort_order == "desc":
                 sort_field = f"-{sort_field}"
 
@@ -864,11 +919,11 @@ class PatientReportView(
                 field_name = sort_field.replace("-", "")
                 # Calculate HbA1c values
                 pt_qs = calculate_hba1c_values(pt_qs, calculate_kpis)
-                
+
                 pt_qs = sorted(
                     pt_qs,
                     key=lambda p: (
-                        p.get(field_name) is None, 
+                        p.get(field_name) is None,
                         p.get(field_name) or 0,
                     ),
                     reverse=reverse,
@@ -912,72 +967,141 @@ class PatientReportView(
 
             def get_patient_ids_and_count(**kwargs):
                 patient_queryset = self.object_list.filter(**kwargs)
-                return patient_queryset.values_list("pk", flat=True), patient_queryset.count()
+                return patient_queryset.values_list(
+                    "pk", flat=True
+                ), patient_queryset.count()
 
-            def add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count):
-                context[f"total_passed_{kpi_name}"] = kpi_result.patient_querysets["passed"].filter(pk__in=patient_ids).count()
+            def add_kpi_total(
+                context, kpi_name, kpi_result, patient_ids, patient_count
+            ):
+                context[f"total_passed_{kpi_name}"] = (
+                    kpi_result.patient_querysets["passed"]
+                    .filter(pk__in=patient_ids)
+                    .count()
+                )
                 context[f"total_eligible_{kpi_name}"] = patient_count
 
-            complete_year = get_patient_ids_and_count(
-                is_complete_year_of_care=True
-            )
+            complete_year = get_patient_ids_and_count(is_complete_year_of_care=True)
 
             # For age-specific checks (12+ years old at start of audit period)
             complete_year_12plus = get_patient_ids_and_count(
                 is_complete_year_of_care=True,
-                date_of_birth__lte=self.audit_period.start_date - relativedelta(years=12)
+                date_of_birth__lte=self.audit_period.start_date
+                - relativedelta(years=12),
             )
 
             for kpi_name, kpi_result, (patient_ids, patient_count) in [
                 ("hba1c", self.calculate_kpis.calculate_kpi_25_hba1c(), complete_year),
                 ("bmi", self.calculate_kpis.calculate_kpi_26_bmi(), complete_year),
-                ("thyroid_screen", self.calculate_kpis.calculate_kpi_27_thyroid_screen(), complete_year),
-                ("blood_pressure", self.calculate_kpis.calculate_kpi_28_blood_pressure(), complete_year_12plus),
-                ("urinary_albumin", self.calculate_kpis.calculate_kpi_29_urinary_albumin(), complete_year_12plus),
-                ("foot_exam", self.calculate_kpis.calculate_kpi_31_foot_examination(), complete_year_12plus),
-                ("retinal_screening", self.calculate_kpis.calculate_kpi_30_retinal_screening(), complete_year),
+                (
+                    "thyroid_screen",
+                    self.calculate_kpis.calculate_kpi_27_thyroid_screen(),
+                    complete_year,
+                ),
+                (
+                    "blood_pressure",
+                    self.calculate_kpis.calculate_kpi_28_blood_pressure(),
+                    complete_year_12plus,
+                ),
+                (
+                    "urinary_albumin",
+                    self.calculate_kpis.calculate_kpi_29_urinary_albumin(),
+                    complete_year_12plus,
+                ),
+                (
+                    "foot_exam",
+                    self.calculate_kpis.calculate_kpi_31_foot_examination(),
+                    complete_year_12plus,
+                ),
+                (
+                    "retinal_screening",
+                    self.calculate_kpis.calculate_kpi_30_retinal_screening(),
+                    complete_year,
+                ),
             ]:
                 add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count)
-        
+
         elif self.selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
             context["ineligible_reasons"] = {
                 "smoking_status": "Not required as less than 12 years old",
-                "smoking_cessation_referral": "Not required as less than 12 years old",
+                "smoking_cessation_referral": {
+                    "under_12": "Not required as less than 12 years old",
+                    "non_smoker_no_referral": "Not required as non-smoker",
+                },
             }
 
             def get_patient_ids_and_count(**kwargs):
                 patient_queryset = self.object_list.filter(**kwargs)
-                return patient_queryset.values_list("pk", flat=True), patient_queryset.count()
+                return patient_queryset.values_list(
+                    "pk", flat=True
+                ), patient_queryset.count()
 
-            def add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count):
-                context[f"total_passed_{kpi_name}"] = kpi_result.patient_querysets["passed"].filter(pk__in=patient_ids).count()
+            def add_kpi_total(
+                context, kpi_name, kpi_result, patient_ids, patient_count
+            ):
+                context[f"total_passed_{kpi_name}"] = (
+                    kpi_result.patient_querysets["passed"]
+                    .filter(pk__in=patient_ids)
+                    .count()
+                )
                 context[f"total_eligible_{kpi_name}"] = patient_count
 
-            complete_year = get_patient_ids_and_count(
-                is_complete_year_of_care=True
-            )
+            complete_year = get_patient_ids_and_count(is_complete_year_of_care=True)
 
             # For age-specific checks (12+ years old at start of audit period)
             complete_year_12plus = get_patient_ids_and_count(
                 is_complete_year_of_care=True,
-                date_of_birth__lte=self.audit_period.start_date - relativedelta(years=12)
+                date_of_birth__lte=self.audit_period.start_date
+                - relativedelta(years=12),
             )
 
             for kpi_name, kpi_result, (patient_ids, patient_count) in [
-                ("hba1c_4plus", self.calculate_kpis.calculate_kpi_33_hba1c_4plus(), complete_year),
-                ("psychological_assessment", self.calculate_kpis.calculate_kpi_34_psychological_assessment(), complete_year),
-                ("additional_dietetic_appt_offered", self.calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered(), complete_year),
-                ("pts_attending_additional_dietetic_appt", self.calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment(), complete_year),
-                ("influenza_immunisation_recommended", self.calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended(), complete_year),
-                ("sick_day_rules_advice", self.calculate_kpis.calculate_kpi_40_sick_day_rules_advice(), complete_year),
-                ("smoking_status", self.calculate_kpis.calculate_kpi_35_smoking_status_screened(), complete_year_12plus),
-                ("smoking_cessation_referral", self.calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service(), complete_year_12plus),
+                (
+                    "hba1c_4plus",
+                    self.calculate_kpis.calculate_kpi_33_hba1c_4plus(),
+                    complete_year,
+                ),
+                (
+                    "psychological_assessment",
+                    self.calculate_kpis.calculate_kpi_34_psychological_assessment(),
+                    complete_year,
+                ),
+                (
+                    "additional_dietetic_appt_offered",
+                    self.calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered(),
+                    complete_year,
+                ),
+                (
+                    "pts_attending_additional_dietetic_appt",
+                    self.calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment(),
+                    complete_year,
+                ),
+                (
+                    "influenza_immunisation_recommended",
+                    self.calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended(),
+                    complete_year,
+                ),
+                (
+                    "sick_day_rules_advice",
+                    self.calculate_kpis.calculate_kpi_40_sick_day_rules_advice(),
+                    complete_year,
+                ),
+                (
+                    "smoking_status",
+                    self.calculate_kpis.calculate_kpi_35_smoking_status_screened(),
+                    complete_year_12plus,
+                ),
+                (
+                    "smoking_cessation_referral",
+                    self.calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service(),
+                    complete_year_12plus,
+                ),
             ]:
                 add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count)
 
-        context["breadcrumbs"] = data_breadcrumbs(self.pdu, self.audit_period, [
-            ("Patient Report", "pdu-patient-report")
-        ])
+        context["breadcrumbs"] = data_breadcrumbs(
+            self.pdu, self.audit_period, [("Patient Report", "pdu-patient-report")]
+        )
 
         return context
 
@@ -1005,7 +1129,7 @@ class PatientReportView(
         return ["patient_report/patient_report.html"]
 
 
-def measure_status(complete: bool | None) -> str: 
+def measure_status(complete: bool | None) -> str:
     match complete:
         case True:
             return "COMPLETE"
@@ -1013,6 +1137,7 @@ def measure_status(complete: bool | None) -> str:
             return "INCOMPLETE"
         case None:
             return "NA"
+
 
 @login_and_otp_required()
 @check_data_permissions()
@@ -1026,7 +1151,7 @@ def download_patient_report(request, audit_period, pdu):
                 audit_period=audit_period,
                 selected_category=category.value,
             )
-            
+
             data = defaultdict(list)
 
             for row in pt_qs:
@@ -1034,8 +1159,12 @@ def download_patient_report(request, audit_period, pdu):
 
                 match category:
                     case TableCategories.HEALTH_CHECKS:
-                        data["complete_year_of_care"].append(row["is_complete_year_of_care"])
-                        data["gte_12yo_at_start_of_audit_year"].append(row["is_gte_12yo"])
+                        data["complete_year_of_care"].append(
+                            row["is_complete_year_of_care"]
+                        )
+                        data["gte_12yo_at_start_of_audit_year"].append(
+                            row["is_gte_12yo"]
+                        )
 
                         data["passed_yearly_checks"].append(row["num_passed"])
                         data["total_yearly_checks"].append(row["num_total"])
@@ -1047,15 +1176,19 @@ def download_patient_report(request, audit_period, pdu):
                             "blood_pressure",
                             "urinary_albumin",
                             "foot_exam",
-                            "retinal_screening"
+                            "retinal_screening",
                         ]
 
                         for field in fields:
                             data[field].append(measure_status(row[f"passed_{field}"]))
 
                     case TableCategories.ADDITIONAL_CARE_PROCESSES:
-                        data["complete_year_of_care"].append(row["is_complete_year_of_care"])
-                        data["gte_12yo_at_start_of_audit_year"].append(row["is_gte_12yo"])
+                        data["complete_year_of_care"].append(
+                            row["is_complete_year_of_care"]
+                        )
+                        data["gte_12yo_at_start_of_audit_year"].append(
+                            row["is_gte_12yo"]
+                        )
 
                         fields = [
                             "psychological_assessment",
@@ -1064,26 +1197,28 @@ def download_patient_report(request, audit_period, pdu):
                             "additional_dietetic_appt_offered",
                             "pts_attending_additional_dietetic_appt",
                             "influenza_immunisation_recommended",
-                            "sick_day_rules_advice"
+                            "sick_day_rules_advice",
                         ]
 
                         for field in fields:
                             data[field].append(measure_status(row[field]))
-                    
+
                     case TableCategories.CARE_AT_DIAGNOSIS:
                         data["diagnosis_date"].append(row["diagnosis_date"])
 
                         fields = [
                             "coeliac_disease_screening",
                             "thyroid_disease_screening",
-                            "carbohydrate_counting_education"
+                            "carbohydrate_counting_education",
                         ]
 
                         for field in fields:
                             data[field].append(measure_status(row[field]))
 
                     case TableCategories.ADMISSIONS:
-                        data["complete_year_of_care"].append(row["is_complete_year_of_care"])
+                        data["complete_year_of_care"].append(
+                            row["is_complete_year_of_care"]
+                        )
 
                         data["mean_hba1c_mmolmol"].append(row["kpi_44_mean_hba1c"])
                         data["mean_hba1c_pct"].append(row["mean_hba1c_pct"])
@@ -1091,15 +1226,20 @@ def download_patient_report(request, audit_period, pdu):
                         data["median_hba1c_mmolmol"].append(row["kpi_45_median_hba1c"])
                         data["median_hba1c_pct"].append(row["median_hba1c_pct"])
 
-                        for field in ["number_of_admissions", "number_of_dka_admissions"]:
+                        for field in [
+                            "number_of_admissions",
+                            "number_of_dka_admissions",
+                        ]:
                             data[field].append(row[field])
-                    
+
                     case TableCategories.TREATMENT:
                         for field in ["treatment_regimen", "glucose_monitoring", "hcl"]:
                             data[field].append(row[field])
-                    
+
                     case TableCategories.OUTCOMES:
-                        data["complete_year_of_care"].append(row["is_complete_year_of_care"])
+                        data["complete_year_of_care"].append(
+                            row["is_complete_year_of_care"]
+                        )
 
                         fields = [
                             "latest_hba1c_mmol_mol",
@@ -1109,7 +1249,7 @@ def download_patient_report(request, audit_period, pdu):
                             "hba1c_delta",
                             "latest_hba1c_date",
                             "previous_to_latest_hba1c_date",
-                            "days_delta_between_latest_and_previous_hba1c"
+                            "days_delta_between_latest_and_previous_hba1c",
                         ]
 
                         for field in fields:
@@ -1124,6 +1264,5 @@ def download_patient_report(request, audit_period, pdu):
     return HttpResponse(
         contents.getvalue(),
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={
-            "Content-Disposition": f'attachment; filename="{filename}"'
-        })
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -58,15 +58,23 @@ class PatientVisitsListView(
     model = Visit
     template_name = "visits.html"
 
-    def get_context_data(self, **kwargs):
-        patient_id = self.kwargs.get("patient_id")
-        context = super(PatientVisitsListView, self).get_context_data(**kwargs)
-        patient = Patient.objects.get(pk=patient_id)
+    def dispatch(self, request, *args, **kwargs):
+        # Pull context from URL instead of defaulting to "current"
+        self.audit_period_slug = kwargs.get("audit_period")
+        self.pz_code = kwargs.get("pz_code")
+        self.audit_period = get_object_or_404(AuditPeriod, slug=self.audit_period_slug)
+        return super().dispatch(request, *args, **kwargs)
 
-        audit_period = self.audit_period
+    def get_context_data(self, **kwargs):
+        context = super(PatientVisitsListView, self).get_context_data(**kwargs)
+        context["audit_period"] = self.audit_period
+        context["pz_code"] = self.pz_code
+        context["patient_id"] = self.kwargs["patient_id"]
+        patient = get_object_or_404(Patient, pk=context["patient_id"])
+
         submission = patient.submissions.filter(
             submission_active=True,
-            audit_period=audit_period,
+            audit_period=self.audit_period,
         ).first()
         visits = (
             Visit.objects.filter(  # filter visits to those within the audit year
@@ -74,7 +82,8 @@ class PatientVisitsListView(
             )
             .filter(
                 visit_falls_within_audit_period_Q_object(
-                    audit_start_date=audit_period.start_date, prepend_query_path=None
+                    audit_start_date=self.audit_period.start_date,
+                    prepend_query_path=None,
                 )
             )
             .order_by("is_valid", "id")
@@ -86,10 +95,10 @@ class PatientVisitsListView(
         context["visits"] = calculated_visits
         context["patient"] = patient
         context["submission"] = submission
-        paediatric_diabetes_unit = submission.paediatric_diabetes_unit
-
+        paediatric_diabetes_unit = getattr(
+            submission, "paediatric_diabetes_unit", getattr(self, "pdu", None)
+        )
         context["paediatric_diabetes_unit"] = paediatric_diabetes_unit
-        context["audit_period"] = audit_period
 
         context["breadcrumbs"] = patient_breadcrumbs(
             self.pdu,

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -21,7 +21,7 @@ from ..general_functions import (
     get_visit_tabs,
     visit_falls_within_audit_period_Q_object,
     data_breadcrumbs,
-    patient_breadcrumbs
+    patient_breadcrumbs,
 )
 from ..models import Patient, Transfer, Visit, AuditPeriod
 from .mixins import (
@@ -29,7 +29,7 @@ from .mixins import (
     CheckCurrentAuditYearMixin,
     LoginAndOTPRequiredMixin,
     PDUPermissionMixin,
-    QuestionnaireContextMixin
+    QuestionnaireContextMixin,
 )
 
 # Third party imports
@@ -37,7 +37,11 @@ logger = logging.getLogger(__name__)
 
 
 class PatientVisitsListView(
-    LoginAndOTPRequiredMixin, PDUPermissionMixin, PermissionRequiredMixin, QuestionnaireContextMixin, ListView
+    LoginAndOTPRequiredMixin,
+    PDUPermissionMixin,
+    PermissionRequiredMixin,
+    QuestionnaireContextMixin,
+    ListView,
 ):
     """
     The PatientVisitsListView class.
@@ -58,6 +62,7 @@ class PatientVisitsListView(
         patient_id = self.kwargs.get("patient_id")
         context = super(PatientVisitsListView, self).get_context_data(**kwargs)
         patient = Patient.objects.get(pk=patient_id)
+
         audit_period = self.audit_period
         submission = patient.submissions.filter(
             submission_active=True,
@@ -86,12 +91,19 @@ class PatientVisitsListView(
         context["paediatric_diabetes_unit"] = paediatric_diabetes_unit
         context["audit_period"] = audit_period
 
-        context["breadcrumbs"] = patient_breadcrumbs(self.pdu, self.audit_period, patient, [
-            {
-                "label": "Visits",
-                "href": self.data_reverse("pdu-patient-visits", kwargs={"patient_id": patient.pk})
-            }
-        ])
+        context["breadcrumbs"] = patient_breadcrumbs(
+            self.pdu,
+            self.audit_period,
+            patient,
+            [
+                {
+                    "label": "Visits",
+                    "href": self.data_reverse(
+                        "pdu-patient-visits", kwargs={"patient_id": patient.pk}
+                    ),
+                }
+            ],
+        )
 
         return context
 
@@ -122,18 +134,29 @@ class VisitCreateView(
         context["visit_tabs"] = get_visit_tabs(form=None)
         context["override_height_weight"] = False
 
-        context["paediatric_diabetes_unit"] = patient.submissions.first().paediatric_diabetes_unit
+        context["paediatric_diabetes_unit"] = (
+            patient.submissions.first().paediatric_diabetes_unit
+        )
 
-        context["breadcrumbs"] = patient_breadcrumbs(self.pdu, self.audit_period, patient, [
-            {
-                "label": "Visits",
-                "href": self.data_reverse("pdu-patient-visits", kwargs={"patient_id": patient.pk})
-            },
-            {
-                "label": "Add visit",
-                "href": self.data_reverse("pdu-visit-create", kwargs={"patient_id": patient.pk})
-            }
-        ])
+        context["breadcrumbs"] = patient_breadcrumbs(
+            self.pdu,
+            self.audit_period,
+            patient,
+            [
+                {
+                    "label": "Visits",
+                    "href": self.data_reverse(
+                        "pdu-patient-visits", kwargs={"patient_id": patient.pk}
+                    ),
+                },
+                {
+                    "label": "Add visit",
+                    "href": self.data_reverse(
+                        "pdu-visit-create", kwargs={"patient_id": patient.pk}
+                    ),
+                },
+            ],
+        )
 
         return context
 
@@ -144,13 +167,17 @@ class VisitCreateView(
         return self.data_reverse(
             "pdu-patient-visits", kwargs={"patient_id": self.kwargs["patient_id"]}
         )
-    
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         # Get override_postcode from POST data if available
-        if self.request.method in ('POST', 'PUT'):
-            kwargs['override_height_weight'] = self.request.POST.get('override_height_weight', 'false') == 'true'
-            kwargs['audit_period'] = AuditPeriod.objects.get_audit_period_for_request(self.request)
+        if self.request.method in ("POST", "PUT"):
+            kwargs["override_height_weight"] = (
+                self.request.POST.get("override_height_weight", "false") == "true"
+            )
+            kwargs["audit_period"] = AuditPeriod.objects.get_audit_period_for_request(
+                self.request
+            )
         return kwargs
 
     def get_initial(self):
@@ -169,7 +196,7 @@ class VisitCreateView(
 
         super(VisitCreateView, self).form_valid(form)
         return HttpResponseRedirect(self.get_success_url())
-    
+
     def form_invalid(self, form):
         context = self.get_context_data()
         if "height" in form.errors or "weight" in form.errors:
@@ -182,8 +209,8 @@ class VisitCreateView(
                 )
                 form.postcode = form.cleaned_data["override_height_weight"]
             else:
-                context['button_title'] = "Save Measurements Anyway"
-                context['override_height_weight'] = True
+                context["button_title"] = "Save Measurements Anyway"
+                context["override_height_weight"] = True
                 messages.error(
                     self.request,
                     "The measurement(s) you have entered are invalid. Please check the values entered and try again.",
@@ -191,8 +218,6 @@ class VisitCreateView(
                 form.override_height_weight = True
             return self.render_to_response(context)
         return super().form_invalid(form)
-
-
 
 
 class VisitUpdateView(
@@ -223,19 +248,26 @@ class VisitUpdateView(
         patient = visit.patient
         context["patient"] = visit.patient
 
-        context["breadcrumbs"] = patient_breadcrumbs(self.pdu, self.audit_period, patient, [
-            {
-                "label": "Visits",
-                "href": self.data_reverse("pdu-patient-visits", kwargs={"patient_id": patient.pk})
-            },
-            {
-                "label": visit.visit_date,
-                "href": self.data_reverse("pdu-visit-update", kwargs={
-                    "patient_id": patient.pk,
-                    "pk": visit.pk
-                })
-            }
-        ])
+        context["breadcrumbs"] = patient_breadcrumbs(
+            self.pdu,
+            self.audit_period,
+            patient,
+            [
+                {
+                    "label": "Visits",
+                    "href": self.data_reverse(
+                        "pdu-patient-visits", kwargs={"patient_id": patient.pk}
+                    ),
+                },
+                {
+                    "label": visit.visit_date,
+                    "href": self.data_reverse(
+                        "pdu-visit-update",
+                        kwargs={"patient_id": patient.pk, "pk": visit.pk},
+                    ),
+                },
+            ],
+        )
 
         return context
 
@@ -252,18 +284,22 @@ class VisitUpdateView(
         patient = Patient.objects.get(pk=self.kwargs["patient_id"])
         initial["patient"] = patient
         return initial
-    
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         # Get override_postcode from POST data if available
-        if self.request.method in ('POST', 'PUT'):
-            kwargs['override_height_weight'] = self.request.POST.get('override_height_weight', 'false') == 'true'
-            kwargs['audit_period'] = self.audit_period
+        if self.request.method in ("POST", "PUT"):
+            kwargs["override_height_weight"] = (
+                self.request.POST.get("override_height_weight", "false") == "true"
+            )
+            kwargs["audit_period"] = self.audit_period
         return kwargs
 
     def form_valid(self, form: BaseModelForm) -> HttpResponse:
         if "delete" in self.request.POST:
-            return redirect(self.data_reverse("pdu-visit-delete", kwargs={"pk": self.kwargs["pk"]}))
+            return redirect(
+                self.data_reverse("pdu-visit-delete", kwargs={"pk": self.kwargs["pk"]})
+            )
         visit = form.save(commit=True)
         visit.errors = None
         visit.is_valid = True
@@ -275,7 +311,7 @@ class VisitUpdateView(
         return HttpResponseRedirect(
             redirect_to=self.data_reverse("pdu-patient-visits", kwargs=context)
         )
-    
+
     def form_invalid(self, form):
         context = self.get_context_data()
         if "height" in form.errors or "weight" in form.errors:
@@ -288,8 +324,8 @@ class VisitUpdateView(
                 )
                 form.postcode = form.cleaned_data["override_height_weight"]
             else:
-                context['button_title'] = "Save Measurements Anyway"
-                context['override_height_weight'] = True
+                context["button_title"] = "Save Measurements Anyway"
+                context["override_height_weight"] = True
                 messages.error(
                     self.request,
                     "The measurement(s) you have entered are invalid. Please check the values entered and try again.",
@@ -319,20 +355,27 @@ class VisitDeleteView(
         visit = self.get_object()
         patient = visit.patient
 
-        context["breadcrumbs"] = patient_breadcrumbs(self.pdu, self.audit_period, patient, [
-            {
-                "label": "Visits",
-                "href": self.data_reverse("pdu-patient-visits", kwargs={"patient_id": patient.pk})
-            },
-            {
-                "label": visit.visit_date,
-                "href": self.data_reverse("pdu-visit-update", kwargs={
-                    "patient_id": patient.pk,
-                    "pk": visit.pk
-                })
-            }
-        ])
-        
+        context["breadcrumbs"] = patient_breadcrumbs(
+            self.pdu,
+            self.audit_period,
+            patient,
+            [
+                {
+                    "label": "Visits",
+                    "href": self.data_reverse(
+                        "pdu-patient-visits", kwargs={"patient_id": patient.pk}
+                    ),
+                },
+                {
+                    "label": visit.visit_date,
+                    "href": self.data_reverse(
+                        "pdu-visit-update",
+                        kwargs={"patient_id": patient.pk, "pk": visit.pk},
+                    ),
+                },
+            ],
+        )
+
         return context
 
     def get_success_url(self):


### PR DESCRIPTION
### Overview
Fix #1257
Non smokers currently fail if they have not been referred for cessation support, but of course it is only the smokers that should get that.

This PR updates the KPI calculation to exclude non-smokers from the calculation around referrals, and updates the patient report to reflect nonsmokers as ineligible for this measure with a suitable tooltip to reflect this.
A second issue fixed along the way was to add an AuditPeriod fixture to the test suite so that KPI tests can be run individually, as currently AuditProgress is added only at the beginning of all KPI tests.

### Code changes
`kpis.pi` - exclude nonsmokers from cessation referrals
`confttest.py` - create an AuditProgress fixture
`test_patient_report.py` - fix the tests and import the new fixture
`patient_report.py` - alters the annotation for  smoking cessation referrals to return a Char rather than a Boolean to allow different ineligibility types. the template is then updated as well as the ineligiblility tooltips

### Documentation changes (done or required as a result of this PR)
Updates the KPI 36 documentation to reflect nonsmokers excluded

### Related Issues
closes #1257
