### PR TITLE
Fix submission download buttons

### DIFF
--- a/project/npda/templates/partials/page_elements/original_data_popup.html
+++ b/project/npda/templates/partials/page_elements/original_data_popup.html
@@ -1,5 +1,5 @@
 {% load npda_tags %}
-<dialog id="original_data_modal" class="modal text-black">
+<dialog id="original_data_modal_{{submission.pk}}" class="modal text-black">
   <div class="modal-box">
     <h3 class="text-lg font-bold">Good Data Protection Practice</h3>
     <p class="py-4">
@@ -13,10 +13,10 @@
                 name="submit-data"
                 value="download-data"
                 type="submit"
-                onclick="original_data_modal.close()">Download</button>
+                onclick="original_data_modal_{{submission.pk}}.close()">Download</button>
         <button class="btn btn-outline"
                 type="button"
-                onclick="original_data_modal.close()">
+                onclick="original_data_modal_{{submission.pk}}.close()">
           Cancel
         </form>
       </div>

--- a/project/npda/templates/partials/page_elements/patient_table_actions.html
+++ b/project/npda/templates/partials/page_elements/patient_table_actions.html
@@ -72,7 +72,7 @@
                 <li>
                     <button class="btn {% if submission_error_count > 0 %} btn-warning {% else %} btn-success {% endif %} text-white {% if not perms.npda.view_submission %}btn-disabled{% endif %}"
                             type="button"
-                            onclick="quality_report_modal.showModal()">
+                            onclick="quality_report_modal_{{submission.pk}}.showModal()">
                         <i class="fa-solid fa-file-excel"></i>
                         Data Quality Report
                         {% if submission_error_count > 0 %}
@@ -97,7 +97,7 @@
                         {% if perms.npda.can_download_csv %}
                             <li>
                                 <button type="button"
-                                        onclick="original_data_modal.showModal()"
+                                        onclick="original_data_modal_{{submission.pk}}.showModal()"
                                         class="{% if not perms.npda.can_download_csv %}btn-disabled{% endif %}">
                                     <i class="fa-solid fa-download"></i>
                                     Download original file

--- a/project/npda/templates/partials/page_elements/quality_report_popup.html
+++ b/project/npda/templates/partials/page_elements/quality_report_popup.html
@@ -1,5 +1,5 @@
 {% load npda_tags %}
-<dialog id="quality_report_modal" class="modal text-black">
+<dialog id="quality_report_modal_{{submission.pk}}" class="modal text-black">
   <div class="modal-box">
       <h3 class="text-lg font-bold">Download Data Quality Report</h3>
       <p class="py-4">
@@ -13,7 +13,7 @@
             name="submit-data"
             value="download-report"
             type="submit"
-            onclick="quality_report_modal.close()">
+            onclick="quality_report_modal_{{submission.pk}}.close()">
               Download
           </button>
         </form>

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -160,7 +160,7 @@
                       {% endif %}
                     {% endif %}
                     {% if submission.submission_active %}
-                      <a href="{% data_url 'pdu-patients' %}"
+                      <a href="{% data_url 'pdu-patients' pz_code=submission.paediatric_diabetes_unit.pz_code %}"
                           class="bg-rcpch_light_blue border-[6px] border-rcpch_light_blue btn-sm w-full h-auto grow px-2 py-1 font-semibold text-center text-white rounded-none hover:bg-rcpch_pink hover:border-rcpch_pink hover:text-white xl:max-w-max">
                         <div class="tooltip tooltip-left"
                               data-tip="View submission details, including the patients uploaded.">

--- a/project/npda/templates/partials/submission_history.html
+++ b/project/npda/templates/partials/submission_history.html
@@ -90,24 +90,24 @@
                       {{ submission.paediatric_diabetes_unit.pz_code }} ({{ submission.paediatric_diabetes_unit.lead_organisation_name }})
                     </td>
                   {% endif %}
-                  <!-- Pop up which shows data protection guidance for quality report download -->
-                  {% include 'partials/page_elements/quality_report_popup.html' %}
-                  <!-- Pop up which shows data protection guidance for original data download -->
-                  {% include 'partials/page_elements/original_data_popup.html' %}
                   <td class="flex flex-row flex-wrap justify-start items-stretch gap-2 xl:flex-nowrap">
                     {% if submission.submission_active %}
+                      <!-- Pop up which shows data protection guidance for original data download or CSV export -->
+                      {% include 'partials/page_elements/original_data_popup.html' %}
                       <!-- data quality report only visible for PDU view -->
                       {% if submission.csv_file_name and perms.npda.can_download_csv %}
                         <div class="join join-vertical grow items-center lg:join-horizontal">
                           <div class="h-full flex grow items-center px-2 text-white bg-gray-400">
                             <i class="fa-download fas mr-1"></i> Download:
                           </div>
+                          <!-- Pop up which shows data protection guidance for quality report download -->
+                          {% include 'partials/page_elements/quality_report_popup.html' %}
                           <div class="h-full flex items-center p-1 text-white bg-gray-400">
                             <button name="submit-data"
                                     value="download-report"
                                     type="submit"
                                     class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 mr-2 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
-                                    onclick="quality_report_modal.showModal()">
+                                    onclick="quality_report_modal_{{submission.pk}}.showModal()">
                               <div class="tooltip tooltip-bottom"
                                     data-tip="Download a spreadsheet (.xlsx) that shows your uploaded data with validation comments">
                                 <i class="fa-file-excel fa-solid"></i> Quality Report
@@ -118,7 +118,7 @@
                                       value="download-data"
                                       type="submit"
                                       class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
-                                      onclick="original_data_modal.showModal()">
+                                      onclick="original_data_modal_{{submission.pk}}.showModal()">
                                 <div class="tooltip tooltip-bottom"
                                     data-tip="Download a copy of the uploaded .CSV file">
                                   <i class="fa-file-csv fa-solid"></i>
@@ -133,7 +133,7 @@
                                   value="download-data"
                                   type="submit"
                                   class="btn bg-rcpch_light_blue btn-sm join-item h-auto px-2 py-1 font-semibold text-white rounded-none hover:bg-rcpch_pink hover:text-white"
-                                  onclick="original_data_modal.showModal()">
+                                  onclick="original_data_modal_{{submission.pk}}.showModal()">
                             <div class="tooltip tooltip-bottom"
                                 data-tip="Download a copy of data as CSV">
                               <i class="fa-file-csv fa-solid"></i>


### PR DESCRIPTION
Follow up to #1280 to fix the download buttons on the national view of submission history, as that shows multiple submissions. Also fix the View Submission button to link to each PDU correctly.