### PR TITLE
Improvements to flagging errors when merging patient rows

### DIFF
--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -76,7 +76,7 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
     model_field = column.get("model_field")
 
     if model in ["Patient", "Transfer"]:
-        values_by_date = ((row["Visit/Appointment Date"], row[heading]) for _, row in rows.iterrows() if pd.notnull(row[heading]) and pd.notnull(row["Visit/Appointment Date"]))
+        values_by_date = ((row["Visit/Appointment Date"], row[heading]) for _, row in rows.iterrows() if pd.notnull(row[heading]))
         unique_values = rows[heading].dropna().unique()
 
         flag_values = False
@@ -90,10 +90,13 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
                 rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=ETHNICITIES[-1][0])
             case "reason_leaving_service":
                 rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
+                flag_values = True
             case "diabetes_type" | "postcode" | "gp_practice_ods_code":
                 rows[heading] = most_recent_by_visit_date(rows, heading)
+                flag_values = True
             case "diagnosis_date":
                 rows[heading] = smallest(rows, heading)
+                flag_values = True
         
         if len(unique_values) > 1 and flag_values:
             unique_values_str = ", ".join(unique_values.astype(str))

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -1,0 +1,72 @@
+from project.constants.csv_headings import CSV_HEADING_OBJECTS
+
+def most_recent_modal_value_by_visit_date(identifier_heading, rows, column):
+    # NPDA analysis has this notion of "Most up-to-date valid mode"
+    # My understanding of it is that you should:
+    #  - Work out the modal (most common) value
+    #  - If there's more than one mode, return the one from the row with the most recent visit
+    values_by_count_and_last_visit_date = rows.groupby(column).agg(
+        Count=(identifier_heading, 'count'),
+        LastVisitDate=('Visit/Appointment Date', 'max')
+    ).sort_values(by=['Count', 'LastVisitDate'])
+
+    if len(values_by_count_and_last_visit_date) > 0:
+        return values_by_count_and_last_visit_date.iloc[-1].name
+
+def smallest(rows, column):
+    if len(rows) > 0:
+        return rows[column].min()
+
+def smallest_code_with_attached_date(rows, code_column, date_column):
+    rows_with_leaving_service = rows.dropna(subset=[date_column]).sort_values(by=code_column)
+
+    if len(rows_with_leaving_service) > 0:
+        return rows_with_leaving_service.iloc[0][code_column]
+
+def most_recent_by_visit_date(rows, column):
+    if rows['Visit/Appointment Date'].isnull().all():
+        # Unlikely case where there are no visit dates at all (to cover tests)
+        return rows.iloc[0][column]
+
+    rows_with_value = rows.dropna(subset=[column])
+
+    if len(rows_with_value) == 0:
+        return None
+
+    most_recent_row = rows.loc[rows_with_value['Visit/Appointment Date'].idxmax()]
+
+    return most_recent_row[column]
+
+def report_conflicting_values(unique_values, model_field, patient_row_index, heading, errors_to_return):
+    unique_values_str = ", ".join(unique_values.astype(str))
+    error_field = model_field if model_field else "__all__"
+    errors_to_return[patient_row_index][error_field].append(
+        f"Conflicting values for {heading}: {unique_values_str}"
+    )
+
+def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_index, errors_to_return):
+    heading = column["heading"]
+
+    model = column.get("model")
+    model_field = column.get("model_field")
+
+    if model in ["Patient", "Transfer"]:
+        unique_values = rows[heading].dropna().unique()
+
+        if len(unique_values) > 1:
+            report_conflicting_values(unique_values, model_field, patient_row_index, heading, errors_to_return)
+
+        match model_field:
+            case "date_of_birth" | "sex" | "ethnicity":
+                rows[heading] = most_recent_modal_value_by_visit_date(identifier_heading, rows, heading)
+            case "reason_leaving_service":
+                rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
+            case "diabetes_type" | "postcode" | "gp_practice_ods_code":
+                rows[heading] = most_recent_by_visit_date(rows, heading)
+            case "diagnosis_date":
+                rows[heading] = smallest(rows, heading)
+
+
+def merge_rows_for_patient(identifier_heading, rows, patient_row_index, errors_to_return):
+    for column in CSV_HEADING_OBJECTS:
+        merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_index, errors_to_return)

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -1,4 +1,52 @@
 from project.constants.csv_headings import CSV_HEADING_OBJECTS
+from project.constants.sex_types import SEX_TYPE
+
+
+def merge_sex_values(values_by_date):
+    UNKNOWN = SEX_TYPE[-1][0] # 99
+
+    # Moving from UNKNOWN to known is not an error (but moving back to it is)
+    seen_non_unkown_value = False
+    seen_unknown_value_before_non_unknown_value = False
+    
+    acc = {}
+
+    for (date, value) in values_by_date:
+        if value == UNKNOWN and not seen_non_unkown_value:
+            seen_unknown_value_before_non_unknown_value = True
+            continue
+        
+        seen_non_unkown_value = True
+
+        if value in acc:
+            acc[value]["count"] += 1
+
+            if date > acc[value]["most_recent_date"]:
+                acc[value]["most_recent_date"] = date
+        else:
+            acc[value] = {
+                "count": 1,
+                "most_recent_date": date,
+            }
+
+    
+    if len(acc) == 0:
+        if seen_unknown_value_before_non_unknown_value:
+            return UNKNOWN, False # not inconsistent, just unknown
+        
+        return None, True # no information at all, flag as error
+    
+    sorted_values = sorted(acc.items(), key=lambda item: (item[1]["count"], item[1]["most_recent_date"]))
+
+    most_common_value = sorted_values[-1][0]
+
+    flag_errors = len(acc.keys()) > 1
+
+    return most_common_value, flag_errors
+    
+
+
+
 
 def most_recent_modal_value_by_visit_date(identifier_heading, rows, column):
     # NPDA analysis has this notion of "Most up-to-date valid mode"

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -1,22 +1,23 @@
+import pandas as pd
+
 from project.constants.csv_headings import CSV_HEADING_OBJECTS
 from project.constants.sex_types import SEX_TYPE
+from project.constants.ethnicities import ETHNICITIES
 
 
-def merge_sex_values(values_by_date):
-    UNKNOWN = SEX_TYPE[-1][0] # 99
-
+def most_recent_modal_value_by_visit_date(values_by_date, unknown_value):
     # Moving from UNKNOWN to known is not an error (but moving back to it is)
-    seen_non_unkown_value = False
+    seen_non_unknown_value = False
     seen_unknown_value_before_non_unknown_value = False
     
     acc = {}
 
     for (date, value) in values_by_date:
-        if value == UNKNOWN and not seen_non_unkown_value:
+        if value == unknown_value and not seen_non_unknown_value:
             seen_unknown_value_before_non_unknown_value = True
             continue
         
-        seen_non_unkown_value = True
+        seen_non_unknown_value = True
 
         if value in acc:
             acc[value]["count"] += 1
@@ -32,7 +33,7 @@ def merge_sex_values(values_by_date):
     
     if len(acc) == 0:
         if seen_unknown_value_before_non_unknown_value:
-            return UNKNOWN, False # not inconsistent, just unknown
+            return unknown_value, False # not inconsistent, just unknown
         
         return None, True # no information at all, flag as error
     
@@ -43,23 +44,6 @@ def merge_sex_values(values_by_date):
     flag_errors = len(acc.keys()) > 1
 
     return most_common_value, flag_errors
-    
-
-
-
-
-def most_recent_modal_value_by_visit_date(identifier_heading, rows, column):
-    # NPDA analysis has this notion of "Most up-to-date valid mode"
-    # My understanding of it is that you should:
-    #  - Work out the modal (most common) value
-    #  - If there's more than one mode, return the one from the row with the most recent visit
-    values_by_count_and_last_visit_date = rows.groupby(column).agg(
-        Count=(identifier_heading, 'count'),
-        LastVisitDate=('Visit/Appointment Date', 'max')
-    ).sort_values(by=['Count', 'LastVisitDate'])
-
-    if len(values_by_count_and_last_visit_date) > 0:
-        return values_by_count_and_last_visit_date.iloc[-1].name
 
 def smallest(rows, column):
     if len(rows) > 0:
@@ -92,24 +76,31 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
     model_field = column.get("model_field")
 
     if model in ["Patient", "Transfer"]:
+        values_by_date = ((row["Visit/Appointment Date"], row[heading]) for _, row in rows.iterrows() if pd.notnull(row[heading]) and pd.notnull(row["Visit/Appointment Date"]))
         unique_values = rows[heading].dropna().unique()
 
-        if len(unique_values) > 1:
-            unique_values_str = ", ".join(unique_values.astype(str))
-            error_field = model_field if model_field else "__all__"
-            errors_to_return[patient_row_index][error_field].append(
-                f"Conflicting values for {heading}: {unique_values_str}"
-            )
+        flag_values = False
 
         match model_field:
-            case "date_of_birth" | "sex" | "ethnicity":
-                rows[heading] = most_recent_modal_value_by_visit_date(identifier_heading, rows, heading)
+            case "date_of_birth":
+                rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=None)
+            case "sex":
+                rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=SEX_TYPE[-1][0])
+            case "ethnicity":
+                rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=ETHNICITIES[-1][0])
             case "reason_leaving_service":
                 rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
             case "diabetes_type" | "postcode" | "gp_practice_ods_code":
                 rows[heading] = most_recent_by_visit_date(rows, heading)
             case "diagnosis_date":
                 rows[heading] = smallest(rows, heading)
+        
+        if len(unique_values) > 1 and flag_values:
+            unique_values_str = ", ".join(unique_values.astype(str))
+            error_field = model_field if model_field else "__all__"
+            errors_to_return[patient_row_index][error_field].append(
+                f"Conflicting values for {heading}: {unique_values_str}"
+            )
 
 
 def merge_rows_for_patient(identifier_heading, rows, patient_row_index, errors_to_return):

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -58,21 +58,6 @@ def smallest_code_with_attached_date(rows, code_column, date_column):
         return rows_with_leaving_service.iloc[0][code_column]
 
 
-def most_recent_by_visit_date(rows, column):
-    if rows['Visit/Appointment Date'].isnull().all():
-        # Unlikely case where there are no visit dates at all (to cover tests)
-        return rows.iloc[0][column]
-
-    rows_with_value = rows.dropna(subset=[column])
-
-    if len(rows_with_value) == 0:
-        return None
-
-    most_recent_row = rows.loc[rows_with_value['Visit/Appointment Date'].idxmax()]
-
-    return most_recent_row[column]
-
-
 def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_index, errors_to_return):
     heading = column["heading"]
 
@@ -80,8 +65,10 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
     model_field = column.get("model_field")
 
     if model in ["Patient", "Transfer"]:
-        values_by_date = ((row["Visit/Appointment Date"], row[heading]) for _, row in rows.iterrows() if pd.notnull(row[heading]))
         unique_values = rows[heading].dropna().unique()
+
+        values_by_date = ((row["Visit/Appointment Date"], row[heading]) for _, row in rows.iterrows() if pd.notnull(row[heading]))
+        values_by_date = sorted(values_by_date, key=lambda x: x[0]) # sort by date
 
         flag_values = False
 
@@ -104,7 +91,7 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
                 flag_values = len(unique_values) > 1
             
             case "diabetes_type" | "postcode" | "gp_practice_ods_code":
-                rows[heading] = most_recent_by_visit_date(rows, heading)
+                rows[heading] = values_by_date[-1][1] if len(values_by_date) > 0 else None # most recent value by date
                 flag_values = False # not an error if these change
         
         if flag_values:

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -45,15 +45,18 @@ def most_recent_modal_value_by_visit_date(values_by_date, unknown_value):
 
     return most_common_value, flag_errors
 
+
 def smallest(rows, column):
     if len(rows) > 0:
         return rows[column].min()
+
 
 def smallest_code_with_attached_date(rows, code_column, date_column):
     rows_with_leaving_service = rows.dropna(subset=[date_column]).sort_values(by=code_column)
 
     if len(rows_with_leaving_service) > 0:
         return rows_with_leaving_service.iloc[0][code_column]
+
 
 def most_recent_by_visit_date(rows, column):
     if rows['Visit/Appointment Date'].isnull().all():
@@ -68,6 +71,7 @@ def most_recent_by_visit_date(rows, column):
     most_recent_row = rows.loc[rows_with_value['Visit/Appointment Date'].idxmax()]
 
     return most_recent_row[column]
+
 
 def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_index, errors_to_return):
     heading = column["heading"]
@@ -84,21 +88,26 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
         match model_field:
             case "date_of_birth":
                 rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=None)
+            
             case "sex":
                 rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=SEX_TYPE[-1][0])
+            
             case "ethnicity":
                 rows[heading], flag_values = most_recent_modal_value_by_visit_date(values_by_date, unknown_value=ETHNICITIES[-1][0])
+            
             case "reason_leaving_service":
                 rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
-                flag_values = True
-            case "diabetes_type" | "postcode" | "gp_practice_ods_code":
-                rows[heading] = most_recent_by_visit_date(rows, heading)
-                flag_values = True
+                flag_values = len(unique_values) > 1
+            
             case "diagnosis_date":
                 rows[heading] = smallest(rows, heading)
-                flag_values = True
+                flag_values = len(unique_values) > 1
+            
+            case "diabetes_type" | "postcode" | "gp_practice_ods_code":
+                rows[heading] = most_recent_by_visit_date(rows, heading)
+                flag_values = False # not an error if these change
         
-        if len(unique_values) > 1 and flag_values:
+        if flag_values:
             unique_values_str = ", ".join(unique_values.astype(str))
             error_field = model_field if model_field else "__all__"
             errors_to_return[patient_row_index][error_field].append(

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -37,13 +37,6 @@ def most_recent_by_visit_date(rows, column):
 
     return most_recent_row[column]
 
-def report_conflicting_values(unique_values, model_field, patient_row_index, heading, errors_to_return):
-    unique_values_str = ", ".join(unique_values.astype(str))
-    error_field = model_field if model_field else "__all__"
-    errors_to_return[patient_row_index][error_field].append(
-        f"Conflicting values for {heading}: {unique_values_str}"
-    )
-
 def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_index, errors_to_return):
     heading = column["heading"]
 
@@ -54,7 +47,11 @@ def merge_patient_rows_for_column(identifier_heading, column, rows, patient_row_
         unique_values = rows[heading].dropna().unique()
 
         if len(unique_values) > 1:
-            report_conflicting_values(unique_values, model_field, patient_row_index, heading, errors_to_return)
+            unique_values_str = ", ".join(unique_values.astype(str))
+            error_field = model_field if model_field else "__all__"
+            errors_to_return[patient_row_index][error_field].append(
+                f"Conflicting values for {heading}: {unique_values_str}"
+            )
 
         match model_field:
             case "date_of_birth" | "sex" | "ethnicity":

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -35,6 +35,7 @@ from project.npda.forms.visit_form import VisitForm
 from project.npda.forms.external_patient_validators import validate_patient_async
 from project.npda.forms.external_visit_validators import validate_visit_async
 from project.npda.general_functions.csv.csv_clean import csv_clean
+from project.npda.general_functions.csv.csv_merge import merge_rows_for_patient
 from project.npda.models import (
     Patient, 
     Transfer,
@@ -262,69 +263,7 @@ async def csv_upload(
                 transfer_fields[field] = None
 
         return transfer_fields
-    
-    def most_recent_modal_value_by_visit_date(rows, column):
-        # NPDA analysis has this notion of "Most up-to-date valid mode"
-        # My understanding of it is that you should:
-        #  - Work out the modal (most common) value
-        #  - If there's more than one mode, return the one from the row with the most recent visit
-        values_by_count_and_last_visit_date = rows.groupby(column).agg(
-            Count=(identifier_heading, 'count'),
-            LastVisitDate=('Visit/Appointment Date', 'max')
-        ).sort_values(by=['Count', 'LastVisitDate'])
 
-        if len(values_by_count_and_last_visit_date) > 0:
-            return values_by_count_and_last_visit_date.iloc[-1].name
-    
-    def smallest(rows, column):
-        if len(rows) > 0:
-            return rows[column].min()
-
-    def smallest_code_with_attached_date(rows, code_column, date_column):
-        rows_with_leaving_service = rows.dropna(subset=[date_column]).sort_values(by=code_column)
-
-        if len(rows_with_leaving_service) > 0:
-            return rows_with_leaving_service.iloc[0][code_column]
-    
-    def most_recent_by_visit_date(rows, column):
-        if rows['Visit/Appointment Date'].isnull().all():
-            # Unlikely case where there are no visit dates at all (to cover tests)
-            return rows.iloc[0][column]
-
-        rows_with_value = rows.dropna(subset=[column])
-
-        if len(rows_with_value) == 0:
-            return None
-
-        most_recent_row = rows.loc[rows_with_value['Visit/Appointment Date'].idxmax()]
-
-        return most_recent_row[column]
-    
-    def merge_rows_for_patient(column, rows, patient_row_index):
-        heading = column["heading"]
-
-        model = column.get("model")
-        model_field = column.get("model_field")
-
-        if model in ["Patient", "Transfer"]:
-            unique_values = rows[heading].dropna().unique()
-
-            if len(unique_values) > 1:
-                unique_values_str = ", ".join(unique_values.astype(str))
-                error_field = model_field if model_field else "__all__"
-                errors_to_return[patient_row_index][error_field].append(
-                    f"Conflicting values for {heading}: {unique_values_str}"
-                )
-
-            match model_field:
-                case "date_of_birth" | "sex" | "ethnicity":
-                    rows[heading] = most_recent_modal_value_by_visit_date(rows, heading)
-                case "reason_leaving_service":
-                    rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
-                case "diabetes_type" | "postcode" | "gp_practice_ods_code":
-                    rows[heading] = most_recent_by_visit_date(rows, heading)
-                case "diagnosis_date":
-                    rows[heading] = smallest(rows, heading)
 
     """
     Process the csv file and validate and save the data in the tables, parsing any errors
@@ -386,9 +325,7 @@ async def csv_upload(
 
         first_patient_row_index = int(rows.iloc[0]["row_index"])
 
-        for column in CSV_HEADING_OBJECTS:
-            merge_rows_for_patient(column, rows, first_patient_row_index)
-        
+        merge_rows_for_patient(identifier_heading, rows, first_patient_row_index, errors_to_return)
         patient_row = rows.iloc[0]
 
         try:

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -300,34 +300,31 @@ async def csv_upload(
 
         return most_recent_row[column]
     
-    def merge_rows_for_patient(rows, patient_row_index):
-        for column in CSV_HEADING_OBJECTS:
-            heading = column["heading"]
+    def merge_rows_for_patient(column, rows, patient_row_index):
+        heading = column["heading"]
 
-            model = column.get("model")
-            model_field = column.get("model_field")
+        model = column.get("model")
+        model_field = column.get("model_field")
 
-            if model in ["Patient", "Transfer"]:
-                unique_values = rows[heading].dropna().unique()
+        if model in ["Patient", "Transfer"]:
+            unique_values = rows[heading].dropna().unique()
 
-                if len(unique_values) > 1:
-                    unique_values_str = ", ".join(unique_values.astype(str))
-                    error_field = model_field if model_field else "__all__"
-                    errors_to_return[patient_row_index][error_field].append(
-                        f"Conflicting values for {heading}: {unique_values_str}"
-                    )
+            if len(unique_values) > 1:
+                unique_values_str = ", ".join(unique_values.astype(str))
+                error_field = model_field if model_field else "__all__"
+                errors_to_return[patient_row_index][error_field].append(
+                    f"Conflicting values for {heading}: {unique_values_str}"
+                )
 
-                match model_field:
-                    case "date_of_birth" | "sex" | "ethnicity":
-                        rows[heading] = most_recent_modal_value_by_visit_date(rows, heading)
-                    case "reason_leaving_service":
-                        rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
-                    case "diabetes_type" | "postcode" | "gp_practice_ods_code":
-                        rows[heading] = most_recent_by_visit_date(rows, heading)
-                    case "diagnosis_date":
-                        rows[heading] = smallest(rows, heading)
-        
-        return rows.iloc[0]
+            match model_field:
+                case "date_of_birth" | "sex" | "ethnicity":
+                    rows[heading] = most_recent_modal_value_by_visit_date(rows, heading)
+                case "reason_leaving_service":
+                    rows[heading] = smallest_code_with_attached_date(rows, "Reason for leaving service", "Date of leaving service")
+                case "diabetes_type" | "postcode" | "gp_practice_ods_code":
+                    rows[heading] = most_recent_by_visit_date(rows, heading)
+                case "diagnosis_date":
+                    rows[heading] = smallest(rows, heading)
 
     """
     Process the csv file and validate and save the data in the tables, parsing any errors
@@ -388,7 +385,11 @@ async def csv_upload(
         patient = None
 
         first_patient_row_index = int(rows.iloc[0]["row_index"])
-        patient_row = merge_rows_for_patient(rows, first_patient_row_index)
+
+        for column in CSV_HEADING_OBJECTS:
+            merge_rows_for_patient(column, rows, first_patient_row_index)
+        
+        patient_row = rows.iloc[0]
 
         try:
             patient_form = await validate_patient_using_form(patient_row, async_client)

--- a/project/npda/tests/general_functions_tests/test_csv_merge.py
+++ b/project/npda/tests/general_functions_tests/test_csv_merge.py
@@ -1,0 +1,111 @@
+from project.npda.general_functions.csv.csv_merge import merge_sex_values
+from project.constants.sex_types import SEX_TYPE
+
+def test_consistent_sex():
+    data = [
+        ("2026/01/01", SEX_TYPE[0][0]),
+        ("2026/02/01", SEX_TYPE[0][0]),
+        ("2026/03/01", SEX_TYPE[0][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[0][0]
+    assert flag_values == False
+
+
+def test_inconsistent_sex():
+    data = [
+        ("2026/01/01", SEX_TYPE[0][0]),
+        ("2026/02/01", SEX_TYPE[0][0]),
+        ("2026/03/01", SEX_TYPE[1][0]),
+        ("2026/04/01", SEX_TYPE[1][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[1][0]
+    assert flag_values == True
+
+
+def test_moving_from_unknown_sex_to_known():
+    data = [
+        ("2026/01/01", SEX_TYPE[3][0]),
+        ("2026/02/01", SEX_TYPE[3][0]),
+        ("2026/03/01", SEX_TYPE[1][0]),
+        ("2026/04/01", SEX_TYPE[1][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[1][0]
+    assert flag_values == False
+
+
+def test_unknown_sex_most_recent_value():
+    data = [
+        ("2026/01/01", SEX_TYPE[1][0]),
+        ("2026/02/01", SEX_TYPE[1][0]),
+        ("2026/03/01", SEX_TYPE[3][0]),
+        ("2026/04/01", SEX_TYPE[3][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[3][0]
+    assert flag_values == True
+
+
+def test_consistent_sex():
+    data = [
+        ("2026/01/01", SEX_TYPE[0][0]),
+        ("2026/02/01", SEX_TYPE[0][0]),
+        ("2026/03/01", SEX_TYPE[0][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[0][0]
+    assert flag_values == False
+
+
+def test_inconsistent_sex():
+    data = [
+        ("2026/01/01", SEX_TYPE[0][0]),
+        ("2026/02/01", SEX_TYPE[0][0]),
+        ("2026/03/01", SEX_TYPE[1][0]),
+        ("2026/04/01", SEX_TYPE[1][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[1][0]
+    assert flag_values == True
+
+
+def test_moving_from_unknown_to_known():
+    data = [
+        ("2026/01/01", SEX_TYPE[3][0]),
+        ("2026/02/01", SEX_TYPE[3][0]),
+        ("2026/03/01", SEX_TYPE[1][0]),
+        ("2026/04/01", SEX_TYPE[1][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[1][0]
+    assert flag_values == False
+
+
+def test_unknown_sex_most_recent_value():
+    data = [
+        ("2026/01/01", SEX_TYPE[1][0]),
+        ("2026/02/01", SEX_TYPE[1][0]),
+        ("2026/03/01", SEX_TYPE[3][0]),
+        ("2026/04/01", SEX_TYPE[3][0]),
+    ]
+
+    output, flag_values = merge_sex_values(data)
+
+    assert output == SEX_TYPE[3][0]
+    assert flag_values == True

--- a/project/npda/tests/general_functions_tests/test_csv_merge.py
+++ b/project/npda/tests/general_functions_tests/test_csv_merge.py
@@ -1,4 +1,4 @@
-from project.npda.general_functions.csv.csv_merge import merge_sex_values
+from project.npda.general_functions.csv.csv_merge import most_recent_modal_value_by_visit_date
 from project.constants.sex_types import SEX_TYPE
 
 def test_consistent_sex():
@@ -8,7 +8,7 @@ def test_consistent_sex():
         ("2026/03/01", SEX_TYPE[0][0]),
     ]
 
-    output, flag_values = merge_sex_values(data)
+    output, flag_values = most_recent_modal_value_by_visit_date(data, SEX_TYPE[-1][0])
 
     assert output == SEX_TYPE[0][0]
     assert flag_values == False
@@ -22,7 +22,7 @@ def test_inconsistent_sex():
         ("2026/04/01", SEX_TYPE[1][0]),
     ]
 
-    output, flag_values = merge_sex_values(data)
+    output, flag_values = most_recent_modal_value_by_visit_date(data, SEX_TYPE[-1][0])
 
     assert output == SEX_TYPE[1][0]
     assert flag_values == True
@@ -36,7 +36,7 @@ def test_moving_from_unknown_sex_to_known():
         ("2026/04/01", SEX_TYPE[1][0]),
     ]
 
-    output, flag_values = merge_sex_values(data)
+    output, flag_values = most_recent_modal_value_by_visit_date(data, SEX_TYPE[-1][0])
 
     assert output == SEX_TYPE[1][0]
     assert flag_values == False
@@ -50,62 +50,7 @@ def test_unknown_sex_most_recent_value():
         ("2026/04/01", SEX_TYPE[3][0]),
     ]
 
-    output, flag_values = merge_sex_values(data)
-
-    assert output == SEX_TYPE[3][0]
-    assert flag_values == True
-
-
-def test_consistent_sex():
-    data = [
-        ("2026/01/01", SEX_TYPE[0][0]),
-        ("2026/02/01", SEX_TYPE[0][0]),
-        ("2026/03/01", SEX_TYPE[0][0]),
-    ]
-
-    output, flag_values = merge_sex_values(data)
-
-    assert output == SEX_TYPE[0][0]
-    assert flag_values == False
-
-
-def test_inconsistent_sex():
-    data = [
-        ("2026/01/01", SEX_TYPE[0][0]),
-        ("2026/02/01", SEX_TYPE[0][0]),
-        ("2026/03/01", SEX_TYPE[1][0]),
-        ("2026/04/01", SEX_TYPE[1][0]),
-    ]
-
-    output, flag_values = merge_sex_values(data)
-
-    assert output == SEX_TYPE[1][0]
-    assert flag_values == True
-
-
-def test_moving_from_unknown_to_known():
-    data = [
-        ("2026/01/01", SEX_TYPE[3][0]),
-        ("2026/02/01", SEX_TYPE[3][0]),
-        ("2026/03/01", SEX_TYPE[1][0]),
-        ("2026/04/01", SEX_TYPE[1][0]),
-    ]
-
-    output, flag_values = merge_sex_values(data)
-
-    assert output == SEX_TYPE[1][0]
-    assert flag_values == False
-
-
-def test_unknown_sex_most_recent_value():
-    data = [
-        ("2026/01/01", SEX_TYPE[1][0]),
-        ("2026/02/01", SEX_TYPE[1][0]),
-        ("2026/03/01", SEX_TYPE[3][0]),
-        ("2026/04/01", SEX_TYPE[3][0]),
-    ]
-
-    output, flag_values = merge_sex_values(data)
+    output, flag_values = most_recent_modal_value_by_visit_date(data, SEX_TYPE[-1][0])
 
     assert output == SEX_TYPE[3][0]
     assert flag_values == True

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4492,23 +4492,6 @@ def test_conflict_resolved_leaving_reason_must_have_date_attached(test_user, one
 
 
 @pytest.mark.django_db
-def test_conflicting_diabetes_type(test_user, one_patient_with_four_visits):
-    df = one_patient_with_four_visits
-
-    df.loc[0, "Diabetes Type"] = DIABETES_TYPES[0][0]
-    df.loc[1, "Diabetes Type"] = DIABETES_TYPES[0][0]
-    df.loc[2, "Diabetes Type"] = DIABETES_TYPES[0][0]
-    df.loc[3, "Diabetes Type"] = DIABETES_TYPES[1][0]
-
-    errors = csv_upload_sync(test_user, df)
-    assert "diabetes_type" in errors[0]
-
-    assert Patient.objects.count() == 1
-    # Most recent by visit date
-    assert Patient.objects.first().diabetes_type == DIABETES_TYPES[1][0]
-
-
-@pytest.mark.django_db
 def test_conflicting_diagnosis_date(test_user, one_patient_with_four_visits):
     df = one_patient_with_four_visits
 
@@ -4535,7 +4518,6 @@ def test_conflicting_diabetes_type_where_last_row_is_null(test_user, one_patient
     df.loc[3, "Diabetes Type"] = None
 
     errors = csv_upload_sync(test_user, df)
-    assert "diabetes_type" in errors[0]
 
     assert Patient.objects.count() == 1
     # Most recent by visit date


### PR DESCRIPTION
Fixes #1324 

Improves how we flag errors when merging patient data from multiple rows in a CSV file:

- Changing `diabetes_type`, `postcode` or `gp_practice_ods_code` is no longer an error
- Moving from unknown to a known value is not an error (but moving back to Unknown is)