### PR TITLE
Gracefully handle missing values in PDU number column

### DIFF
--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4289,6 +4289,7 @@ def test_uploading_csv_with_multiple_pdu_numbers_including_one_missing(
 ):
     two_patients_first_with_two_visits_second_with_one.at[0, "PDU Number"] = None
     two_patients_first_with_two_visits_second_with_one.at[1, "PDU Number"] = RCPCH_PZ_CODE
+    two_patients_first_with_two_visits_second_with_one.at[2, "PDU Number"] = ALDER_HEY_PZ_CODE
 
     # write back into temp
     tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_test_uploading_csv_with_multiple_pdu_numbers_including_one_missing.csv"
@@ -4326,6 +4327,7 @@ def test_uploading_csv_with_first_row_missing_pdu_number(
     client,
     test_rcpch_user
 ):
+    two_patients_with_one_visit_each = two_patients_with_one_visit_each.assign(**{"PDU Number": "PZ004"})
     two_patients_with_one_visit_each.at[0, "PDU Number"] = None
 
     # write back into temp
@@ -4335,7 +4337,7 @@ def test_uploading_csv_with_first_row_missing_pdu_number(
     # Log in user
     client = login_and_verify_user(client, test_rcpch_user)
 
-    url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
 
     # Feed file to view
     with open(tmp_csv_path, "rb") as csv_file:
@@ -4349,10 +4351,11 @@ def test_uploading_csv_with_first_row_missing_pdu_number(
 
     assert response.status_code == 302
 
-    error_messages = list(get_messages(response.wsgi_request))
-    assert error_messages[0].level_tag == "error"
-
-    assert Submission.objects.count() == 0, "No submission should be created for incorrect PDU"
+    redirect_url = reverse("pdu-upload-csv-in-progress", kwargs={ "pz_code": "PZ004", "audit_period": "2025-2026"})
+    assert response.url == redirect_url
+    
+    assert Submission.objects.count() == 1, "Submission should be created for upload where first row is missing PDU number but subsequent rows have correct PDU number"
+    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4279,6 +4279,82 @@ def test_uploading_csv_with_conflicting_pdu_numbers(
     assert Submission.objects.count() == 0, "No submission should be created for incorrect PDU"
 
 
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1344
+@pytest.mark.django_db
+def test_uploading_csv_with_multiple_pdu_numbers_including_one_missing(
+    two_patients_first_with_two_visits_second_with_one,
+    tmp_path,
+    client,
+    test_rcpch_user
+):
+    two_patients_first_with_two_visits_second_with_one.at[0, "PDU Number"] = None
+    two_patients_first_with_two_visits_second_with_one.at[1, "PDU Number"] = RCPCH_PZ_CODE
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_test_uploading_csv_with_multiple_pdu_numbers_including_one_missing.csv"
+    two_patients_first_with_two_visits_second_with_one.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Feed file to view
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    error_messages = list(get_messages(response.wsgi_request))
+    assert error_messages[0].level_tag == "error"
+
+    assert Submission.objects.count() == 0, "No submission should be created for incorrect PDU"
+
+
+# https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1344
+# Found as part of debugging the above issue so including for maximum regression proofing hopefully
+@pytest.mark.django_db
+def test_uploading_csv_with_first_row_missing_pdu_number(
+    two_patients_with_one_visit_each,
+    tmp_path,
+    client,
+    test_rcpch_user
+):
+    two_patients_with_one_visit_each.at[0, "PDU Number"] = None
+
+    # write back into temp
+    tmp_csv_path = tmp_path / "dummy_sheet_test_csv_upload_test_uploading_csv_with_first_row_missing_pdu_number.csv"
+    two_patients_with_one_visit_each.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse("pdu-upload-csv", kwargs={ "pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"})
+
+    # Feed file to view
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(
+            url,
+            {
+                'csv_upload': csv_file
+            },
+            format='multipart'
+        )
+
+    assert response.status_code == 302
+
+    error_messages = list(get_messages(response.wsgi_request))
+    assert error_messages[0].level_tag == "error"
+
+    assert Submission.objects.count() == 0, "No submission should be created for incorrect PDU"
+
+
 @pytest.mark.django_db
 def test_uploading_csv_with_pdu_number_missing_leading_pz(
     two_patients_with_one_visit_each,

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -438,16 +438,20 @@ def upload_csv(request, audit_period, pdu):
         if parsed_csv.identifier_column == "NHS Number" and is_jersey:
             return upload_error("CSV file must use Unique Reference Number as the identifier column unless uploading for Jersey")
 
-        if parsed_csv.df["PDU Number"].nunique() > 1:
-            message = f"CSV file contains multiple PDU Numbers: {', '.join(parsed_csv.df['PDU Number'].unique())}. Please upload a file containing data for a single PDU only."
+        # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1344
+        # Gracefully handle missing values in the "PDU Number" column
+        unique_pdu_numbers = parsed_csv.df["PDU Number"].dropna().unique()
+
+        if len(unique_pdu_numbers) > 1:
+            message = f"CSV file contains multiple PDU Numbers: {', '.join(unique_pdu_numbers)}. Please upload a file containing data for a single PDU only."
             return upload_error(message)
 
         # 1316 - Twinkle/Diamond outputs PDU number without leading PZ and zeros
         expected_pdu_number = pdu.pz_code.lstrip("PZ").lstrip("0")
-        pdu_number_in_csv = parsed_csv.df["PDU Number"].iloc[0].lstrip("PZ").lstrip("0")
+        pdu_number_in_csv = unique_pdu_numbers[0].lstrip("PZ").lstrip("0") if len(unique_pdu_numbers) > 0 else None
 
         if pdu_number_in_csv != expected_pdu_number:
-            message = f"PDU Number in CSV file ({parsed_csv.df['PDU Number'].iloc[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."
+            message = f"PDU Number in CSV file ({unique_pdu_numbers[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."
             return upload_error(message)
 
         if not audit_period.is_open and not (request.user.is_superuser or request.user.is_rcpch_audit_team_member):


### PR DESCRIPTION
Fixes #1344 

Gracefully handle missing values in PDU number column. It's fine to upload a CSV where all rows have the same value or some rows have no value but the others are the same.