### PR TITLE
Export questionnaire data as CSV

### DIFF
--- a/project/npda/general_functions/csv/csv_download.py
+++ b/project/npda/general_functions/csv/csv_download.py
@@ -1,13 +1,16 @@
 import json
+import csv
+from io import StringIO
 
 from django.apps import apps
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 
 from ..write_errors_to_xlsx import write_errors_to_xlsx
+from ....constants.csv_headings import CSV_HEADING_OBJECTS, UNIQUE_IDENTIFIER_JERSEY, UNIQUE_IDENTIFIER_ENGLAND
 
 
-def download_csv(request, submission_id):
+def download_csv_file(request, submission_id):
     """
     Download a CSV file.
     """
@@ -40,4 +43,27 @@ def download_xlsx(request, submission_id):
 
     response = HttpResponse(xlsx_file, content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     response["Content-Disposition"] = f'attachment; filename="{xlsx_file_name}"'
+    return response
+
+
+def export_as_csv(request, submission):
+    out = StringIO()
+    writer = csv.writer(out, delimiter=",")
+
+    pz_code = submission.paediatric_diabetes_unit.pz_code
+    is_jersey = pz_code == "PZ248"
+
+    if is_jersey:
+        HEADINGS_LIST = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
+    else:
+        HEADINGS_LIST = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+
+    header = [row["heading"] for row in HEADINGS_LIST]
+    writer.writerow(header)
+
+    filename = f"{submission.paediatric_diabetes_unit.pz_code}-{submission.audit_period.display_name()}.csv"
+
+    response = HttpResponse(out.getvalue(), content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+
     return response

--- a/project/npda/general_functions/csv/csv_download.py
+++ b/project/npda/general_functions/csv/csv_download.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404
 
 from ..write_errors_to_xlsx import write_errors_to_xlsx
 from ....constants.csv_headings import CSV_HEADING_OBJECTS, UNIQUE_IDENTIFIER_JERSEY, UNIQUE_IDENTIFIER_ENGLAND
+from ....npda.models.visit import Visit
 
 
 def download_csv_file(request, submission_id):
@@ -60,6 +61,31 @@ def export_as_csv(request, submission):
 
     header = [row["heading"] for row in HEADINGS_LIST]
     writer.writerow(header)
+
+    visits = Visit.objects.filter(patient__in=submission.patients.all()).select_related("patient").prefetch_related("patient__paediatric_diabetes_units")
+
+    for visit in visits:
+        row = []
+        transfer = visit.patient.paediatric_diabetes_units.filter(paediatric_diabetes_unit__pz_code=pz_code).first()
+
+        for row_heading in HEADINGS_LIST:
+            heading = row_heading["heading"]
+            model = row_heading.get("model")
+            field_name = row_heading.get("model_field")
+
+            match (heading, model):
+                case ("PDU Number", _):
+                    row.append(submission.paediatric_diabetes_unit.pz_code)
+                case (_, "Visit"):
+                    row.append(getattr(visit, field_name))
+                case (_, "Patient"):
+                    row.append(getattr(visit.patient, field_name))
+                case (_, "Transfer"):
+                    row.append(getattr(transfer, field_name))
+                case _:
+                    raise Exception(f"Unknown model: {model}")
+        
+        writer.writerow(row)
 
     filename = f"{submission.paediatric_diabetes_unit.pz_code}-{submission.audit_period.display_name()}.csv"
 

--- a/project/npda/templates/partials/page_elements/original_data_popup.html
+++ b/project/npda/templates/partials/page_elements/original_data_popup.html
@@ -3,7 +3,7 @@
   <div class="modal-box">
     <h3 class="text-lg font-bold">Good Data Protection Practice</h3>
     <p class="py-4">
-      This download contains your entire original data file. It contains personal information and must be stored securely and deleted after use.
+      This download contains your entire NPDA data submission. It contains personal information and must be stored securely and deleted after use.
     </p>
     <div class="modal-action">
       <form method="post" action="{% data_url 'pdu-submissions' %}">

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -90,33 +90,29 @@
                       {{ submission.paediatric_diabetes_unit.pz_code }} ({{ submission.paediatric_diabetes_unit.lead_organisation_name }})
                     </td>
                   {% endif %}
+                  <!-- Pop up which shows data protection guidance for quality report download -->
+                  {% include 'partials/page_elements/quality_report_popup.html' %}
+                  <!-- Pop up which shows data protection guidance for original data download -->
+                  {% include 'partials/page_elements/original_data_popup.html' %}
                   <td class="flex flex-row flex-wrap justify-start items-stretch gap-2 xl:flex-nowrap">
-                    <form method="post"
-                          action="{% data_url 'pdu-submissions' %}"
-                          class="join grow xl:max-w-max">
-                      {% csrf_token %}
-                      <input type="hidden" name="audit_id" value="{{ submission.pk }}">
-                      {% if submission.submission_active %}
-                        <!-- data quality report only visible for PDU view -->
-                        {% if submission.csv_file_name and perms.npda.can_download_csv %}
-                          <div class="join join-vertical grow items-center lg:join-horizontal">
-                            <div class="h-full flex grow items-center px-2 text-white bg-gray-400">
-                              <i class="fa-download fas mr-1"></i> Download:
-                            </div>
-                            <div class="h-full flex items-center p-1 text-white bg-gray-400">
-                              <button name="submit-data"
-                                      value="download-report"
-                                      type="submit"
-                                      class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 mr-2 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
-                                      onclick="quality_report_modal.showModal()">
-                                <div class="tooltip tooltip-bottom"
-                                     data-tip="Download a spreadsheet (.xlsx) that shows your uploaded data with validation comments">
-                                  <i class="fa-file-excel fa-solid"></i> Quality Report
-                                </div>
-                              </button>
-                              <!-- Pop up which shows data protection guidance for quality report download -->
-                              {% include 'partials/page_elements/quality_report_popup.html' %}
-                            {% endif %}
+                    {% if submission.submission_active %}
+                      <!-- data quality report only visible for PDU view -->
+                      {% if submission.csv_file_name and perms.npda.can_download_csv %}
+                        <div class="join join-vertical grow items-center lg:join-horizontal">
+                          <div class="h-full flex grow items-center px-2 text-white bg-gray-400">
+                            <i class="fa-download fas mr-1"></i> Download:
+                          </div>
+                          <div class="h-full flex items-center p-1 text-white bg-gray-400">
+                            <button name="submit-data"
+                                    value="download-report"
+                                    type="submit"
+                                    class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 mr-2 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
+                                    onclick="quality_report_modal.showModal()">
+                              <div class="tooltip tooltip-bottom"
+                                    data-tip="Download a spreadsheet (.xlsx) that shows your uploaded data with validation comments">
+                                <i class="fa-file-excel fa-solid"></i> Quality Report
+                              </div>
+                            </button>
                             {% if perms.npda.can_download_csv %}
                               <button name="submit-data"
                                       value="download-data"
@@ -124,33 +120,50 @@
                                       class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
                                       onclick="original_data_modal.showModal()">
                                 <div class="tooltip tooltip-bottom"
-                                     data-tip="Download a copy of the uploaded .CSV file">
+                                    data-tip="Download a copy of the uploaded .CSV file">
                                   <i class="fa-file-csv fa-solid"></i>
                                   Raw Data
                                 </div>
                               </button>
                             {% endif %}
-                            <!-- Pop up which shows data protection guidance for original data download -->
-                            {% include 'partials/page_elements/original_data_popup.html' %}
-                          </div>
                         </div>
                       {% else %}
-                        {% if perms.npda.delete_submission %}
-                          {% comment %}only those with permission can see this button{% endcomment %}
+                        {% if perms.npda.can_download_csv %}
+                          <button name="submit-data"
+                                  value="download-data"
+                                  type="submit"
+                                  class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
+                                  onclick="original_data_modal.showModal()">
+                            <div class="tooltip tooltip-bottom"
+                                data-tip="Download a copy of data as CSV">
+                              <i class="fa-file-csv fa-solid"></i>
+                              Export as CSV
+                            </div>
+                          </button>
+                        {% endif %}
+                      {% endif %}
+                    {% else %}
+                      {% if perms.npda.delete_submission %}
+                        {% comment %}only those with permission can see this button{% endcomment %}
+                        <form method="post"
+                                action="{% data_url 'pdu-submissions' %}"
+                                class="join grow xl:max-w-max">
+                            {% csrf_token %}
+                          <input type="hidden" name="audit_id" value="{{ submission.pk }}">
                           <button name="submit-data"
                                   value="delete-data"
                                   type="submit"
                                   class="join-item bg-rcpch_red text-white font-semibold hover:text-white py-1 px-2 border border-rcpch_red hover:bg-rcpch_red_dark_tint hover:border-rcpch_red_dark_tint btn-sm rounded-none {% if submission.submission_active %}opacity-50 cursor-not-allowed{% endif %}  h-auto">
                             Delete {% comment %} only inactive submissions can be deleted {% endcomment %}
                           </button>
-                        {% endif %}
+                        </form>
                       {% endif %}
-                    </form>
+                    {% endif %}
                     {% if submission.submission_active %}
                       <a href="{% data_url 'pdu-patients' %}"
-                         class="bg-rcpch_light_blue border-[6px] border-rcpch_light_blue btn-sm w-full h-auto grow px-2 py-1 font-semibold text-center text-white rounded-none hover:bg-rcpch_pink hover:border-rcpch_pink hover:text-white xl:max-w-max">
+                          class="bg-rcpch_light_blue border-[6px] border-rcpch_light_blue btn-sm w-full h-auto grow px-2 py-1 font-semibold text-center text-white rounded-none hover:bg-rcpch_pink hover:border-rcpch_pink hover:text-white xl:max-w-max">
                         <div class="tooltip tooltip-left"
-                             data-tip="View submission details, including the patients uploaded.">
+                              data-tip="View submission details, including the patients uploaded.">
                           View Submission <i class="fa-eye fa-solid"></i>
                         </div>
                       </a>

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -29,8 +29,9 @@ from project.npda.views.decorators import login_and_otp_required, check_data_per
 from project.constants.colors import RCPCH_LIGHT_BLUE
 from ..general_functions.session import refresh_session_filters, save_csv_uploading_user_to_visitactivity
 from ..general_functions.csv import (
-    download_csv,
+    download_csv_file,
     download_xlsx,
+    export_as_csv,
     csv_parse,
     create_csv_submission,
     gather_unique_patient_and_visit_counts
@@ -276,7 +277,10 @@ class SubmissionsListView(
                 pk=request.POST.get("audit_id")
             ).get()
             if request.user.is_rcpch_audit_team_member or submission.paediatric_diabetes_unit in request.user.organisation_employers.all():
-                return download_csv(request, submission.id)
+                if submission.csv_file_name:
+                    return download_csv_file(request, submission.id)
+                else:
+                    return export_as_csv(request, submission)
             else:
                 raise PermissionDenied(
                     f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",


### PR DESCRIPTION
Closes  #1020 

Replaces the "Raw Data" download button on the submission screen with an "Export as CSV" button for submissions done via questionnaire.
