### PR TITLE
Don't mask error when looking up lead organisation in map render

### DIFF
--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -51,14 +51,9 @@ def get_map_chart_partial(request, audit_period, pdu):
 
     lead_organisation_ods_code = submission.paediatric_diabetes_unit.lead_organisation_ods_code
 
-    try:
-        pdu_lead_organisation = fetch_organisation_by_ods_code(
-            ods_code=lead_organisation_ods_code
-        )
-    except:
-        raise ValueError(
-            f"Lead organisation for PDU {lead_organisation_ods_code=} not found"
-        )
+    pdu_lead_organisation = fetch_organisation_by_ods_code(
+        ods_code=lead_organisation_ods_code
+    )
 
     try:
         # these are all registered patients for the current cohort at the selected organisation to be plotted in the map


### PR DESCRIPTION
Seeing a trickle of errors rendering the map, see #1337 

```
Internal Server Error: /period/2025-2026/pdu/PZ053/get_map_chart_partial

ValueError at /period/2025-2026/pdu/PZ053/get_map_chart_partial
Lead organisation for PDU lead_organisation_ods_code='RJL32' not found

Request Method: GET
Request URL: https://npda.rcpch.ac.uk/period/2025-2026/pdu/PZ053/get_map_chart_partial
```

I think this try/except is masking the underlying error. By not wrapping it we should see the status code error in exception logging.