### PR TITLE
Add not known pseudo postcode

### DIFF
--- a/project/constants/postcodes.py
+++ b/project/constants/postcodes.py
@@ -1,8 +1,9 @@
 """
 Constants for 'unknown' postcodes
 These are Office for National Statistics (ONS) codes for where a postcode is not known
-ZZ99 3VZ No fixed abode 
-ZZ99 3CZ England/U.K  not otherwise specified 
+ZZ99 3VZ No fixed abode
+ZZ99 3WZ Not known
+ZZ99 3CZ England/U.K not otherwise specified 
 ZZ99 3GZ Wales not otherwise specified 
 ZZ99 1WZ Scotland not otherwise specified
 ZZ99 2WZ Northern Ireland not otherwise specified
@@ -12,6 +13,7 @@ https://www.datadictionary.wales.nhs.uk/index.html#!worddocuments/postcode.htm
 
 UNKNOWN_POSTCODES_NO_SPACES = [
     "ZZ993VZ",
+    "ZZ993WZ",
     "ZZ993CZ",
     "ZZ993GZ",
     "ZZ991WZ",


### PR DESCRIPTION
We were missing a pseudo postcode

- https://www.england.nhs.uk/long-read/commissioner-assignment-method-flow-chart-2024-25-accompanying-guidance-and-reference-tables/
- https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/get-and-update-contact-details-in-pds#address-information