### PR TITLE
Don't mark missing retinal screening as N/A in patient report export

### DIFF
--- a/project/npda/templates/patient_report/components/true_false_incomplete_icons.html
+++ b/project/npda/templates/patient_report/components/true_false_incomplete_icons.html
@@ -1,3 +1,9 @@
+{% comment %}
+  !! IMPORTANT !!
+  If you add any special cases here (eg retinal screening) please ensure
+  you also add them to the CSV export for the patient report too
+  (patient_report.py/download_patient_report)
+{% endcomment %}
 {% if result is True or result == "True" %}
 {% comment %} PASS {% endcomment %}
   <i class="fa-solid fa-circle-check text-success text-xl"></i>

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -1216,7 +1216,14 @@ def download_patient_report(request, audit_period, pdu):
                         ]
 
                         for field in fields:
-                            data[field].append(measure_status(row[f"passed_{field}"]))
+                            status = measure_status(row[f"passed_{field}"])
+
+                            if field == "retinal_screening" and status == "NA" and row["is_gte_12yo"]:
+                                # As retinal screening is bi-annual, they might have been covered last year
+                                # https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1276
+                                status = ""
+
+                            data[field].append(status)
 
                     case TableCategories.ADDITIONAL_CARE_PROCESSES:
                         data["complete_year_of_care"].append(


### PR DESCRIPTION
Follow up to https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1276 applying the same logic in the patient report export