### PR TITLE
Roll out new patient report by default

### DIFF
--- a/project/constants/feature_flags.py
+++ b/project/constants/feature_flags.py
@@ -2,9 +2,5 @@ FEATURE_FLAGS = {
     "hide_users_other_than_test": {
         "description": "Hide all users except test users from the user list - useful for demos to avoid showing personal data",
         "default": False,
-    },
-    "patient_report_query_helpers": {
-        "description": "Use new patient report query helper annotations",
-        "default": False,
-    },
+    }
 }

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -37,18 +37,21 @@ def _patient_identifier_field(pdu) -> str:
     return "unique_reference_number" if pdu.pz_code == "PZ248" else "nhs_number"
 
 
-def build_base_queryset(pdu, audit_period):
+def build_base_queryset(pdu, audit_period, *, type1_only=True):
     audit_range = (audit_period.start_date, audit_period.end_date)
     patient_identifier = _patient_identifier_field(pdu)
 
+    filters = Q(
+        submissions__submission_active=True,
+        submissions__audit_period=audit_period,
+        submissions__paediatric_diabetes_unit=pdu,
+        visit__visit_date__range=audit_range,
+    )
+    if type1_only:
+        filters &= Q(diabetes_type=DIABETES_TYPES[0][0])
+
     base_qs = (
-        Patient.objects.filter(
-            submissions__submission_active=True,
-            submissions__audit_period=audit_period,
-            submissions__paediatric_diabetes_unit=pdu,
-            diabetes_type=DIABETES_TYPES[0][0],
-            visit__visit_date__range=audit_range,
-        )
+        Patient.objects.filter(filters)
         .distinct()
         .annotate(
             patient_identifier=F(patient_identifier),

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -82,11 +82,6 @@ def build_base_queryset(pdu, audit_period, *, type1_only=True):
 
 def annotate_health_checks(qs, audit_period):
     audit_range = (audit_period.start_date, audit_period.end_date)
-    prev_audit = audit_period.previous_audit_period()
-    retinal_range = (
-        prev_audit.start_date if prev_audit else audit_period.start_date,
-        audit_period.end_date,
-    )
 
     hba1c_exists = Exists(
         Visit.objects.filter(
@@ -131,7 +126,7 @@ def annotate_health_checks(qs, audit_period):
     retinal_exists = Exists(
         Visit.objects.filter(
             patient=OuterRef("pk"),
-            retinal_screening_observation_date__range=retinal_range,
+            retinal_screening_observation_date__range=audit_range,
             retinal_screening_result__isnull=False,
         )
     )
@@ -139,7 +134,7 @@ def annotate_health_checks(qs, audit_period):
     latest_retinal_screening_date = Subquery(
         Visit.objects.filter(
             patient=OuterRef("pk"),
-            retinal_screening_observation_date__range=retinal_range,
+            retinal_screening_observation_date__range=audit_range,
             retinal_screening_result__isnull=False,
         )
         .order_by("-retinal_screening_observation_date")
@@ -184,11 +179,11 @@ def annotate_health_checks(qs, audit_period):
         passed_retinal_screening=Case(
             When(
                 Q(is_gte_12yo=True) & Q(dx_over_1y=True) & retinal_exists,
-                then=True,
+                then=Value("complete"),
             ),
-            When(Q(is_gte_12yo=False) | Q(dx_over_1y=False), then=None),
-            default=False,
-            output_field=BooleanField(),
+            When(Q(is_gte_12yo=False) | Q(dx_over_1y=False), then=Value("not_required")),
+            default=Value(""),
+            output_field=CharField(),
         ),
         latest_retinal_screening_date=latest_retinal_screening_date,
     ).annotate(

--- a/project/npda/templates/patient_report/health_checks_table_partial.html
+++ b/project/npda/templates/patient_report/health_checks_table_partial.html
@@ -170,7 +170,19 @@
       </td>
       <td>{{ patient.num_passed }} / {{ patient.num_total }}</td>
       <td>
-        {% include "patient_report/components/true_false_incomplete_icons.html" with result=patient.passed_retinal_screening ineligible_reason=ineligible_reasons.retinal_screening field_name="retinal_screening" complete_tooltip_date=patient.latest_retinal_screening_date %}
+        {% if patient.passed_retinal_screening == "complete" %}
+          {% if patient.latest_retinal_screening_date %}
+            <div class="tooltip tooltip-bottom" data-tip="Most recent: {{ patient.latest_retinal_screening_date|date:'d/m/Y' }}">
+              <i class="fa-solid fa-circle-check text-success text-xl"></i>
+            </div>
+          {% else %}
+            <i class="fa-solid fa-circle-check text-success text-xl"></i>
+          {% endif %}
+        {% elif patient.passed_retinal_screening == "not_required" %}
+          <div class="tooltip tooltip-bottom" data-tip="{{ ineligible_reasons.retinal_screening }}">
+            <i class="fa-solid fa-ban text-muted text-xl"></i>
+          </div>
+        {% endif %}
       </td>
     </tr>
   {% empty %}

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -144,7 +144,7 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is False
-        assert row["passed_retinal_screening"] is None
+        assert row["passed_retinal_screening"] == "not_required"
 
     def test_retinal_screening_over_12_with_data_passes(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
@@ -171,9 +171,9 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] is True
+        assert row["passed_retinal_screening"] == "complete"
 
-    def test_retinal_screening_over_12_without_data_fails(
+    def test_retinal_screening_over_12_without_data_is_blank(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -197,9 +197,9 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] is False
+        assert row["passed_retinal_screening"] == ""
 
-    def test_retinal_screening_passes_with_previous_audit_period_data(
+    def test_retinal_screening_blank_with_previous_audit_period_data(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -222,7 +222,7 @@ class TestPatientReportHealthCheckQueries:
             hba1c_date=audit_period.start_date + relativedelta(days=10),
         )
 
-        # Retinal screening in previous audit period should count
+        # Retinal screening in previous audit period no longer counts
         VisitFactory(
             patient=patient,
             visit_date=previous_period.start_date + relativedelta(days=60),
@@ -236,9 +236,9 @@ class TestPatientReportHealthCheckQueries:
         rows = self._get_health_check_rows(pdu, audit_period)
         row = rows[patient.pk]
 
-        assert row["passed_retinal_screening"] is True
+        assert row["passed_retinal_screening"] == ""
 
-    def test_retinal_screening_fails_with_no_data_across_two_periods(
+    def test_retinal_screening_blank_with_no_data_across_two_periods(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -264,7 +264,7 @@ class TestPatientReportHealthCheckQueries:
         rows = self._get_health_check_rows(pdu, audit_period)
         row = rows[patient.pk]
 
-        assert row["passed_retinal_screening"] is False
+        assert row["passed_retinal_screening"] == ""
 
     def test_retinal_screening_not_required_within_first_year_of_diagnosis(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
@@ -293,9 +293,9 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] is None
+        assert row["passed_retinal_screening"] == "not_required"
 
-    def test_retinal_screening_with_date_but_no_result_fails(
+    def test_retinal_screening_with_date_but_no_result_is_blank(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -330,9 +330,9 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] is False
+        assert row["passed_retinal_screening"] == ""
 
-    def test_retinal_screening_previous_period_date_without_result_fails(
+    def test_retinal_screening_previous_period_date_without_result_is_blank(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -368,7 +368,7 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] is False
+        assert row["passed_retinal_screening"] == ""
 
     def test_incomplete_year_of_care_still_passes_hba1c(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -40,32 +40,6 @@ from dateutil.relativedelta import relativedelta
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [
-    pytest.mark.usefixtures("patient_report_feature_flag"),
-    pytest.mark.parametrize(
-        "patient_report_feature_flag",
-        [False, True],
-        indirect=True,
-    ),
-]
-
-
-@pytest.fixture
-def patient_report_feature_flag(request, monkeypatch):
-    enabled = request.param
-
-    import project.npda.tests.view_tests.test_patient_report as module
-
-    original_login = module.login_and_verify_user
-
-    def _wrapped_login(client, user):
-        user.feature_flags = ["patient_report_query_helpers"] if enabled else []
-        user.save(update_fields=["feature_flags"])
-        return original_login(client, user)
-
-    monkeypatch.setattr(module, "login_and_verify_user", _wrapped_login)
-    return enabled
-
 
 @pytest.mark.django_db
 def test_anonymous_user_cannot_access_patient_report(

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -1235,7 +1235,7 @@ def test_retinal_screening_under_12yo_shows_ineligible(
         nhs_number="5555555555",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=365),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -1308,7 +1308,7 @@ def test_retinal_screening_over_12yo_with_data_passes(
         nhs_number="6666666666",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=365),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -1381,7 +1381,7 @@ def test_retinal_screening_over_12yo_with_data_fails(
         nhs_number="7777777777",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=365),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)
@@ -1454,7 +1454,7 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
         nhs_number="8888888888",
         diabetes_type=DIABETES_TYPES[0][0],  # T1DM
         date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(days=365),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
     )
 
     visit_date = audit_period.start_date + relativedelta(days=10)

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -102,6 +102,7 @@ def test_no_duplicate_patients_in_report(
     new_submission = Submission.objects.create(
         paediatric_diabetes_unit=ah_rcpch_audit_team_user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=ah_rcpch_audit_team_user,
         submission_active=True,
@@ -157,7 +158,7 @@ def _create_outcomes_test_setup(client):
         "transfer__date_leaving_service": None,
     }
 
-    return ah_rcpch_audit_team_user, AUDIT_START_DATE, eligible_criteria
+    return ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria
 
 
 @pytest.mark.django_db
@@ -173,7 +174,7 @@ def test_outcomes_no_hba1c_measurements(
     Verifies that all HbA1c-related fields are None when a patient
     has visits but no HbA1c data recorded.
     """
-    ah_rcpch_audit_team_user, AUDIT_START_DATE, eligible_criteria = (
+    ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
         _create_outcomes_test_setup(client)
     )
 
@@ -195,6 +196,7 @@ def test_outcomes_no_hba1c_measurements(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=ah_rcpch_audit_team_user.organisation_employers.first(),
         audit_year=AUDIT_START_DATE.year,
+        audit_period=audit_period,
         submission_date=AUDIT_START_DATE,
         submission_by=ah_rcpch_audit_team_user,
         submission_active=True,
@@ -244,7 +246,7 @@ def test_outcomes_single_hba1c_measurement(
     Verifies that latest HbA1c values are populated correctly while
     previous values remain None, and no delta calculations are performed.
     """
-    ah_rcpch_audit_team_user, AUDIT_START_DATE, eligible_criteria = (
+    ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
         _create_outcomes_test_setup(client)
     )
 
@@ -266,6 +268,7 @@ def test_outcomes_single_hba1c_measurement(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=ah_rcpch_audit_team_user.organisation_employers.first(),
         audit_year=AUDIT_START_DATE.year,
+        audit_period=audit_period,
         submission_date=AUDIT_START_DATE,
         submission_by=ah_rcpch_audit_team_user,
         submission_active=True,
@@ -318,7 +321,7 @@ def test_outcomes_multiple_hba1c_measurements(
     percentage conversions are accurate, and delta calculations show the
     percentage change between measurements.
     """
-    ah_rcpch_audit_team_user, AUDIT_START_DATE, eligible_criteria = (
+    ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
         _create_outcomes_test_setup(client)
     )
 
@@ -349,6 +352,7 @@ def test_outcomes_multiple_hba1c_measurements(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=ah_rcpch_audit_team_user.organisation_employers.first(),
         audit_year=AUDIT_START_DATE.year,
+        audit_period=audit_period,
         submission_date=AUDIT_START_DATE,
         submission_by=ah_rcpch_audit_team_user,
         submission_active=True,
@@ -430,6 +434,7 @@ def test_report_for_patients_turning_12_in_audit_year(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -523,6 +528,7 @@ def test_report_for_sick_day_rules(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -588,6 +594,7 @@ def test_care_at_diagnosis_for_type_1_patient(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -655,6 +662,7 @@ def test_carb_counting_countdown_when_no_date_entered(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -717,6 +725,7 @@ def test_coeliac_screening_countdown_when_no_date_entered(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -779,6 +788,7 @@ def test_thyroid_screening_overdue_when_threshold_passed(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -842,6 +852,7 @@ def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -907,6 +918,7 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -969,6 +981,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1034,6 +1047,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1097,6 +1111,7 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1161,6 +1176,7 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1235,6 +1251,7 @@ def test_retinal_screening_under_12yo_shows_ineligible(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1307,6 +1324,7 @@ def test_retinal_screening_over_12yo_with_data_passes(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1379,6 +1397,7 @@ def test_retinal_screening_over_12yo_with_data_fails(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1451,6 +1470,7 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1525,6 +1545,7 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,
@@ -1594,6 +1615,7 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
         submission_date=audit_period.start_date,
         submission_by=user,
         submission_active=True,

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -1278,8 +1278,8 @@ def test_retinal_screening_under_12yo_shows_ineligible(
     patient_data = patients[0]
     assert patient_data["patient_identifier"] == "5555555555"
     assert patient_data["is_gte_12yo"] is False
-    # Should be None (ineligible) even though data exists
-    assert patient_data["passed_retinal_screening"] is None
+    # Should be "not_required" (ineligible) even though data exists
+    assert patient_data["passed_retinal_screening"] == "not_required"
 
 
 @pytest.mark.django_db
@@ -1352,7 +1352,7 @@ def test_retinal_screening_over_12yo_with_data_passes(
     assert patient_data["patient_identifier"] == "6666666666"
     assert patient_data["is_gte_12yo"] is True
     # Should pass because they are 12+ with valid data
-    assert patient_data["passed_retinal_screening"] is True
+    assert patient_data["passed_retinal_screening"] == "complete"
 
 
 @pytest.mark.django_db
@@ -1424,8 +1424,8 @@ def test_retinal_screening_over_12yo_with_data_fails(
     patient_data = patients[0]
     assert patient_data["patient_identifier"] == "7777777777"
     assert patient_data["is_gte_12yo"] is True
-    # Should fail because they are eligible but don't pass
-    assert patient_data["passed_retinal_screening"] is False
+    # Should be blank because they are eligible but don't pass — eye screen is biannual
+    assert patient_data["passed_retinal_screening"] == ""
 
 
 @pytest.mark.django_db
@@ -1497,8 +1497,8 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
     patient_data = patients[0]
     assert patient_data["patient_identifier"] == "8888888888"
     assert patient_data["is_gte_12yo"] is True
-    # Should be None (no data available) - template will show blank, not ineligible icon
-    assert patient_data["passed_retinal_screening"] is None
+    # Should be blank (no data available) - template will show blank, not ineligible icon
+    assert patient_data["passed_retinal_screening"] == ""
 
 
 @pytest.mark.django_db

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -219,6 +219,7 @@ This should involve:
 
 ##### Outcomes
 
+- Base cohort is all patients, not just those with Type 1 diabetes. Still only include patients in the current audit period.
 - Latest and previous HbA1c in audit period via `Subquery` ordered by `visit_date`.
 - Compute % change between previous and latest HbA1c (rounded).
 - Mean and median HbA1c per patient from audit-period values, excluding first 90 days post-diagnosis.

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -177,7 +177,8 @@ This should involve:
 - Blood pressure: `Exists` visit with `systolic_blood_pressure` and `blood_pressure_observation_date` in audit range; only required if >= 12.
 - Urinary albumin: `Exists` visit with `albumin_creatinine_ratio` and `albumin_creatinine_ratio_date` in audit range; only required if >= 12.
 - Foot exam: `Exists` visit with `foot_examination_observation_date` in audit range; only required if >= 12.
-- Eye screen: `Exists` visit with `retinal_screening_observation_date` and `retinal_screening_result` in current or previous audit period; not required if < 12 or diabetes duration < 1 year.
+- Eye screen: `Exists` visit with `retinal_screening_observation_date` and `retinal_screening_result` in audit range; not required if < 12 or diabetes duration < 1 year.
+  - If not present, return a blank entry in the report not "incomplete". This is because the screen is only mandatory bi-annually.
 - Total: `num_passed` vs `num_total` (3 for < 12, 6 for >= 12).
 
 ##### Additional Care Processes

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -134,7 +134,7 @@ This shows the mean and median HbA1c (both as IFCC and DCCT) of all visit HbA1cs
 
 ### Aim
 
-To Create a new patient report behind a feature flag that does not use the KPI class for its calculations, addressing each of the issues above.
+To Create a new patient report that does not use the KPI class for its calculations, addressing each of the issues above.
 
 This should involve:
 
@@ -152,12 +152,6 @@ This should involve:
 - [ ] It is fine to reuse partials to limit the impact of the refactor
 
 ### Detailed Implementation Plan (Agreed)
-
-#### Feature Flag and Access
-
-- Implement a server-side, persistent per-user feature flag to enable the new patient report, scoped to NPDA audit team members and superusers.
-- Keep the existing patient report routes and templates; switch query source based on the feature flag.
-- Leave the existing KPI-based implementation intact for fallback.
 
 #### Cohort Definition (Base Query)
 
@@ -238,7 +232,6 @@ This should involve:
 
 #### Requirements Coverage Checklist
 
-- Feature flag: server-side, persistent per-user; toggle visible to NPDA audit team members and superusers.
 - UI framework: use DaisyUI components and existing config; avoid custom components where DaisyUI fits.
 - Interactivity: HTMX for category switching, sorting, and pagination (reuse existing partials).
 - Security: keep current decorators/mixins for OTP login, PDU scoping, and role-based access.

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -3,55 +3,30 @@ import io
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-from decimal import Decimal
 from enum import Enum
 
 from dateutil.relativedelta import relativedelta
 import pandas as pd
 from django.db.models import (
-    BooleanField,
-    Case,
-    CharField,
-    Count,
-    DecimalField,
-    Exists,
     F,
-    IntegerField,
-    OuterRef,
     Q,
-    Value,
-    When,
-    Subquery,
-    ExpressionWrapper,
-    DurationField,
-    Func,
     Value,
 )
 
 # Django imports
 from django.http import HttpResponse
 from django.views.generic import ListView
-from project.constants.hba1c_format import HBA1C_FORMATS
-from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REASONS
-from project.constants.diabetes_types import DIABETES_TYPES
 from project.npda.general_functions.breadcrumbs import data_breadcrumbs
 from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.general_functions.patient_report import (
     queries as patient_report_queries,
 )
-from project.npda.models import Patient, AuditPeriod, Visit
-from project.npda.models.db_functions import Round
+from project.npda.models import Patient, AuditPeriod
 from project.npda.views.decorators import check_data_permissions, login_and_otp_required
 from project.npda.views.mixins import PDUPermissionMixin, LoginAndOTPRequiredMixin
 from django.db.models import QuerySet
 
 logger = logging.getLogger(__name__)
-
-PATIENT_REPORT_QUERY_HELPERS_FLAG = "patient_report_query_helpers"
-
-
-def use_patient_report_query_helpers(request) -> bool:
-    return PATIENT_REPORT_QUERY_HELPERS_FLAG in request.session.get("feature_flags", [])
 
 
 def apply_care_at_diagnosis_display(patients, reference_date):
@@ -167,64 +142,8 @@ class TableCategories(Enum):
         return cls.HEALTH_CHECKS.value
 
 
-def calculate_hba1c_values(pt_qs: QuerySet[Patient], calculate_kpis: CalculateKPIS):
-    """Helper function to calculate HbA1c values for a queryset."""
-    patient_ids = set(pt_qs.values_list("pk", flat=True))
-
-    valid_visits_with_hba1c = (
-        calculate_kpis._get_valid_visits_for_kpi_44_and_45(
-            Patient.objects.filter(pk__in=patient_ids)
-        )
-        .annotate(
-            hba1c_mmol_mol=Case(
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[0][0]),
-                    then=F("hba1c"),
-                ),
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                    then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
-                ),
-                default=None,
-                output_field=DecimalField(max_digits=5, decimal_places=2),
-            )
-        )
-        .values("hba1c_mmol_mol", "patient__pk")
-        .filter(hba1c_mmol_mol__isnull=False)
-    )
-    hba1c_values_by_patient = defaultdict(list)
-    for visit in valid_visits_with_hba1c:
-        hba1c_values_by_patient[visit["patient__pk"]].append(visit["hba1c_mmol_mol"])
-    for patient in pt_qs:
-        hba1c_values = hba1c_values_by_patient.get(patient["pk"], [])
-        if hba1c_values:
-            mean_hba1c_mmol_mol = calculate_kpis.calculate_mean(hba1c_values)
-            median_hba1c_mmol_mol = calculate_kpis.calculate_median(hba1c_values)
-            patient["kpi_44_mean_hba1c"] = round(mean_hba1c_mmol_mol)
-            patient["kpi_45_median_hba1c"] = round(median_hba1c_mmol_mol)
-            patient["mean_hba1c_pct"] = round(
-                (0.09148 * mean_hba1c_mmol_mol) + 2.152
-                if mean_hba1c_mmol_mol > 0 and mean_hba1c_mmol_mol is not None
-                else None,
-                1,
-            )
-            patient["median_hba1c_pct"] = round(
-                (0.09148 * median_hba1c_mmol_mol) + 2.152
-                if median_hba1c_mmol_mol > 0 and median_hba1c_mmol_mol is not None
-                else None,
-                1,
-            )
-        else:
-            patient["kpi_44_mean_hba1c"] = None
-            patient["kpi_45_median_hba1c"] = None
-            patient["mean_hba1c_pct"] = None
-            patient["median_hba1c_pct"] = None
-
-    return pt_qs
-
-
 def calculate_queryset(
-    pdu, audit_period: AuditPeriod, selected_category: str, use_query_helpers: bool
+    pdu, audit_period: AuditPeriod, selected_category: str
 ) -> QuerySet[Patient]:
     pz_code = pdu.pz_code
     calculation_date = audit_period.kpi_calculation_date()
@@ -235,333 +154,12 @@ def calculate_queryset(
         is_jersey=pz_code == "PZ248",
     )
     calculate_kpis.set_patients_for_calculation(pz_codes=[pz_code])
-    patient_identifier = (
-        "nhs_number" if pz_code != "PZ248" else "unique_reference_number"
-    )
-    if use_query_helpers:
-        base_qs = patient_report_queries.build_base_queryset(pdu, audit_period)
-        patient_identifier = patient_report_queries._patient_identifier_field(pdu)
-
-        if selected_category == TableCategories.HEALTH_CHECKS.value:
-            pt_qs = (
-                patient_report_queries.annotate_health_checks(base_qs, audit_period)
-                .order_by(
-                    "-is_complete_year_of_care",
-                    "-passed_hba1c",
-                    "-passed_bmi",
-                    "-passed_thyroid_screen",
-                    "-passed_blood_pressure",
-                    "-passed_urinary_albumin",
-                    "-passed_foot_exam",
-                    "patient_identifier",
-                )
-                .values(
-                    "pk",
-                    "patient_identifier",
-                    "is_gte_12yo",
-                    "is_complete_year_of_care",
-                    "passed_hba1c",
-                    "passed_bmi",
-                    "passed_thyroid_screen",
-                    "passed_blood_pressure",
-                    "passed_urinary_albumin",
-                    "passed_foot_exam",
-                    "num_passed",
-                    "num_total",
-                    "passed_retinal_screening",
-                    "latest_retinal_screening_date",
-                )
-            )
-            return pt_qs, calculate_kpis, patient_identifier
-
-        if selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
-            pt_qs = (
-                patient_report_queries.annotate_additional_care_processes(
-                    base_qs, audit_period
-                )
-                .order_by(
-                    "-is_complete_year_of_care",
-                    "-hba1c_4plus",
-                    "-psychological_assessment",
-                    "-smoking_status",
-                    "-smoking_cessation_referral",
-                    "-additional_dietetic_appt_offered",
-                    "-pts_attending_additional_dietetic_appt",
-                    "-influenza_immunisation_recommended",
-                    "-sick_day_rules_advice",
-                    "patient_identifier",
-                )
-                .values(
-                    "pk",
-                    "patient_identifier",
-                    "is_complete_year_of_care",
-                    "is_gte_12yo",
-                    "hba1c_4plus",
-                    "psychological_assessment",
-                    "smoking_status",
-                    "smoking_cessation_referral",
-                    "additional_dietetic_appt_offered",
-                    "pts_attending_additional_dietetic_appt",
-                    "influenza_immunisation_recommended",
-                    "sick_day_rules_advice",
-                )
-            )
-            return pt_qs, calculate_kpis, patient_identifier
-
-        if selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
-            pt_qs = (
-                patient_report_queries.annotate_care_at_diagnosis(base_qs, audit_period)
-                .order_by(
-                    "-coeliac_disease_screening",
-                    "-thyroid_disease_screening",
-                    "-carbohydrate_counting_education",
-                    "patient_identifier",
-                )
-                .values(
-                    "pk",
-                    "patient_identifier",
-                    "diagnosis_date",
-                    "coeliac_disease_screening",
-                    "thyroid_disease_screening",
-                    "carbohydrate_counting_education",
-                )
-            )
-            return pt_qs, calculate_kpis, patient_identifier
-
-        if selected_category == TableCategories.ADMISSIONS.value:
-            pt_qs = patient_report_queries.annotate_admissions(
-                base_qs, audit_period
-            ).values(
-                "pk",
-                "patient_identifier",
-                "is_complete_year_of_care",
-                "number_of_admissions",
-                "number_of_dka_admissions",
-            )
-            pt_qs = patient_report_queries.calculate_hba1c_values(pt_qs, audit_period)
-            return pt_qs, calculate_kpis, patient_identifier
-
-        if selected_category == TableCategories.TREATMENT.value:
-            pt_qs = patient_report_queries.annotate_treatment(
-                base_qs, audit_period
-            ).values(
-                "pk",
-                "patient_identifier",
-                "is_complete_year_of_care",
-                "treatment_regimen",
-                "glucose_monitoring",
-                "hcl",
-            )
-            return pt_qs, calculate_kpis, patient_identifier
-
-        if selected_category == TableCategories.OUTCOMES.value:
-            pt_qs = patient_report_queries.annotate_outcomes(
-                base_qs, audit_period
-            ).values(
-                "pk",
-                "patient_identifier",
-                "is_complete_year_of_care",
-                "latest_hba1c_mmol_mol",
-                "latest_hba1c_pct",
-                "previous_to_latest_hba1c_mmol_mol",
-                "previous_to_latest_hba1c_pct",
-                "hba1c_delta",
-                "latest_hba1c_date",
-                "previous_to_latest_hba1c_date",
-                "days_delta_between_latest_and_previous_hba1c",
-            )
-            return pt_qs, calculate_kpis, patient_identifier
-
-    all_t1dm_pts = (
-        calculate_kpis.calculate_kpi_3_total_t1dm()
-        .patient_querysets["eligible"]
-        .annotate(patient_identifier=F(patient_identifier))
-    )
-    all_t1dm_pts_with_complete_year_of_care = (
-        calculate_kpis.calculate_kpi_5_total_t1dm_complete_year().patient_querysets[
-            "eligible"
-        ]
-    )
-    pt_qs = all_t1dm_pts.annotate(
-        is_complete_year_of_care=Case(
-            When(
-                Exists(
-                    all_t1dm_pts_with_complete_year_of_care.filter(pk=OuterRef("pk"))
-                ),
-                then=True,
-            ),
-            default=False,
-            output_field=BooleanField(),
-        )
-    )
+    base_qs = patient_report_queries.build_base_queryset(pdu, audit_period)
+    patient_identifier = patient_report_queries._patient_identifier_field(pdu)
 
     if selected_category == TableCategories.HEALTH_CHECKS.value:
-        prev_audit = audit_period.previous_audit_period()
-        retinal_range = (
-            prev_audit.start_date if prev_audit else audit_period.start_date,
-            audit_period.end_date,
-        )
         pt_qs = (
-            pt_qs.annotate(
-                is_gte_12yo=Q(
-                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
-                ),
-                passed_hba1c=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_25_hba1c_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                passed_bmi=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_26_bmi_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                passed_thyroid_screen=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_27_thyroid_screen_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                passed_blood_pressure=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_28_blood_pressure_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=False),
-                        default=None,
-                        output_field=BooleanField(),
-                    ),
-                    output_field=BooleanField(),
-                ),
-                passed_urinary_albumin=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_29_urinary_albumin_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=False),
-                        default=None,
-                        output_field=BooleanField(),
-                    ),
-                    output_field=BooleanField(),
-                ),
-                passed_retinal_screening=Case(
-                    # First: Patient passed (≥12yo with valid screening)
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_30_retinal_screening()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    # Second: Patient is under 12 (ineligible by age)
-                    When(
-                        ~Q(is_gte_12yo=True),
-                        then=None,
-                    ),
-                    # Third: Patient is ≥12 but has NO retinal screening data at all
-                    When(
-                        Q(is_gte_12yo=True)
-                        & ~Exists(
-                            Visit.objects.filter(
-                                patient=OuterRef("pk"),
-                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                            ).filter(
-                                Q(retinal_screening_result__isnull=False)
-                                | Q(retinal_screening_observation_date__isnull=False)
-                            )
-                        ),
-                        then=None,
-                    ),
-                    # Default: Patient is ≥12, has some retinal data, but didn't pass
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                latest_retinal_screening_date=Subquery(
-                    Visit.objects.filter(
-                        patient=OuterRef("pk"),
-                        retinal_screening_observation_date__range=retinal_range,
-                        retinal_screening_result__isnull=False,
-                    )
-                    .order_by("-retinal_screening_observation_date")
-                    .values("retinal_screening_observation_date")[:1]
-                ),
-                passed_foot_exam=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_31_foot_examination_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=Case(
-                        When(is_gte_12yo=True, then=False),
-                        default=None,
-                        output_field=BooleanField(),
-                    ),
-                    output_field=BooleanField(),
-                ),
-                num_passed=Case(
-                    When(
-                        is_gte_12yo=True,
-                        then=(
-                            Case(When(passed_hba1c=True, then=1), default=0)
-                            + Case(When(passed_bmi=True, then=1), default=0)
-                            + Case(When(passed_thyroid_screen=True, then=1), default=0)
-                            + Case(When(passed_blood_pressure=True, then=1), default=0)
-                            + Case(When(passed_urinary_albumin=True, then=1), default=0)
-                            + Case(When(passed_foot_exam=True, then=1), default=0)
-                        ),
-                    ),
-                    When(
-                        is_gte_12yo=False,
-                        then=(
-                            Case(When(passed_hba1c=True, then=1), default=0)
-                            + Case(When(passed_bmi=True, then=1), default=0)
-                            + Case(When(passed_thyroid_screen=True, then=1), default=0)
-                        ),
-                    ),
-                    default=0,
-                    output_field=IntegerField(),
-                ),
-                num_total=Case(
-                    When(is_gte_12yo=True, then=6),
-                    When(is_gte_12yo=False, then=3),
-                    default=0,
-                    output_field=IntegerField(),
-                ),
-            )
+            patient_report_queries.annotate_health_checks(base_qs, audit_period)
             .order_by(
                 "-is_complete_year_of_care",
                 "-passed_hba1c",
@@ -589,156 +187,12 @@ def calculate_queryset(
                 "latest_retinal_screening_date",
             )
         )
-    elif selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
+        return pt_qs, calculate_kpis, patient_identifier
+
+    if selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
         pt_qs = (
-            pt_qs.annotate(
-                hba1c_4plus=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_33_hba1c_4plus_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                psychological_assessment=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_34_psychological_assessment_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                is_gte_12yo=Q(
-                    date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
-                ),
-                smoking_status=Case(
-                    When(
-                        is_gte_12yo=False,
-                        then=None,  # Not eligible
-                    ),
-                    When(
-                        Exists(
-                            Visit.objects.filter(
-                                patient=OuterRef("pk"),
-                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                                smoking_status__in=[
-                                    1,
-                                    2,
-                                ],  # non-smoker or smoker recorded
-                            )
-                        ),
-                        then=True,  # pass
-                    ),
-                    default=Value(
-                        False
-                    ),  # fail (includes smoking status not recorded 99)
-                    output_field=BooleanField(),
-                ),
-                smoking_cessation_referral=Case(
-                    When(
-                        is_gte_12yo=False,
-                        then=Value("under_12"),  # Not eligible
-                    ),
-                    When(
-                        Exists(
-                            Visit.objects.filter(
-                                patient=OuterRef("pk"),
-                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                                smoking_status__in=[99],  # unknown - fail
-                            )
-                        ),
-                        then=Value("False"),
-                    ),
-                    When(
-                        Exists(
-                            Visit.objects.filter(
-                                patient=OuterRef("pk"),
-                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                                smoking_status__in=[1],  # non-smoker
-                            )
-                        ),
-                        then=Value("non_smoker_no_referral"),
-                    ),
-                    When(
-                        Exists(
-                            Visit.objects.filter(
-                                patient=OuterRef("pk"),
-                                visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                                smoking_status__in=[2],  # smoker
-                            )
-                        ),
-                        then=Case(
-                            When(
-                                Exists(
-                                    Visit.objects.filter(
-                                        patient=OuterRef("pk"),
-                                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                                        smoking_cessation_referral_date__isnull=False,
-                                    )
-                                ),
-                                then=Value("True"),  # pass
-                            ),
-                            default=Value("False"),  # fail
-                        ),
-                    ),
-                    output_field=CharField(),
-                ),
-                additional_dietetic_appt_offered=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                pts_attending_additional_dietetic_appt=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                influenza_immunisation_recommended=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended_for_patient_report_table()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                sick_day_rules_advice=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_40_sick_day_rules_advice()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
+            patient_report_queries.annotate_additional_care_processes(
+                base_qs, audit_period
             )
             .order_by(
                 "-is_complete_year_of_care",
@@ -767,53 +221,11 @@ def calculate_queryset(
                 "sick_day_rules_advice",
             )
         )
-    elif selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
-        pt_qs = calculate_kpis.calculate_kpi_2_total_new_diagnoses().patient_querysets[
-            "eligible"
-        ]
-        pt_qs = pt_qs.filter(
-            diabetes_type=DIABETES_TYPES[0][0]  # T1DM
-        )
+        return pt_qs, calculate_kpis, patient_identifier
+
+    if selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
         pt_qs = (
-            pt_qs.annotate(
-                patient_identifier=F(patient_identifier),
-                coeliac_disease_screening=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_41_coeliac_disease_screening()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                thyroid_disease_screening=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_42_thyroid_disease_screening()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                carbohydrate_counting_education=Case(
-                    When(
-                        Exists(
-                            calculate_kpis.calculate_kpi_43_carbohydrate_counting_education()
-                            .patient_querysets["passed"]
-                            .filter(pk=OuterRef("pk"))
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-            )
+            patient_report_queries.annotate_care_at_diagnosis(base_qs, audit_period)
             .order_by(
                 "-coeliac_disease_screening",
                 "-thyroid_disease_screening",
@@ -829,316 +241,24 @@ def calculate_queryset(
                 "carbohydrate_counting_education",
             )
         )
-    elif selected_category == TableCategories.ADMISSIONS.value:
-        pt_qs = (
-            pt_qs.annotate(
-                number_of_admissions=Count(
-                    "visit",
-                    filter=Q(
-                        Q(
-                            visit__hospital_admission_date__range=calculate_kpis.AUDIT_DATE_RANGE
-                        )
-                        | Q(
-                            visit__hospital_discharge_date__range=calculate_kpis.AUDIT_DATE_RANGE
-                        )
-                    )
-                    & Q(
-                        visit__hospital_admission_reason__in=[
-                            choice[0] for choice in HOSPITAL_ADMISSION_REASONS
-                        ]
-                    )
-                    & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE),
-                    distinct=True,
-                ),
-                number_of_dka_admissions=Count(
-                    "visit",
-                    filter=Q(
-                        Q(
-                            visit__hospital_admission_date__range=calculate_kpis.AUDIT_DATE_RANGE
-                        )
-                        | Q(
-                            visit__hospital_discharge_date__range=calculate_kpis.AUDIT_DATE_RANGE
-                        )
-                    )
-                    & Q(
-                        visit__hospital_admission_reason=HOSPITAL_ADMISSION_REASONS[1][
-                            0
-                        ]
-                    )
-                    & Q(visit__visit_date__range=calculate_kpis.AUDIT_DATE_RANGE),
-                    distinct=True,
-                ),
-            )
-            .filter(Q(number_of_admissions__gt=0) | Q(number_of_dka_admissions__gt=0))
-            .values(
-                "pk",
-                "patient_identifier",
-                "is_complete_year_of_care",
-                "number_of_admissions",
-                "number_of_dka_admissions",
-            )
-        )
-        pt_qs = calculate_hba1c_values(pt_qs, calculate_kpis)
+        return pt_qs, calculate_kpis, patient_identifier
 
-    elif selected_category == TableCategories.OUTCOMES.value:
-        # get ALL patients for current submission
-        pt_qs = (
-            calculate_kpis.calculate_kpi_1_total_eligible()
-            .patient_querysets["eligible"]
-            .annotate(
-                patient_identifier=F(patient_identifier),
-                is_complete_year_of_care=Case(
-                    When(
-                        Exists(
-                            all_t1dm_pts_with_complete_year_of_care.filter(
-                                pk=OuterRef("pk")
-                            )
-                        ),
-                        then=True,
-                    ),
-                    default=False,
-                    output_field=BooleanField(),
-                ),
-                latest_hba1c_date=Subquery(
-                    Visit.objects.filter(
-                        patient=OuterRef("pk"),
-                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                        hba1c__isnull=False,
-                    )
-                    .order_by("-visit_date")
-                    .values("visit_date")[:1]
-                ),
-                previous_to_latest_hba1c_date=Subquery(
-                    Visit.objects.filter(
-                        patient=OuterRef("pk"),
-                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                        hba1c__isnull=False,
-                    )
-                    .order_by("-visit_date")
-                    .values("visit_date")[1:2]
-                ),
-                days_delta_between_latest_and_previous_hba1c=Case(
-                    When(
-                        Q(latest_hba1c_date__isnull=False)
-                        & Q(previous_to_latest_hba1c_date__isnull=False),
-                        then=Func(
-                            ExpressionWrapper(
-                                F("latest_hba1c_date")
-                                - F("previous_to_latest_hba1c_date"),
-                                output_field=DurationField(),
-                            ),
-                            function="EXTRACT",
-                            template="EXTRACT(DAY FROM %(expressions)s)",
-                            output_field=IntegerField(),
-                        ),
-                    ),
-                    default=None,
-                    output_field=IntegerField(),
-                ),
-                latest_hba1c_mmol_mol=Subquery(
-                    Visit.objects.filter(
-                        patient=OuterRef("pk"),
-                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                        hba1c__isnull=False,
-                    )
-                    .annotate(
-                        hba1c_mmol_mol=Case(
-                            When(
-                                Q(hba1c_format=HBA1C_FORMATS[0][0]),
-                                then=F("hba1c"),
-                            ),
-                            When(
-                                Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                                then=(F("hba1c") - Round(Decimal("2.152")))
-                                / Decimal("0.09148"),
-                            ),
-                            default=None,
-                            output_field=IntegerField(),
-                        )
-                    )
-                    .order_by("-hba1c_date")
-                    .values("hba1c_mmol_mol")[:1]
-                ),
-                latest_hba1c_pct=Case(
-                    When(
-                        Q(latest_hba1c_mmol_mol__isnull=False)
-                        & Q(latest_hba1c_mmol_mol__gt=0),
-                        then=(Decimal("0.09148") * F("latest_hba1c_mmol_mol"))
-                        + Decimal("2.152"),
-                    ),
-                    default=None,
-                    output_field=DecimalField(max_digits=4, decimal_places=1),
-                ),
-                previous_to_latest_hba1c_mmol_mol=Subquery(
-                    Visit.objects.filter(
-                        patient=OuterRef("pk"),
-                        visit_date__range=calculate_kpis.AUDIT_DATE_RANGE,
-                        hba1c__isnull=False,
-                    )
-                    .annotate(
-                        hba1c_mmol_mol=Case(
-                            When(
-                                Q(hba1c_format=HBA1C_FORMATS[0][0]),
-                                then=F("hba1c"),
-                            ),
-                            When(
-                                Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                                then=(F("hba1c") - Round(Decimal("2.152")))
-                                / Decimal("0.09148"),
-                            ),
-                            default=None,
-                            output_field=IntegerField(),
-                        )
-                    )
-                    .order_by("-hba1c_date")
-                    .values("hba1c_mmol_mol")[1:2]
-                ),
-                previous_to_latest_hba1c_pct=Case(
-                    When(
-                        Q(previous_to_latest_hba1c_mmol_mol__isnull=False)
-                        & Q(previous_to_latest_hba1c_mmol_mol__gt=0),
-                        then=(
-                            Decimal("0.09148") * F("previous_to_latest_hba1c_mmol_mol")
-                        )
-                        + Decimal("2.152"),
-                    ),
-                    default=None,
-                    output_field=DecimalField(max_digits=4, decimal_places=1),
-                ),
-                hba1c_delta=Case(
-                    When(
-                        Q(latest_hba1c_mmol_mol__isnull=False)
-                        & Q(previous_to_latest_hba1c_mmol_mol__isnull=False),
-                        then=Round(
-                            (
-                                F("latest_hba1c_mmol_mol")
-                                - F("previous_to_latest_hba1c_mmol_mol")
-                            )
-                            * Decimal("100.0")
-                            / F("previous_to_latest_hba1c_mmol_mol")
-                        ),
-                    ),
-                    default=None,
-                    output_field=DecimalField(max_digits=3, decimal_places=1),
-                ),
-            )
-            .values(
-                "pk",
-                "patient_identifier",
-                "is_complete_year_of_care",
-                "latest_hba1c_mmol_mol",
-                "latest_hba1c_pct",
-                "previous_to_latest_hba1c_mmol_mol",
-                "previous_to_latest_hba1c_pct",
-                "hba1c_delta",
-                "latest_hba1c_date",
-                "previous_to_latest_hba1c_date",
-                "days_delta_between_latest_and_previous_hba1c",
-            )
+    if selected_category == TableCategories.ADMISSIONS.value:
+        pt_qs = patient_report_queries.annotate_admissions(
+            base_qs, audit_period
+        ).values(
+            "pk",
+            "patient_identifier",
+            "is_complete_year_of_care",
+            "number_of_admissions",
+            "number_of_dka_admissions",
         )
+        pt_qs = patient_report_queries.calculate_hba1c_values(pt_qs, audit_period)
+        return pt_qs, calculate_kpis, patient_identifier
 
-    elif selected_category == TableCategories.TREATMENT.value:
-        pt_qs = pt_qs.annotate(
-            treatment_regimen=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_13_one_to_three_injections_per_day()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("1-3 injections/day"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_14_four_or_more_injections_per_day()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("4+ injections/day"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_15_insulin_pump()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Insulin pump"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_16_one_to_three_injections_plus_other_medication()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("1-3 injections + blood glucose lowering meds"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_17_four_or_more_injections_plus_other_medication()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("4+ injections + blood glucose lowering meds"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_18_insulin_pump_plus_other_medication()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Insulin pump + blood glucose lowering meds"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_19_dietary_management_alone()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Dietary management alone"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_20_dietary_management_plus_other_medication()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Dietary management + blood glucose lowering meds"),
-                ),
-                default=Value("No treatment regimen"),
-                output_field=CharField(),
-            ),
-            glucose_monitoring=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_21_flash_glucose_monitor()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Flash glucose monitor"),
-                ),
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_22_real_time_cgm_with_alarms()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Continuous glucose monitor with alarms"),
-                ),
-                default=Value("No glucose monitoring"),
-                output_field=CharField(),
-            ),
-            hcl=Case(
-                When(
-                    Exists(
-                        calculate_kpis.calculate_kpi_24_hybrid_closed_loop_system()
-                        .patient_querysets["passed"]
-                        .filter(pk=OuterRef("pk"))
-                    ),
-                    then=Value("Yes"),
-                ),
-                default=Value("No"),
-                output_field=CharField(),
-            ),
+    if selected_category == TableCategories.TREATMENT.value:
+        pt_qs = patient_report_queries.annotate_treatment(
+            base_qs, audit_period
         ).values(
             "pk",
             "patient_identifier",
@@ -1147,8 +267,27 @@ def calculate_queryset(
             "glucose_monitoring",
             "hcl",
         )
+        return pt_qs, calculate_kpis, patient_identifier
 
-    return pt_qs, calculate_kpis, patient_identifier
+    if selected_category == TableCategories.OUTCOMES.value:
+        pt_qs = patient_report_queries.annotate_outcomes(
+            base_qs, audit_period
+        ).values(
+            "pk",
+            "patient_identifier",
+            "is_complete_year_of_care",
+            "latest_hba1c_mmol_mol",
+            "latest_hba1c_pct",
+            "previous_to_latest_hba1c_mmol_mol",
+            "previous_to_latest_hba1c_pct",
+            "hba1c_delta",
+            "latest_hba1c_date",
+            "previous_to_latest_hba1c_date",
+            "days_delta_between_latest_and_previous_hba1c",
+        )
+        return pt_qs, calculate_kpis, patient_identifier
+
+    raise ValueError(f"Unknown category: {selected_category}")
 
 
 class PatientReportView(
@@ -1175,9 +314,8 @@ class PatientReportView(
         self.selected_category = category
         pz_code = self.pdu.pz_code
 
-        use_query_helpers = use_patient_report_query_helpers(request)
         pt_qs, calculate_kpis, patient_identifier = calculate_queryset(
-            self.pdu, self.audit_period, category, use_query_helpers
+            self.pdu, self.audit_period, category
         )
 
         # Save to use later in get_context_data
@@ -1250,12 +388,9 @@ class PatientReportView(
                 reverse = sort_order == "desc"
                 field_name = sort_field.replace("-", "")
                 # Calculate HbA1c values
-                if use_query_helpers:
-                    pt_qs = patient_report_queries.calculate_hba1c_values(
-                        pt_qs, self.audit_period
-                    )
-                else:
-                    pt_qs = calculate_hba1c_values(pt_qs, calculate_kpis)
+                pt_qs = patient_report_queries.calculate_hba1c_values(
+                    pt_qs, self.audit_period
+                )
 
                 pt_qs = sorted(
                     pt_qs,
@@ -1267,12 +402,9 @@ class PatientReportView(
                 )
             else:
                 pt_qs = pt_qs.order_by(sort_field)
-                if use_query_helpers:
-                    pt_qs = patient_report_queries.calculate_hba1c_values(
-                        pt_qs, self.audit_period
-                    )
-                else:
-                    pt_qs = calculate_hba1c_values(pt_qs, calculate_kpis)
+                pt_qs = patient_report_queries.calculate_hba1c_values(
+                    pt_qs, self.audit_period
+                )
         else:
             # Default ordering
             order_by = ["-is_complete_year_of_care", patient_identifier]
@@ -1281,12 +413,9 @@ class PatientReportView(
                 order_by = [patient_identifier]
 
             pt_qs = pt_qs.order_by(*order_by)
-            if use_query_helpers:
-                pt_qs = patient_report_queries.calculate_hba1c_values(
-                    pt_qs, self.audit_period
-                )
-            else:
-                pt_qs = calculate_hba1c_values(pt_qs, calculate_kpis)
+            pt_qs = patient_report_queries.calculate_hba1c_values(
+                pt_qs, self.audit_period
+            )
 
         if self.selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
             reference_date = self.audit_period.kpi_calculation_date()
@@ -1504,7 +633,6 @@ def download_patient_report(request, audit_period, pdu):
                 pdu=pdu,
                 audit_period=audit_period,
                 selected_category=category.value,
-                use_query_helpers=use_patient_report_query_helpers(request),
             )
 
             data = defaultdict(list)

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -662,22 +662,20 @@ def download_patient_report(request, audit_period, pdu):
                             "blood_pressure",
                             "urinary_albumin",
                             "foot_exam",
-                            "retinal_screening",
                         ]
 
                         for field in fields:
                             status = measure_status(row[f"passed_{field}"])
-
-                            if (
-                                field == "retinal_screening"
-                                and status == "NA"
-                                and row["is_gte_12yo"]
-                            ):
-                                # As retinal screening is bi-annual, they might have been covered last year
-                                # https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1276
-                                status = ""
-
                             data[field].append(status)
+
+                        # Retinal screening uses string-based status
+                        retinal = row["passed_retinal_screening"]
+                        if retinal == "complete":
+                            data["retinal_screening"].append("COMPLETE")
+                        elif retinal == "not_required":
+                            data["retinal_screening"].append("NA")
+                        else:
+                            data["retinal_screening"].append("")
 
                     case TableCategories.ADDITIONAL_CARE_PROCESSES:
                         data["complete_year_of_care"].append(

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -270,8 +270,11 @@ def calculate_queryset(
         return pt_qs, calculate_kpis, patient_identifier
 
     if selected_category == TableCategories.OUTCOMES.value:
+        outcomes_qs = patient_report_queries.build_base_queryset(
+            pdu, audit_period, type1_only=False
+        )
         pt_qs = patient_report_queries.annotate_outcomes(
-            base_qs, audit_period
+            outcomes_qs, audit_period
         ).values(
             "pk",
             "patient_identifier",


### PR DESCRIPTION
- Remove feature flag for new patient report.
- Fix outcomes tab in the new implementation to include all patients, not just T1.
- Roll back to original eye screen behaviour
  - Don't try to reach across audit years, it assumed the patients will have the same primary key but they get a new one per submission
  - Restore blank rather than incomplete for missing eye screen (as it's bi-annual)
  - Re-opened #1272 to cover implementing across audit years again

Closes #1314.
Closes #1327.
Closes #1302.
Closes #1301.
Closes #1299.
Closes #1350 

Thanks Claude for doing the grunt work based on the spec changes.