### PR TITLE
Adjust cholesterol bounds

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -411,13 +411,13 @@ class VisitForm(forms.ModelForm):
         total_cholesterol = self.cleaned_data["total_cholesterol"]
 
         if total_cholesterol:
-            if total_cholesterol < 2:
+            if total_cholesterol < 0.9:
                 raise ValidationError(
-                    "Total Cholesterol Level (mmol/l) out of range. Cannot be below 2"
+                    "Total Cholesterol Level (mmol/l) out of range. Cannot be below 0.9"
                 )
-            elif total_cholesterol > 12:
+            elif total_cholesterol > 15:
                 raise ValidationError(
-                    "Total Cholesterol Level (mmol/l) out of range. Cannot be above 12"
+                    "Total Cholesterol Level (mmol/l) out of range. Cannot be above 15"
                 )
 
         return total_cholesterol

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -919,7 +919,7 @@ def test_total_cholesterol_value_below_range_form_fails_validation():
 
     form = VisitForm(
         data={
-            "total_cholesterol": 1,
+            "total_cholesterol": 0.8,
             "total_cholesterol_date": "2026-01-01",
         },
         initial={"patient": patient},
@@ -927,7 +927,7 @@ def test_total_cholesterol_value_below_range_form_fails_validation():
     # Trigger the cleaners
     assert (
         form.is_valid() == False
-    ), f"Form should be invalid as total cholesterol < 2, passed"
+    ), f"Form should be invalid as total cholesterol < 0.9, passed"
 
     assert "total_cholesterol" in form.errors
 
@@ -949,9 +949,9 @@ def test_total_cholesterol_value_above_range_form_fails_validation():
     # Trigger the cleaners
     assert (
         form.is_valid() == False
-    ), f"Form should be invalid as total cholesterol > 12 mmol/L, passed"
+    ), f"Form should be invalid as total cholesterol > 15 mmol/L, passed"
 
-    assert "total_cholesterol" not in form.errors
+    assert "total_cholesterol" in form.errors
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -929,6 +929,8 @@ def test_total_cholesterol_value_below_range_form_fails_validation():
         form.is_valid() == False
     ), f"Form should be invalid as total cholesterol < 2, passed"
 
+    assert "total_cholesterol" in form.errors
+
 
 @pytest.mark.django_db
 def test_total_cholesterol_value_above_range_form_fails_validation():
@@ -948,6 +950,8 @@ def test_total_cholesterol_value_above_range_form_fails_validation():
     assert (
         form.is_valid() == False
     ), f"Form should be invalid as total cholesterol > 12 mmol/L, passed"
+
+    assert "total_cholesterol" not in form.errors
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #1328 by adjusting the validation bounds for total cholesterol.

In previous years we have used `1 <= v <= 15` but as per the issue we have updated the platform to allow 0.9 too.