### PR TITLE
Ignore null values when merging patient rows in CSV upload

### DIFF
--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -291,7 +291,12 @@ async def csv_upload(
             # Unlikely case where there are no visit dates at all (to cover tests)
             return rows.iloc[0][column]
 
-        most_recent_row = rows.loc[rows['Visit/Appointment Date'].idxmax()]
+        rows_with_value = rows.dropna(subset=[column])
+
+        if len(rows_with_value) == 0:
+            return None
+
+        most_recent_row = rows.loc[rows_with_value['Visit/Appointment Date'].idxmax()]
 
         return most_recent_row[column]
     

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4524,3 +4524,19 @@ def test_conflicting_diagnosis_date(test_user, one_patient_with_four_visits):
     # Earliest
     assert Patient.objects.first().diagnosis_date == datetime.date(2018, 1, 1)
 
+
+@pytest.mark.django_db
+def test_conflicting_diabetes_type_where_last_row_is_null(test_user, one_patient_with_four_visits):
+    df = one_patient_with_four_visits
+
+    df.loc[0, "Diabetes Type"] = DIABETES_TYPES[0][0]
+    df.loc[1, "Diabetes Type"] = DIABETES_TYPES[0][0]
+    df.loc[2, "Diabetes Type"] = DIABETES_TYPES[1][0]
+    df.loc[3, "Diabetes Type"] = None
+
+    errors = csv_upload_sync(test_user, df)
+    assert "diabetes_type" in errors[0]
+
+    assert Patient.objects.count() == 1
+    # Most recent by visit date
+    assert Patient.objects.first().diabetes_type == DIABETES_TYPES[1][0]


### PR DESCRIPTION
Fixes bug reported by PZ246 where they saw "gp practice ODS code and GP postcode cannot both be empty" when their last row for the patient was missing ODS code but all the other rows had it