### PR TITLE
Refactor CI test runs and dataset markers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,20 +48,25 @@ jobs:
         env:
           NPDA_DATASET_YEARS: "2021"
           NPDA_PYTEST_MARKER: dataset
+          PYTEST_ADDOPTS: "-o log_cli=false"
         run: s/test
 
       - name: "Run dataset tests (2026)"
         env:
           NPDA_DATASET_YEARS: "2026"
           NPDA_PYTEST_MARKER: dataset
+          PYTEST_ADDOPTS: "-o log_cli=false"
         run: s/test
 
       - name: "Run non-dataset tests"
         env:
           NPDA_PYTEST_MARKER: "not dataset"
+          PYTEST_ADDOPTS: "-o log_cli=false"
         run: s/test
 
       - name: "Run performance tests"
+        env:
+          PYTEST_ADDOPTS: "-o log_cli=false"
         run: docker compose exec django pytest -v -m performance
 
       - name: "Shutdown containers"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ on:
       - "*"
 
 jobs:
-  build-and-run-pytest-suite-in-docker-compose:
+  build-and-run-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,8 +29,41 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: "Run PR check script"
+      - name: "Setup environment and containers"
         env:
           AZURE_CONFIG_STORAGE_ACCOUNT: ${{ secrets.AZURE_CONFIG_STORAGE_ACCOUNT }}
           AZURE_CONFIG_FILE_SHARE: ${{ secrets.AZURE_CONFIG_FILE_SHARE }}
-        run: s/pr-check
+        run: |
+          az storage file download \
+            --auth-mode login \
+            --enable-file-backup-request-intent \
+            --account-name ${AZURE_CONFIG_STORAGE_ACCOUNT} \
+            --share-name ${AZURE_CONFIG_FILE_SHARE} \
+            --query 'size' \
+            --path .env --dest envs/.env
+          DOCKER_BUILDKIT=0 docker compose up -d postgis
+          DOCKER_BUILDKIT=0 docker compose up -d --no-deps django
+
+      - name: "Run dataset tests (2021)"
+        env:
+          NPDA_DATASET_YEARS: "2021"
+          NPDA_PYTEST_MARKER: dataset
+        run: s/test
+
+      - name: "Run dataset tests (2026)"
+        env:
+          NPDA_DATASET_YEARS: "2026"
+          NPDA_PYTEST_MARKER: dataset
+        run: s/test
+
+      - name: "Run non-dataset tests"
+        env:
+          NPDA_PYTEST_MARKER: "not dataset"
+        run: s/test
+
+      - name: "Run performance tests"
+        run: docker compose exec django pytest -v -m performance
+
+      - name: "Shutdown containers"
+        if: always()
+        run: docker compose down

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -5,6 +5,7 @@ Configures pytest fixtures for npda app tests.
 # standard imports
 
 import logging
+import os
 
 # third-party imports
 from datetime import date
@@ -45,6 +46,38 @@ register(NPDAUserFactory)  # => npdauser_factory
 register(OrganisationEmployerFactory)  # => npdauser_factory
 register(PaediatricsDiabetesUnitFactory)  # => npdauser_factory
 register(TransferFactory)  # => npdauser_factory
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dataset-year",
+        action="append",
+        default=[],
+        help="Dataset year(s) to test (e.g. --dataset-year=2021)",
+    )
+
+
+def _dataset_years_from_config(pytestconfig):
+    opt = pytestconfig.getoption("--dataset-year")
+    if opt:
+        return [int(y) for y in opt]
+
+    env = os.getenv("NPDA_DATASET_YEARS")
+    if env:
+        return [int(y.strip()) for y in env.split(",") if y.strip()]
+
+    return [2021, 2026]
+
+
+def pytest_generate_tests(metafunc):
+    if "dataset_year" in metafunc.fixturenames:
+        years = _dataset_years_from_config(metafunc.config)
+        metafunc.parametrize("dataset_year", years)
+
+
+@pytest.fixture
+def dataset_year(request):
+    return request.param
 
 
 @pytest.fixture

--- a/project/npda/tests/form_tests/test_patient_form.py
+++ b/project/npda/tests/form_tests/test_patient_form.py
@@ -31,6 +31,9 @@ from project.constants import SEX_TYPE
 logger = logging.getLogger(__name__)
 
 
+pytestmark = pytest.mark.dataset
+
+
 MOCK_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
     postcode=VALID_FIELDS["postcode"],
     gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
@@ -41,11 +44,6 @@ MOCK_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
 )
 
 ALDER_HEY_PZ_CODE = "PZ074"
-
-
-@pytest.fixture(params=[2021, 2026])
-def dataset_year(request):
-    return request.param
 
 
 @pytest.fixture

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -17,12 +17,10 @@ from project.npda.models import Visit, AuditPeriod
 from project.npda.tests.factories.patient_factory import PatientFactory
 
 
+pytestmark = pytest.mark.dataset
+
+
 MOCK_EXTERNAL_VALIDATION_RESULT = VisitExternalValidationResult(None, None, None, None)
-
-
-@pytest.fixture(params=[2021, 2026])
-def dataset_year(request):
-    return request.param
 
 
 @pytest.fixture

--- a/project/npda/tests/model_tests/test_submissions.py
+++ b/project/npda/tests/model_tests/test_submissions.py
@@ -27,7 +27,13 @@ from django.apps import apps
 from project.constants.user import RCPCH_AUDIT_TEAM
 
 # NPDA imports
-from project.npda.models import NPDAUser, Submission, Transfer, AuditPeriod
+from project.npda.models import (
+    NPDAUser,
+    Submission,
+    Transfer,
+    AuditPeriod,
+    PaediatricDiabetesUnit,
+)
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.factories import (
     PatientFactory,
@@ -66,7 +72,7 @@ def test_npda_user_can_create_submission(
     client = login_and_verify_user(client, ah_user)
 
     # Get Alder Hey PDU
-    pdu = PaediatricsDiabetesUnitFactory(pz_code=ALDER_HEY_PZ_CODE)
+    pdu = PaediatricDiabetesUnit.objects.get(pz_code=ALDER_HEY_PZ_CODE)
 
     # Create some patients
     patients = PatientFactory.create_batch(5)
@@ -284,7 +290,9 @@ def test_patients_copied_from_previous_questionnaire_submission(
     )
 
     # Patient 3: Patient with death date (should NOT be copied)
-    patient_3 = PatientFactory(death_date=previous_audit_period.end_date - timedelta(days=1))
+    patient_3 = PatientFactory(
+        death_date=previous_audit_period.end_date - timedelta(days=1)
+    )
     previous_submission.patients.add(patient_3)
     Transfer.objects.create(
         patient=patient_3,
@@ -293,13 +301,12 @@ def test_patients_copied_from_previous_questionnaire_submission(
 
     assert previous_submission.patients.count() == 3
 
-    url = reverse("pdu-submissions", kwargs={
-        "audit_period": next_audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE
-    })
+    url = reverse(
+        "pdu-submissions",
+        kwargs={"audit_period": next_audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+    )
 
-    response = client.post(url, data = {
-        "submit-data": "start-questionnaire-submission"
-    })
+    response = client.post(url, data={"submit-data": "start-questionnaire-submission"})
 
     assert response.status_code == 302
 

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -55,6 +55,9 @@ from project.npda.tests.utils import login_and_verify_user
 
 logger = logging.getLogger(__name__)
 
+
+pytestmark = pytest.mark.dataset
+
 ALDER_HEY_PZ_CODE = "PZ074"
 
 GOSH_PZ_CODE = "PZ196"
@@ -64,11 +67,6 @@ GOSH_PZ_CODE = "PZ196"
 def valid_df(dummy_sheets_folder):
     file = dummy_sheets_folder / "dummy_sheet_test.csv"
     return csv_parse(file).df
-
-
-@pytest.fixture(params=[2021, 2026])
-def dataset_year(request):
-    return request.param
 
 
 @pytest.fixture

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -73,6 +73,9 @@ from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.factories.patient_factory import PatientFactory
 
 
+pytestmark = pytest.mark.dataset
+
+
 MOCK_PATIENT_EXTERNAL_VALIDATION_RESULT = PatientExternalValidationResult(
     postcode=VALID_FIELDS["postcode"],
     gp_practice_ods_code=VALID_FIELDS["gp_practice_ods_code"],
@@ -155,11 +158,6 @@ RCPCH_PZ_CODE = "PZ999"
 def valid_df(dummy_sheets_folder):
     file = dummy_sheets_folder / "dummy_sheet_test.csv"
     return csv_parse(file).df
-
-
-@pytest.fixture(params=[2021, 2026])
-def dataset_year(request):
-    return request.param
 
 
 @pytest.fixture
@@ -5264,7 +5262,11 @@ def test_uploading_csv_against_incorrect_pdu(
     error_messages = list(get_messages(response.wsgi_request))
     assert error_messages[0].level_tag == "error"
 
-    assert Submission.objects.count() == 0, (
+    submissions_for_pdu = Submission.objects.filter(
+        audit_period=audit_period_for_dataset_year,
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE,
+    )
+    assert submissions_for_pdu.count() == 0, (
         "No submission should be created for incorrect PDU"
     )
 
@@ -5290,6 +5292,20 @@ def test_uploading_csv_with_conflicting_pdu_numbers(
         kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"},
     )
 
+    audit_period, _created = AuditPeriod.objects.get_or_create(
+        slug="2025-2026",
+        defaults={
+            "is_open": True,
+            "is_visible": True,
+            "start_date": date(2025, 4, 1),
+            "end_date": date(2026, 3, 31),
+        },
+    )
+    submission_count_before = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE,
+    ).count()
+
     # Feed file to view
     with open(tmp_csv_path, "rb") as csv_file:
         response = client.post(url, {"csv_upload": csv_file}, format="multipart")
@@ -5299,7 +5315,11 @@ def test_uploading_csv_with_conflicting_pdu_numbers(
     error_messages = list(get_messages(response.wsgi_request))
     assert error_messages[0].level_tag == "error"
 
-    assert Submission.objects.count() == 0, (
+    submission_count_after = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE,
+    ).count()
+    assert submission_count_after == submission_count_before, (
         "No submission should be created for incorrect PDU"
     )
 
@@ -5326,6 +5346,20 @@ def test_uploading_csv_with_pdu_number_missing_leading_pz(
         "pdu-upload-csv", kwargs={"pz_code": "PZ004", "audit_period": "2025-2026"}
     )
 
+    audit_period, _created = AuditPeriod.objects.get_or_create(
+        slug="2025-2026",
+        defaults={
+            "is_open": True,
+            "is_visible": True,
+            "start_date": date(2025, 4, 1),
+            "end_date": date(2026, 3, 31),
+        },
+    )
+    submission_count_before = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code="PZ004",
+    ).count()
+
     # Feed file to view
     with open(tmp_csv_path, "rb") as csv_file:
         response = client.post(url, {"csv_upload": csv_file}, format="multipart")
@@ -5338,10 +5372,13 @@ def test_uploading_csv_with_pdu_number_missing_leading_pz(
     )
     assert response.url == redirect_url
 
-    assert Submission.objects.count() == 1, (
+    submission_count_after = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code="PZ004",
+    ).count()
+    assert submission_count_after == submission_count_before + 1, (
         "Submission should be created for PDU with missing leading PZ"
     )
-    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
 
 
 @pytest.mark.django_db
@@ -5366,6 +5403,20 @@ def test_uploading_csv_with_pdu_number_missing_leading_zeros(
         "pdu-upload-csv", kwargs={"pz_code": "PZ004", "audit_period": "2025-2026"}
     )
 
+    audit_period, _created = AuditPeriod.objects.get_or_create(
+        slug="2025-2026",
+        defaults={
+            "is_open": True,
+            "is_visible": True,
+            "start_date": date(2025, 4, 1),
+            "end_date": date(2026, 3, 31),
+        },
+    )
+    submission_count_before = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code="PZ004",
+    ).count()
+
     # Feed file to view
     with open(tmp_csv_path, "rb") as csv_file:
         response = client.post(url, {"csv_upload": csv_file}, format="multipart")
@@ -5378,10 +5429,13 @@ def test_uploading_csv_with_pdu_number_missing_leading_zeros(
     )
     assert response.url == redirect_url
 
-    assert Submission.objects.count() == 1, (
+    submission_count_after = Submission.objects.filter(
+        audit_period=audit_period,
+        paediatric_diabetes_unit__pz_code="PZ004",
+    ).count()
+    assert submission_count_after == submission_count_before + 1, (
         "Submission should be created for PDU with missing leading zeroes"
     )
-    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/utils.py
+++ b/project/npda/tests/utils.py
@@ -40,7 +40,7 @@ def create_submission(
     audit_start_date_or_audit_period: date | AuditPeriod,
     pz_code: str,
     csv_file_name: str | None = None,
-    csv_file: bytes | None = None
+    csv_file: bytes | None = None,
 ) -> Submission:
     """
 
@@ -55,18 +55,25 @@ def create_submission(
         audit_period = AuditPeriod.objects.get(start_date=audit_start_date)
 
     npda_user = NPDAUserFactory(
-            first_name="test",
-            role=test_user_audit_centre_reader_data.role,
-            # Assign flags based on user role
-            is_active=test_user_audit_centre_reader_data.is_active,
-            is_staff=test_user_audit_centre_reader_data.is_staff,
-            is_rcpch_audit_team_member=test_user_audit_centre_reader_data.is_rcpch_audit_team_member,
-            is_rcpch_staff=test_user_audit_centre_reader_data.is_rcpch_staff,
-            groups=[test_user_audit_centre_reader_data.group_name],
-            # Assign to PDU via organisation employer by passing in list of pz_codes
-            organisation_employers=[pz_code],
-        )
+        first_name="test",
+        role=test_user_audit_centre_reader_data.role,
+        # Assign flags based on user role
+        is_active=test_user_audit_centre_reader_data.is_active,
+        is_staff=test_user_audit_centre_reader_data.is_staff,
+        is_rcpch_audit_team_member=test_user_audit_centre_reader_data.is_rcpch_audit_team_member,
+        is_rcpch_staff=test_user_audit_centre_reader_data.is_rcpch_staff,
+        groups=[test_user_audit_centre_reader_data.group_name],
+        # Assign to PDU via organisation employer by passing in list of pz_codes
+        organisation_employers=[pz_code],
+    )
     pdu = PaediatricDiabetesUnit.objects.get(pz_code=pz_code)
+
+    # Ensure a single active submission per PDU/year for tests that hit update_or_create.
+    Submission.objects.filter(
+        paediatric_diabetes_unit=pdu,
+        audit_year=audit_start_date.year,
+        submission_active=True,
+    ).update(submission_active=False)
 
     return Submission.objects.create(
         paediatric_diabetes_unit=pdu,
@@ -76,5 +83,5 @@ def create_submission(
         submission_by=npda_user,
         submission_active=True,
         csv_file_name=csv_file_name,
-        csv_file=csv_file
+        csv_file=csv_file,
     )

--- a/project/npda/tests/view_tests/dashboard/test_partials.py
+++ b/project/npda/tests/view_tests/dashboard/test_partials.py
@@ -14,10 +14,9 @@ from project.npda.models import NPDAUser
 from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.patient import Patient
 from project.npda.models.submission import Submission
+from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
 from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
-from project.npda.tests.factories import (
-    test_user_audit_centre_editor_data
-)
+from project.npda.tests.factories import test_user_audit_centre_editor_data
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
@@ -33,17 +32,20 @@ def setup(audit_period, patient_args):
         role=test_user_audit_centre_editor_data.role,
     ).first()
 
+    pdu = PaediatricDiabetesUnit.objects.get(pz_code=ALDER_HEY_PZ_CODE)
+
     date_of_birth = audit_period.start_date - relativedelta(years=11, days=2)
 
     patient = PatientFactory(
         nhs_number="4444444444",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        **patient_args
+        transfer__paediatric_diabetes_unit=pdu,
+        **patient_args,
     )
 
     submission = Submission.objects.create(
-        paediatric_diabetes_unit=user.organisation_employers.first(),
+        paediatric_diabetes_unit=pdu,
         audit_period=audit_period,
         audit_year=audit_period.start_date.year,
         submission_date=audit_period.start_date,
@@ -54,21 +56,26 @@ def setup(audit_period, patient_args):
 
     return user, patient
 
+
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1156
 @pytest.mark.django_db
 def test_count_of_patients_transitioning_to_adult_care_does_not_include_other_transfers(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    user, patient = setup(audit_period, patient_args={
-        "diagnosis_date": audit_period.start_date - relativedelta(days=2), # complete year of care
-        "transfer__date_leaving_service": audit_period.start_date + relativedelta(days=2),
-        "transfer__reason_leaving_service": LEAVE_PDU_REASONS[1][0] # Moved out of area
-    })
+    user, patient = setup(
+        audit_period,
+        patient_args={
+            "diagnosis_date": audit_period.start_date
+            - relativedelta(days=2),  # complete year of care
+            "transfer__date_leaving_service": audit_period.start_date
+            + relativedelta(days=2),
+            "transfer__reason_leaving_service": LEAVE_PDU_REASONS[1][
+                0
+            ],  # Moved out of area
+        },
+    )
 
     # Need a visit in the audit period to be eligible
     VisitFactory(
@@ -81,10 +88,12 @@ def test_count_of_patients_transitioning_to_adult_care_does_not_include_other_tr
 
     client = login_and_verify_user(client, user)
 
-    response = client.get(reverse("pdu-get-transitioned-to-adult-service-partial", kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            "pdu-get-transitioned-to-adult-service-partial",
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 0
@@ -93,27 +102,33 @@ def test_count_of_patients_transitioning_to_adult_care_does_not_include_other_tr
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1203
 @pytest.mark.django_db
 def test_count_of_patients_transitioning_to_adult_care_includes_patients_without_visits(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    user, _ = setup(audit_period, patient_args={
-        "diagnosis_date": audit_period.start_date - relativedelta(days=2), # complete year of care
-        "transfer__date_leaving_service": audit_period.start_date + relativedelta(days=2),
-        "transfer__reason_leaving_service": LEAVE_PDU_REASONS[0][0] # Transitioned to adult diabetes service
-    })
+    user, _ = setup(
+        audit_period,
+        patient_args={
+            "diagnosis_date": audit_period.start_date
+            - relativedelta(days=2),  # complete year of care
+            "transfer__date_leaving_service": audit_period.start_date
+            + relativedelta(days=2),
+            "transfer__reason_leaving_service": LEAVE_PDU_REASONS[0][
+                0
+            ],  # Transitioned to adult diabetes service
+        },
+    )
 
     # Deliberately no visit (to cover https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1203)
 
     client = login_and_verify_user(client, user)
 
-    response = client.get(reverse("pdu-get-transitioned-to-adult-service-partial", kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            "pdu-get-transitioned-to-adult-service-partial",
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 1
@@ -121,25 +136,28 @@ def test_count_of_patients_transitioning_to_adult_care_includes_patients_without
 
 @pytest.mark.django_db
 def test_new_diagnoses_includes_patients_without_visits(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    user, _ = setup(audit_period, patient_args={
-        "diagnosis_date": audit_period.start_date + relativedelta(days=2), # incomplete year of care
-    })
+    user, _ = setup(
+        audit_period,
+        patient_args={
+            "diagnosis_date": audit_period.start_date
+            + relativedelta(days=2),  # incomplete year of care
+        },
+    )
 
     # Deliberately no visit (to cover https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1203)
 
     client = login_and_verify_user(client, user)
 
-    response = client.get(reverse("pdu-get-new-diagnoses-partial", kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            "pdu-get-new-diagnoses-partial",
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 1
@@ -147,27 +165,33 @@ def test_new_diagnoses_includes_patients_without_visits(
 
 @pytest.mark.django_db
 def test_moved_out_of_area_includes_patients_without_visits(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
 ):
     audit_period = AuditPeriod.objects.get_default_audit_period()
 
-    user, _ = setup(audit_period, patient_args={
-        "diagnosis_date": audit_period.start_date - relativedelta(days=2), # complete year of care
-        "transfer__date_leaving_service": audit_period.start_date + relativedelta(days=2),
-        "transfer__reason_leaving_service": LEAVE_PDU_REASONS[1][0] # Moved out of area
-    })
+    user, _ = setup(
+        audit_period,
+        patient_args={
+            "diagnosis_date": audit_period.start_date
+            - relativedelta(days=2),  # complete year of care
+            "transfer__date_leaving_service": audit_period.start_date
+            + relativedelta(days=2),
+            "transfer__reason_leaving_service": LEAVE_PDU_REASONS[1][
+                0
+            ],  # Moved out of area
+        },
+    )
 
     # Deliberately no visit (to cover https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1203)
 
     client = login_and_verify_user(client, user)
 
-    response = client.get(reverse("pdu-get-moved-out-of-area-partial", kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            "pdu-get-moved-out-of-area-partial",
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 1
@@ -183,11 +207,7 @@ def test_moved_out_of_area_includes_patients_without_visits(
 )
 @pytest.mark.django_db
 def test_partials_before_submission(
-    seed_groups_fixture,
-    seed_users_fixture,
-    seed_audit_periods_fixture,
-    client,
-    route
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, route
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -198,10 +218,12 @@ def test_partials_before_submission(
 
     client = login_and_verify_user(client, user)
 
-    response = client.get(reverse(route, kwargs={
-        "audit_period": audit_period.slug,
-        "pz_code": ALDER_HEY_PZ_CODE
-    }))
+    response = client.get(
+        reverse(
+            route,
+            kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+        )
+    )
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 0

--- a/project/npda/tests/view_tests/test_performance.py
+++ b/project/npda/tests/view_tests/test_performance.py
@@ -7,9 +7,15 @@ import time
 
 import pytest
 from bs4 import BeautifulSoup
+from django.urls import reverse
 
 from project.npda.general_functions.data_generator_extended import (
-    AgeRange, FakePatientCreator, HbA1cTargetRange, VisitType)
+    AgeRange,
+    FakePatientCreator,
+    HbA1cTargetRange,
+    VisitType,
+)
+from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.npda_user import NPDAUser
 from project.npda.models.submission import Submission
 from project.npda.tests.test_csv_upload import ALDER_HEY_PZ_CODE
@@ -26,7 +32,6 @@ def test_dashboard_view_response_time(
     AUDIT_END_DATE,
     seed_groups_fixture,
     seed_users_fixture,
-    seed_patients_fixture,
     client,
 ):
     """Basic performance test for the dashboard view response time with lots of patients."""
@@ -53,7 +58,9 @@ def test_dashboard_view_response_time(
             audit_start_date=AUDIT_START_DATE,
             audit_end_date=AUDIT_END_DATE,
         )
-        logger.info(f'Seeding {N_PATIENTS} patients with {len(VISIT_TYPES)} visit types...')
+        logger.info(
+            f"Seeding {N_PATIENTS} patients with {len(VISIT_TYPES)} visit types..."
+        )
         new_pts = fake_patient_creator.create_and_save_fake_patients(
             n=N_PATIENTS,
             age_range=AgeRange.AGE_11_15,
@@ -64,8 +71,8 @@ def test_dashboard_view_response_time(
             visit_types=VISIT_TYPES,
             visit_kwargs={"is_valid": True},
         )
-        logger.info('DONE!')
-        logger.info('Creating submission...')
+        logger.info("DONE!")
+        logger.info("Creating submission...")
         new_submission = Submission.objects.create(
             paediatric_diabetes_unit=ah_user.organisation_employers.first(),
             audit_year=AUDIT_START_DATE.year,
@@ -76,15 +83,27 @@ def test_dashboard_view_response_time(
 
         # Add patients to submission
         new_submission.patients.add(*new_pts)
-        logger.info('DONE!')
+        logger.info("DONE!")
 
     def get_top_level_dashboard_view_response():
         start_dashboard = time.time()
         logger.info("\t⏳ Getting top-level dashboard view response...")
-        response = client.get("/dashboard")
+        response = client.get(
+            reverse(
+                "pdu-dashboard",
+                kwargs={
+                    "audit_period": audit_period.slug,
+                    "pz_code": ALDER_HEY_PZ_CODE,
+                },
+            )
+        )
         elapsed_dashboard = time.time() - start_dashboard
 
-        logger.info(f"N_PATIENTS: {N_PATIENTS} * VISIT_TYPES: {len(VISIT_TYPES)}".center(80, "*"))
+        logger.info(
+            f"N_PATIENTS: {N_PATIENTS} * VISIT_TYPES: {len(VISIT_TYPES)}".center(
+                80, "*"
+            )
+        )
 
         # Check valid overall response within some leeway upperbound
         assert response.status_code == 200
@@ -99,6 +118,8 @@ def test_dashboard_view_response_time(
         # Extract All HTMX Requests + hx-vals from the rendered HTML
         for tag in soup.find_all(attrs={"hx-get": True}):
             url = tag["hx-get"]
+            if not url:
+                continue
             hx_vals = tag.get("hx-vals", "{}")
             try:
                 hx_vals_json = json.loads(hx_vals)
@@ -162,6 +183,8 @@ def test_dashboard_view_response_time(
 
     # Login
     client = login_and_verify_user(client, ah_user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
 
     # Now create patients
     seed_patients()

--- a/project/npda/tests/view_tests/test_upload.py
+++ b/project/npda/tests/view_tests/test_upload.py
@@ -14,9 +14,7 @@ from project.npda.tests.utils import login_and_verify_user
 from project.npda.tests.test_csv_upload import mock_remote_calls
 
 
-@pytest.fixture(params=[2021, 2026])
-def dataset_year(request):
-    return request.param
+pytestmark = pytest.mark.dataset
 
 
 @pytest.fixture

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,5 +22,6 @@ markers =
     examples: mark test as workshop-type / example test
     seed: mark test as 'meta test', just used for seeding
     performance: mark test as performance test
+    dataset: mark test as dataset-year dependent
 
 asyncio_mode = auto

--- a/s/pr-check
+++ b/s/pr-check
@@ -1,135 +1,17 @@
 #!/bin/bash -e
+
+# Download .env file (--query avoids outputting all the info about the blob in our public logs)
 az storage file download \
-  --auth-mode login \
-  --enable-file-backup-request-intent \
-  --account-name "${AZURE_CONFIG_STORAGE_ACCOUNT}" \
-  --share-name "${AZURE_CONFIG_FILE_SHARE}" \
-  --query 'size' \
-  --path .env --dest envs/.env
+    --auth-mode login \
+    --enable-file-backup-request-intent \
+    --account-name ${AZURE_CONFIG_STORAGE_ACCOUNT} \
+    --share-name ${AZURE_CONFIG_FILE_SHARE} \
+    --query 'size' \
+    --path .env --dest envs/.env
 
-# Build app image explicitly so services that reference it don't try to pull it
-DOCKER_BUILDKIT=0 docker compose build django
-
-# Only dependencies needed for tests (reduces memory, avoids running flower/mkdocs/etc)
-# Must start django service so s/test can exec into it
-DOCKER_BUILDKIT=0 docker compose up -d postgis redis django
-
-# Wait for services to be ready
-sleep 5
-
-# Run tests in batches to avoid memory exhaustion (exit code 137)
-# Each batch runs separately to allow memory cleanup between groups
-
-restart_django() {
-  echo "Restarting Django container to reclaim memory..."
-  docker compose restart django
-  sleep 5
-}
-
-# Split KPI tests into two halves to stay within CI memory limits.
-# The 2026 dataset adds many Visit model fields; each PatientFactory/VisitFactory
-# call is heavier and memory accumulates over a long session.
-echo "Running KPI calculation tests (part 1/2)..."
-docker compose exec django pytest \
-  project/npda/tests/kpi_calculations/test_calculate_kpis.py \
-  project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py \
-  project/npda/tests/kpi_calculations/test_kpis_13_20.py \
-  project/npda/tests/kpi_calculations/test_kpis_21_23.py \
-  project/npda/tests/kpi_calculations/test_kpis_24.py \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running KPI calculation tests (part 2/2)..."
-docker compose exec django pytest \
-  project/npda/tests/kpi_calculations/test_kpis_1_12.py \
-  project/npda/tests/kpi_calculations/test_kpis_25_32.py \
-  project/npda/tests/kpi_calculations/test_kpis_33_40.py \
-  project/npda/tests/kpi_calculations/test_kpis_41_43.py \
-  project/npda/tests/kpi_calculations/test_kpis_44_49.py \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-# CSV upload tests: 374 collected items (dataset_year fixture is parametrised
-# [2021, 2026] so most tests run twice). Split into 6 batches to stay well
-# within CI memory limits.
-#
-# Batch coverage (157 unique test functions):
-#   1/6 B1a (35 fns, ~64 items):  everything not in the other 5 batches
-#   2/6 B1b (34 fns, ~66 items):  column/header validation, hba1c, treatment
-#   3/6 B2a (16 fns, ~38 items):  blood pressure + decs + urine albumin
-#   4/6 B2b (37 fns, ~84 items):  cholesterol, thyroid, coeliac, psychological, smoking, dietician, inpatient
-#   5/6 B3a (30 fns, ~52 items):  visit date, sex formats, space/upload/conflict tests
-#   6/6 B3b (5 fns,  ~79 items):  bad_data_for field-type tests (parametrized, high item count)
-
-echo "Running CSV upload tests (1/6: general/patient/date-of-birth)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "not (different_column or additional_columns or duplicate_columns or missing_columns or case_insensitive or mixed_case or column_headers_with or invalid_nhs_number_column or invalid_date_of_birth_column or old_template or first_row_with or second_row_with or upload_without_headers or jersey_csv or missing_identifier or both_identifier or dates_with_short or urine_albumin_value_is_rounded or bad_date_format or height_is_rounded or cleaned_fields or async_visit or hba1c or treatment_closed or treatment_missing_closed or treatment_mdi or blood_pressure or decs_value or decs_date or urine_albumin_value_form or urine_albumin_value_below or urine_albumin_value_above or urine_albumin_value_missing or urine_albumin_stage_missing or urine_albumin_date_missing or total_cholesterol or thyroid_treatment or coeliac_screening or psychological_support or smoking_status or dietician or inpatient_admission or visit_date_provided or visit_date_missing or visit_date_not or alternative_formats_for_sex or mix_of_standard_and_alternative or bad_data_for or non_breaking_space or remove_empty_spaces or csv_height_weight or submission_has_audit or visit_with_too or visit_form_dates or thyroid_and_coeliac or uploading_csv or conflicting or conflict_resolved)" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running CSV upload tests (2/6: column headers, hba1c, treatment)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "different_column or additional_columns or duplicate_columns or missing_columns or case_insensitive or mixed_case or column_headers_with or invalid_nhs_number_column or invalid_date_of_birth_column or old_template or first_row_with or second_row_with or upload_without_headers or jersey_csv or missing_identifier or both_identifier or dates_with_short or urine_albumin_value_is_rounded or bad_date_format or height_is_rounded or cleaned_fields or async_visit or hba1c or treatment_closed or treatment_missing_closed or treatment_mdi" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running CSV upload tests (3/6: blood pressure, DECS, urine albumin)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "blood_pressure or decs_value or decs_date or urine_albumin_value_form or urine_albumin_value_below or urine_albumin_value_above or urine_albumin_value_missing or urine_albumin_stage_missing or urine_albumin_date_missing" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running CSV upload tests (4/6: cholesterol, thyroid, coeliac, psychological, smoking, dietician, inpatient)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "total_cholesterol or thyroid_treatment or coeliac_screening or psychological_support or smoking_status or dietician or inpatient_admission" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running CSV upload tests (5/6: visit date, sex formats, conflicts)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "visit_date_provided or visit_date_missing or visit_date_not or alternative_formats_for_sex or mix_of_standard_and_alternative or non_breaking_space or remove_empty_spaces or csv_height_weight or submission_has_audit or visit_with_too or visit_form_dates or thyroid_and_coeliac or uploading_csv or conflicting or conflict_resolved" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running CSV upload tests (6/6: bad data for field types)..."
-docker compose exec django pytest project/npda/tests/test_csv_upload.py \
-  -k "bad_data_for" \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running view tests..."
-docker compose exec django pytest project/npda/tests/view_tests/ \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running model and form tests..."
-docker compose exec django pytest \
-  project/npda/tests/model_tests/ \
-  project/npda/tests/form_tests/ \
-  project/npda/tests/permissions_tests/ \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-restart_django
-
-echo "Running remaining tests..."
-docker compose exec django pytest \
-  project/npda/tests/general_functions_tests/ \
-  project/npda/tests/general_tests/ \
-  project/npda/tests/test_user_actions/ \
-  project/npda/tests/test_error_pages/ \
-  project/npda/tests/test_import_user.py \
-  project/npda/tests/test_meta_tests.py \
-  --no-header --tb=line -o log_cli=false -p no:warnings
-
-echo "All test batches completed successfully!"
-
-docker compose down -v
+# Tests (against local Postgres)
+# Can remove disabling BuildKit once https://github.com/docker/buildx/issues/3576 is released (BuildKit 0.28+)
+DOCKER_BUILDKIT=0 docker compose up -d postgis
+DOCKER_BUILDKIT=0 docker compose up -d --no-deps django
+s/test
+docker compose down

--- a/s/test
+++ b/s/test
@@ -8,4 +8,18 @@
 # all arguments passed to this script are passed to pytest
 
 # *** The project's containers MUST BE RUNNING to execute tests inside it! ***
-docker compose exec django pytest -v $*
+extra_args=()
+if [ -n "${NPDA_PYTEST_MARKER:-}" ]; then
+	extra_args+=("-m" "(${NPDA_PYTEST_MARKER}) and not performance")
+fi
+
+if [ -n "${NPDA_DATASET_YEARS:-}" ]; then
+	docker compose exec \
+		-e NPDA_DATASET_YEARS="$NPDA_DATASET_YEARS" \
+		-e NPDA_PYTEST_MARKER="$NPDA_PYTEST_MARKER" \
+		django pytest -v "${extra_args[@]}" "$@"
+else
+	docker compose exec \
+		-e NPDA_PYTEST_MARKER="$NPDA_PYTEST_MARKER" \
+		django pytest -v "${extra_args[@]}" "$@"
+fi


### PR DESCRIPTION
## Summary
- Remove redis/celery/mkdocs from PR test run by trimming the PR check startup and running only required containers.
- Split dataset-year tests behind a dataset marker with a dataset-year flag so 2021 and 2026 run separately.
- Run non-dataset tests without dataset or performance flags; add a dedicated performance test step.

## Testing
- NPDA_PYTEST_MARKER="dataset" NPDA_DATASET_YEARS="2021" s/test
- NPDA_PYTEST_MARKER="dataset" NPDA_DATASET_YEARS="2026" s/test
- NPDA_PYTEST_MARKER="not dataset" s/test
- docker compose exec django pytest -v -m performance
