### PR TITLE
Fix dev seeding crash on inactive PDU with lead organisation

### DIFF
--- a/project/npda/management/commands/seed_functions/paediatric_diabetes_units_seeder.py
+++ b/project/npda/management/commands/seed_functions/paediatric_diabetes_units_seeder.py
@@ -61,7 +61,7 @@ def paediatric_diabetes_units_seeder():
             ).get("ods_code")
             lead_organisation_name = pdu.get("name")
             last_updated = pdu.get("last_updated") or None
-            active = pdu.get("active") or None
+            active = pdu.get("active") or False
 
             if not lead_organisation_ods_code:
                 logger.warning(
@@ -89,8 +89,10 @@ def paediatric_diabetes_units_seeder():
             if not pz_code:
                 logger.warning(f"PZ code not found for PDU: {pz_code}")
                 continue
-            if active is not None and active is True:
-                default ={
+            
+            new_pdu, created = PaediatricDiabetesUnit.objects.update_or_create(
+                pz_code=pz_code,
+                defaults={
                     "lead_organisation_ods_code": lead_organisation_ods_code,
                     "lead_organisation_name": lead_organisation_name,
                     "parent_ods_code": parent_ods_code,
@@ -99,15 +101,7 @@ def paediatric_diabetes_units_seeder():
                     "paediatric_diabetes_network_name": network_name,
                     "active": active,
                     "last_updated": last_updated,
-                }
-            else:
-                default = {
-                    "active": False,
-                    "last_updated": last_updated,
-                }
-            new_pdu, created = PaediatricDiabetesUnit.objects.update_or_create(
-                pz_code=pz_code,
-                defaults=default,
+                },
             )
 
             add_geocoordinates(new_pdu)


### PR DESCRIPTION
As part of https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1292 we will need to make some PDUs inactive. Previously this involved removing their lead organisation information in the org API however I would like to preserve it for those PDUs so users can still look at their submission under the previous units.

I've been testing this against PZ003 which is already inactive however it was incorrectly shown as active in the org API. When I switched it to active the dev seeding process crashed because there was a guard around saving which meant later on when we're fetching the geocordinates it would not have the lead organisation ODS code, end up fetching all the organisations (!) and then crash because the data was in the wrong place.

This fixes the seeder to include the lead organisation information wherever available.