### PR TITLE
Fix clicking homepage from user list

### DIFF
--- a/project/npda/context_processors.py
+++ b/project/npda/context_processors.py
@@ -25,8 +25,11 @@ def context_from_request(request):
         pz_code = request.resolver_match.kwargs.get("pz_code", None)
 
     audit_period_slug = None
-    if request.resolver_match:
+    if request.resolver_match and "audit_period" in request.resolver_match.kwargs:
         audit_period_slug = request.resolver_match.kwargs.get("audit_period", None)
+    else:
+        default_audit_period = AuditPeriod.objects.get_default_audit_period()
+        audit_period_slug = default_audit_period.slug
 
     user_home_page = get_user_home_page(audit_period_slug, request.user)
 


### PR DESCRIPTION
Fixes #1298 

The user list is not a "data url" - you can manage users for any PDU you have access to and any user can view any audit period.

This led to a bug where the homepage link (clicking the NPDA logo in the top left) didn't work, as there was no audit period slug to include.

I explored adding the audit period to the user page URL but it was quite a lot of code change and it would be misleading anyway since users can see all audit periods.

So I just decided to use the default audit period for non data URLs. This means if you navigate to the user list from a previous audit period, clicking the homepage will punt you back to the default (currently open one). I don't think this is a big deal.