### PR TITLE
Support PDU number without leading PZ or zeroes

### DIFF
--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -61,12 +61,12 @@ def AUDIT_END_DATE():
 
 @pytest.fixture(scope="session")
 def test_pz_codes_fixture():
-    return ["PZ196", "PZ074", "PZ248"]  # GOSH  # Alder Hey  # Jersey
+    return ["PZ196", "PZ074", "PZ248", "PZ004"]  # GOSH, Alder Hey, Jersey, Northampton
 
 
 @pytest.fixture(scope="function")
 def test_pz_codes_function_fixture():
-    return ["PZ196", "PZ074", "PZ248"]  # GOSH  # Alder Hey  # Jersey
+    return ["PZ196", "PZ074", "PZ248", "PZ004"]  # GOSH, Alder Hey, Jersey, Northampton
 
 
 @pytest.fixture(autouse=True)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4286,7 +4286,7 @@ def test_uploading_csv_with_pdu_number_missing_leading_pz(
     client,
     test_rcpch_user
 ):
-    two_patients_with_one_visit_each.at[0, "PDU Number"] = "999"
+    two_patients_with_one_visit_each = two_patients_with_one_visit_each.assign(**{"PDU Number": "004"})
 
     # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_test_uploading_csv_with_pdu_number_missing_leading_pz.csv"
@@ -4295,7 +4295,7 @@ def test_uploading_csv_with_pdu_number_missing_leading_pz(
     # Log in user
     client = login_and_verify_user(client, test_rcpch_user)
 
-    url = reverse("pdu-upload-csv", kwargs={ "pz_code": "PZ999", "audit_period": "2025-2026"})
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
 
     # Feed file to view
     with open(tmp_csv_path, "rb") as csv_file:
@@ -4309,11 +4309,11 @@ def test_uploading_csv_with_pdu_number_missing_leading_pz(
 
     assert response.status_code == 302
 
-    redirect_url = reverse("pdu-upload-csv-in-progress", kwargs={ "pz_code": "PZ999", "audit_period": "2025-2026"})
+    redirect_url = reverse("pdu-upload-csv-in-progress", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
     assert response.url == redirect_url
     
     assert Submission.objects.count() == 1, "Submission should be created for PDU with missing leading PZ"
-    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ999"
+    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
 
 
 @pytest.mark.django_db
@@ -4323,7 +4323,7 @@ def test_uploading_csv_with_pdu_number_missing_leading_zeros(
     client,
     test_rcpch_user
 ):
-    two_patients_with_one_visit_each.at[0, "PDU Number"] = "4"
+    two_patients_with_one_visit_each = two_patients_with_one_visit_each.assign(**{"PDU Number": "4"})
 
     # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_ttest_uploading_csv_with_pdu_number_missing_leading_zeros.csv"

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4280,6 +4280,80 @@ def test_uploading_csv_with_conflicting_pdu_numbers(
 
 
 @pytest.mark.django_db
+def test_uploading_csv_with_pdu_number_missing_leading_pz(
+    two_patients_with_one_visit_each,
+    tmp_path,
+    client,
+    test_rcpch_user
+):
+    two_patients_with_one_visit_each.at[0, "PDU Number"] = "999"
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_test_uploading_csv_with_pdu_number_missing_leading_pz.csv"
+    two_patients_with_one_visit_each.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": "PZ999", "audit_period": "2025-2026"})
+
+    # Feed file to view
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    redirect_url = reverse("pdu-upload-csv-in-progress", kwargs={ "pz_code": "PZ999", "audit_period": "2025-2026"})
+    assert response.url == redirect_url
+    
+    assert Submission.objects.count() == 1, "Submission should be created for PDU with missing leading PZ"
+    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ999"
+
+
+@pytest.mark.django_db
+def test_uploading_csv_with_pdu_number_missing_leading_zeros(
+    two_patients_with_one_visit_each,
+    tmp_path,
+    client,
+    test_rcpch_user
+):
+    two_patients_with_one_visit_each.at[0, "PDU Number"] = "4"
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_ttest_uploading_csv_with_pdu_number_missing_leading_zeros.csv"
+    two_patients_with_one_visit_each.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
+
+    # Feed file to view
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    redirect_url = reverse("pdu-upload-csv-in-progress", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
+    assert response.url == redirect_url
+
+    assert Submission.objects.count() == 1, "Submission should be created for PDU with missing leading zeroes"
+    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
+
+
+@pytest.mark.django_db
 def test_conflicting_stated_gender(test_user, one_patient_with_four_visits):
     df = one_patient_with_four_visits
 

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -441,8 +441,12 @@ def upload_csv(request, audit_period, pdu):
         if parsed_csv.df["PDU Number"].nunique() > 1:
             message = f"CSV file contains multiple PDU Numbers: {', '.join(parsed_csv.df['PDU Number'].unique())}. Please upload a file containing data for a single PDU only."
             return upload_error(message)
-        
-        if parsed_csv.df["PDU Number"].iloc[0] != pdu.pz_code:
+
+        # 1316 - Twinkle/Diamond outputs PDU number without leading PZ and zeros
+        expected_pdu_number = pdu.pz_code.lstrip("PZ").lstrip("0")
+        pdu_number_in_csv = parsed_csv.df["PDU Number"].iloc[0].lstrip("PZ").lstrip("0")
+
+        if pdu_number_in_csv != expected_pdu_number:
             message = f"PDU Number in CSV file ({parsed_csv.df['PDU Number'].iloc[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."
             return upload_error(message)
 


### PR DESCRIPTION
Fixes #1316 

Twinkle/Diamond outputs the PDU number column in the CSV without "PZ" or leading zeroes.