### PR TITLE
Fix duplicate rows when only some visits have smoking status

### DIFF
--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -1367,3 +1367,76 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
 
     assert patient["patient_identifier"] == "4444444444"
     assert patient["smoking_status"] is True  # from the second visit
+
+
+@pytest.mark.django_db
+def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_has_one_row_in_the_patient_report(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+
+    visit_date_1 = audit_period.start_date + relativedelta(days=10)
+    visit_date_2 = audit_period.start_date + relativedelta(days=20)
+
+    # First visit WITH smoking status and cessation referral
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date_1,
+        smoking_status=SMOKING_STATUS[1][0],  # smoker
+        smoking_cessation_referral_date=visit_date_1,
+    )
+
+    # Second visit WITHOUT smoking data
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date_2
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["smoking_status"] is True  # from the first visit
+    assert patient["smoking_cessation_referral"] == "True"  # from the first visit

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -1295,3 +1295,75 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
     assert patient_data["is_gte_12yo"] is True
     # Should be None (no data available) - template will show blank, not ineligible icon
     assert patient_data["passed_retinal_screening"] is None
+
+
+@pytest.mark.django_db
+def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row_in_the_patient_report(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+
+    visit_date_1 = audit_period.start_date + relativedelta(days=10)
+    visit_date_2 = audit_period.start_date + relativedelta(days=20)
+
+    # First visit WITHOUT smoking status
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date_1,
+        smoking_status=None,
+    )
+
+    # Second visit WITH smoking status
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date_2,
+        smoking_status=SMOKING_STATUS[0][0],  # non smoker
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.ADDITIONAL_CARE_PROCESSES.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 1
+
+    patient = response.context["patients"][0]
+
+    assert patient["patient_identifier"] == "4444444444"
+    assert patient["smoking_status"] is True  # from the second visit

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -404,6 +404,16 @@ def calculate_queryset(
                             Visit.objects.filter(
                                 patient=OuterRef("pk"),
                                 visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
+                                smoking_status__in=[99], # unknown - fail
+                            )
+                        ),
+                        then=Value("False")
+                    ),
+                    When(
+                        Exists(
+                            Visit.objects.filter(
+                                patient=OuterRef("pk"),
+                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
                                 smoking_status__in=[1], # non-smoker
                             )
                         ),

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -394,42 +394,41 @@ def calculate_queryset(
                     default=Value(False), # fail (includes smoking status not recorded 99)
                     output_field=BooleanField(),
                 ),
-                smoking_cessation_referral=Value(False),
-                # smoking_cessation_referral=Case(
-                #     When(  # Smoker with referral over 12 years old during audit period
-                #         Q(visit__smoking_status=2)  # smoker
-                #         & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                #         & Q(visit__smoking_cessation_referral_date__isnull=False)
-                #         & Q(
-                #             date_of_birth__lte=audit_period.start_date
-                #             - relativedelta(years=12)
-                #         ),
-                #         then=Value("True"),
-                #     ),
-                #     When(  # Non-smoker during audit period over 12 years old no referral needed
-                #         Q(visit__smoking_status=1)  # non-smoker
-                #         & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                #         & Q(
-                #             date_of_birth__lte=audit_period.start_date
-                #             - relativedelta(years=12)
-                #         )
-                #         & Q(visit__smoking_cessation_referral_date__isnull=True),
-                #         then=Value("non_smoker_no_referral"),
-                #     ),
-                #     When(  # Under 12 years old no eligible
-                #         Q(
-                #             date_of_birth__gt=audit_period.start_date
-                #             - relativedelta(years=12)
-                #         ),
-                #         then=Value("under_12"),
-                #     ),
-                #     default=Case(
-                #         When(is_gte_12yo=True, then=Value("False")),
-                #         default=None,
-                #         output_field=CharField(),
-                #     ),
-                #     output_field=CharField(),
-                # ),
+                smoking_cessation_referral=Case(
+                    When(  # Smoker with referral over 12 years old during audit period
+                        Q(visit__smoking_status=2)  # smoker
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(visit__smoking_cessation_referral_date__isnull=False)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=Value("True"),
+                    ),
+                    When(  # Non-smoker during audit period over 12 years old no referral needed
+                        Q(visit__smoking_status=1)  # non-smoker
+                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                        & Q(
+                            date_of_birth__lte=audit_period.start_date
+                            - relativedelta(years=12)
+                        )
+                        & Q(visit__smoking_cessation_referral_date__isnull=True),
+                        then=Value("non_smoker_no_referral"),
+                    ),
+                    When(  # Under 12 years old no eligible
+                        Q(
+                            date_of_birth__gt=audit_period.start_date
+                            - relativedelta(years=12)
+                        ),
+                        then=Value("under_12"),
+                    ),
+                    default=Case(
+                        When(is_gte_12yo=True, then=Value("False")),
+                        default=None,
+                        output_field=CharField(),
+                    ),
+                    output_field=CharField(),
+                ),
                 additional_dietetic_appt_offered=Case(
                     When(
                         Exists(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -395,38 +395,42 @@ def calculate_queryset(
                     output_field=BooleanField(),
                 ),
                 smoking_cessation_referral=Case(
-                    When(  # Smoker with referral over 12 years old during audit period
-                        Q(visit__smoking_status=2)  # smoker
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(visit__smoking_cessation_referral_date__isnull=False)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=Value("True"),
+                    When(
+                        is_gte_12yo=False,
+                        then=Value("under_12"), # Not eligible
                     ),
-                    When(  # Non-smoker during audit period over 12 years old no referral needed
-                        Q(visit__smoking_status=1)  # non-smoker
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
+                    When(
+                        Exists(
+                            Visit.objects.filter(
+                                patient=OuterRef("pk"),
+                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
+                                smoking_status__in=[1], # non-smoker
+                            )
+                        ),
+                        then=Value("non_smoker_no_referral")
+                    ),
+                    When(
+                        Exists(
+                            Visit.objects.filter(
+                                patient=OuterRef("pk"),
+                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
+                                smoking_status__in=[2], # smoker
+                            )
+                        ),
+                        then=Case(
+                            When(
+                                Exists(
+                                    Visit.objects.filter(
+                                        patient=OuterRef("pk"),
+                                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
+                                        smoking_cessation_referral_date__isnull=False,
+                                    )
+                                ),
+                                then=Value("True"), # pass
+                            ),
                         )
-                        & Q(visit__smoking_cessation_referral_date__isnull=True),
-                        then=Value("non_smoker_no_referral"),
                     ),
-                    When(  # Under 12 years old no eligible
-                        Q(
-                            date_of_birth__gt=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=Value("under_12"),
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=Value("False")),
-                        default=None,
-                        output_field=CharField(),
-                    ),
+                    default=Value("False"), # fail
                     output_field=CharField(),
                 ),
                 additional_dietetic_appt_offered=Case(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -428,9 +428,9 @@ def calculate_queryset(
                                 ),
                                 then=Value("True"), # pass
                             ),
+                            default=Value("False"), # fail
                         )
                     ),
-                    default=Value("False"), # fail
                     output_field=CharField(),
                 ),
                 additional_dietetic_appt_offered=Case(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -25,6 +25,7 @@ from django.db.models import (
     ExpressionWrapper,
     DurationField,
     Func,
+    Value
 )
 
 # Django imports
@@ -377,72 +378,58 @@ def calculate_queryset(
                 ),
                 smoking_status=Case(
                     When(
-                        Q(visit__smoking_status__in=[1, 2])  # smoker
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=True,
+                        is_gte_12yo=False,
+                        then=None, # Not eligible
                     ),
                     When(
-                        Q(visit__smoking_status=99)  # not known
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
+                        Exists(
+                            Visit.objects.filter(
+                                patient=OuterRef("pk"),
+                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
+                                smoking_status__in=[1, 2], # non-smoker or smoker recorded
+                            )
                         ),
-                        then=False,
+                        then=True, # pass
                     ),
-                    When(
-                        Q(
-                            date_of_birth__gt=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=None,
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=False),
-                        default=None,
-                        output_field=BooleanField(),
-                    ),
+                    default=Value(False), # fail (includes smoking status not recorded 99)
                     output_field=BooleanField(),
                 ),
-                smoking_cessation_referral=Case(
-                    When(  # Smoker with referral over 12 years old during audit period
-                        Q(visit__smoking_status=2)  # smoker
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(visit__smoking_cessation_referral_date__isnull=False)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=Value("True"),
-                    ),
-                    When(  # Non-smoker during audit period over 12 years old no referral needed
-                        Q(visit__smoking_status=1)  # non-smoker
-                        & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
-                        & Q(
-                            date_of_birth__lte=audit_period.start_date
-                            - relativedelta(years=12)
-                        )
-                        & Q(visit__smoking_cessation_referral_date__isnull=True),
-                        then=Value("non_smoker_no_referral"),
-                    ),
-                    When(  # Under 12 years old no eligible
-                        Q(
-                            date_of_birth__gt=audit_period.start_date
-                            - relativedelta(years=12)
-                        ),
-                        then=Value("under_12"),
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=Value("False")),
-                        default=None,
-                        output_field=CharField(),
-                    ),
-                    output_field=CharField(),
-                ),
+                smoking_cessation_referral=Value(False),
+                # smoking_cessation_referral=Case(
+                #     When(  # Smoker with referral over 12 years old during audit period
+                #         Q(visit__smoking_status=2)  # smoker
+                #         & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                #         & Q(visit__smoking_cessation_referral_date__isnull=False)
+                #         & Q(
+                #             date_of_birth__lte=audit_period.start_date
+                #             - relativedelta(years=12)
+                #         ),
+                #         then=Value("True"),
+                #     ),
+                #     When(  # Non-smoker during audit period over 12 years old no referral needed
+                #         Q(visit__smoking_status=1)  # non-smoker
+                #         & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE)
+                #         & Q(
+                #             date_of_birth__lte=audit_period.start_date
+                #             - relativedelta(years=12)
+                #         )
+                #         & Q(visit__smoking_cessation_referral_date__isnull=True),
+                #         then=Value("non_smoker_no_referral"),
+                #     ),
+                #     When(  # Under 12 years old no eligible
+                #         Q(
+                #             date_of_birth__gt=audit_period.start_date
+                #             - relativedelta(years=12)
+                #         ),
+                #         then=Value("under_12"),
+                #     ),
+                #     default=Case(
+                #         When(is_gte_12yo=True, then=Value("False")),
+                #         default=None,
+                #         output_field=CharField(),
+                #     ),
+                #     output_field=CharField(),
+                # ),
                 additional_dietetic_appt_offered=Case(
                     When(
                         Exists(


### PR DESCRIPTION
Fixes #1279 where duplicate rows appeared per patient in the additional care processes tab if that patient had both a visit with smoking status information and a visit without.

We must use `Exists` queries here to avoid the duplicate rows. 