### PR TITLE
Fix/csv headings single source of truth

### DIFF
--- a/project/constants/csv_headings.py
+++ b/project/constants/csv_headings.py
@@ -9,6 +9,8 @@ UNIQUE_IDENTIFIER_ENGLAND = (
         "model_field": "nhs_number",
         "model": "Patient",
         "alternative_headings": ["NHSNumber"],
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
     },
 )
 
@@ -17,26 +19,46 @@ UNIQUE_IDENTIFIER_JERSEY = (
         "heading": "Unique Reference Number",
         "model_field": "unique_reference_number",
         "model": "Patient",
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
     },
 )
 
-CSV_HEADING_OBJECTS = (
-    # patient
+"""
+Combined CSV data types for 2021 and 2026 datasets, with unique identifier fields included
+"""
+
+ALL_HEADINGS = [
     {
         "heading": "Date of Birth",
         "model_field": "date_of_birth",
         "model": "Patient",
         "alternative_headings": ["DOB"],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Postcode of usual address",
         "model_field": "postcode",
         "model": "Patient",
+        "alternative_headings": [],
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
+    },
+    {
+        "heading": "Sex assigned at birth",
+        "model_field": "sex",
+        "model": "Patient",
+        "alternative_headings": ["Sex assigned at birth†††"],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Stated gender",
         "model_field": "sex",
         "model": "Patient",
+        "data_type": "int64",
+        "dataset_years": [2021],
     },
     {
         "heading": "Ethnic Category",
@@ -44,354 +66,83 @@ CSV_HEADING_OBJECTS = (
         "model": "Patient",
         # Deliberate typo to accomodate automatically generated Wythenshawe CSVs
         "alternative_headings": ["Ethnic cateogry"],
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Diabetes Type",
         "model_field": "diabetes_type",
         "model": "Patient",
+        "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Date of Diabetes Diagnosis",
         "model_field": "diagnosis_date",
         "model": "Patient",
         "alternative_headings": ["Date of Diagnosis"],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
+    },
+    {
+        "heading": "Did the patient receive immunotherapy prior to or after the diagnosis of stage 3 Type 1 diabetes?",
+        "model_field": "immunotherapy_received",
+        "model": "Patient",
+        "alternative_headings": [
+            "Did the patient receive immunotherapy prior to or after the diagnosis of stage 3 Type 1 diabetes?†"
+        ],
+        "data_type": "int64",
+        "dataset_years": [2026],
+    },
+    {
+        "heading": "Date immunotherapy started",
+        "model_field": "immunotherapy_date",
+        "model": "Patient",
+        "alternative_headings": ["Date immunotherapy started†"],
+        "data_type": "date",
+        "dataset_years": [2026],
     },
     {
         "heading": "Date of leaving service",
         "model_field": "date_leaving_service",
         "model": "Transfer",
+        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Reason for leaving service",
         "model_field": "reason_leaving_service",
         "model": "Transfer",
+        "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Death Date",
         "model_field": "death_date",
         "model": "Patient",
+        # "Effective Death Date" was the heading used in an early NPDA CSV template
         "alternative_headings": ["Effective Death Date"],
-    },
-    {
-        "heading": "GP Practice Code",
-        "model_field": "gp_practice_ods_code",
-        "model": "Patient",
-    },
-    {
-        "heading": "PDU Number",
-        "model_field": "pdu",
-        # Reference attached to Transfer in csv_upload
-        # Transfer
-    },
-    # Visit
-    {
-        "heading": "Visit/Appointment Date",
-        "model_field": "visit_date",
-        "model": "Visit",
-        "alternative_headings": ["Visit Date"],
-    },
-    {
-        "heading": "Patient Height (cm)",
-        "model_field": "height",
-        "model": "Visit",
-    },
-    {
-        "heading": "Patient Weight (kg)",
-        "model_field": "weight",
-        "model": "Visit",
-    },
-    {
-        "heading": "Observation Date (Height and weight)",
-        "model_field": "height_weight_observation_date",
-        "model": "Visit",
-    },
-    {"heading": "Hba1c Value", "model_field": "hba1c", "model": "Visit"},
-    {
-        "heading": "HbA1c result format",
-        "model_field": "hba1c_format",
-        "model": "Visit",
-        # Deliberate typo to accomodate the old NPDA CSV template
-        "alternative_headings": ["HB1AC Result Format"],
-    },
-    {
-        "heading": "Observation Date: Hba1c Value",
-        "model_field": "hba1c_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Diabetes Treatment at time of Hba1c measurement",
-        "model_field": "treatment",
-        "model": "Visit",
-        "alternative_headings": ["Diabetes Treatment at the time of HbA1c measurement"],
-    },
-    {
-        "heading": "If treatment included insulin pump therapy (i.e. option 3 or 6 selected), was this part of a closed loop system?",
-        "model_field": "closed_loop_system",
-        "model": "Visit",
-        "alternative_headings": [
-            # Trailing bracket to accomodate automatically generated Wythenshawe CSVs
-            "If treatment included insulin pump therapy (i.e. option 3 or 6 selected), was this as part of a closed loop system?)"
-        ],
-    },
-    {
-        "heading": "At the time of HbA1c measurement, in addition to standard blood glucose monitoring (SBGM), was the patient using any other method of glucose monitoring?",
-        "model_field": "glucose_monitoring",
-        "model": "Visit",
-        "alternative_headings": [
-            "At the time of HbA1c measurement, was the patient using any other method of glucose monitoring?"
-        ],
-    },
-    {
-        "heading": "Systolic Blood Pressure",
-        "model_field": "systolic_blood_pressure",
-        "model": "Visit",
-    },
-    {
-        "heading": "Diastolic Blood pressure",
-        "model_field": "diastolic_blood_pressure",
-        "model": "Visit",
-    },
-    {
-        "heading": "Observation Date (Blood Pressure)",
-        "model_field": "blood_pressure_observation_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Foot Assessment / Examination Date",
-        "model_field": "foot_examination_observation_date",
-        "model": "Visit",
-        "alternative_headings": ["Foot Assessment/Examination Date"],
-    },
-    {
-        "heading": "Retinal Screening date",
-        "model_field": "retinal_screening_observation_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Retinal Screening Result",
-        "model_field": "retinal_screening_result",
-        "model": "Visit",
-    },
-    {
-        "heading": "Urinary Albumin Level (ACR)",
-        "model_field": "albumin_creatinine_ratio",
-        "model": "Visit",
-    },
-    {
-        "heading": "Observation Date: Urinary Albumin Level",
-        "model_field": "albumin_creatinine_ratio_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Albuminuria Stage",
-        "model_field": "albuminuria_stage",
-        "model": "Visit",
-    },
-    {
-        "heading": "Total Cholesterol Level (mmol/l)",
-        "model_field": "total_cholesterol",
-        "model": "Visit",
-    },
-    {
-        "heading": "Observation Date: Total Cholesterol Level",
-        "model_field": "total_cholesterol_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Observation Date: Thyroid Function",
-        "model_field": "thyroid_function_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "At time of, or following measurement of thyroid function, was the patient prescribed any thyroid treatment?",
-        "model_field": "thyroid_treatment_status",
-        "model": "Visit",
-        "alternative_headings": [
-            "At the time of, or following measurement of thyroid function, was the patient prescribed any thyroid treatment?"
-        ],
-    },
-    {
-        "heading": "Observation Date: Coeliac Disease Screening",
-        "model_field": "coeliac_screen_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Has the patient been recommended a Gluten-free diet?",
-        "model_field": "gluten_free_diet",
-        "model": "Visit",
-        # sic from the old NPDA template (eugh non breaking spaces)
-        "alternative_headings": [
-            "Has the patient been\xa0recommended a Gluten-free\xa0diet?"
-        ],
-    },
-    {
-        "heading": "Observation Date - Psychological Screening Assessment",
-        "model_field": "psychological_screening_assessment_date",
-        "model": "Visit",
-        # sic from the old NPDA template
-        "alternative_headings": [
-            "Observation Date -Psychological Assessment Screening"
-        ],
-    },
-    {
-        "heading": "Was the patient assessed as requiring additional psychological/CAMHS support outside of MDT clinics?",
-        "model_field": "psychological_additional_support_status",
-        "model": "Visit",
-    },
-    {
-        "heading": "Does the patient smoke?",
-        "model_field": "smoking_status",
-        "model": "Visit",
-    },
-    {
-        "heading": "Date of offer of referral to smoking cessation service (if patient is a current smoker)",
-        "model_field": "smoking_cessation_referral_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Date of Level 3 carbohydrate counting education received",
-        "model_field": "carbohydrate_counting_level_three_education_date",
-        "model": "Visit",
-        "alternative_headings": [
-            "Date Level 3 carbohydrate counting education received",
-            "Date of Level 3 carbohydrate counting education received",
-        ],
-    },
-    {
-        "heading": "Was the patient offered an additional appointment with a paediatric dietitian?",
-        "model_field": "dietician_additional_appointment_offered",
-        "model": "Visit",
-    },
-    {
-        "heading": "Date of additional appointment with dietitian",
-        "model_field": "dietician_additional_appointment_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?",
-        "model_field": "ketone_meter_training",
-        "model": "Visit",
-    },
-    {
-        "heading": "Date that influenza immunisation was recommended",
-        "model_field": "flu_immunisation_recommended_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
-        "model_field": "sick_day_rules_training_date",
-        "model": "Visit",
-        "alternative_headings": [
-            # Missing spacing before brackets to accomodate automatically generated Wythenshawe CSVs
-            "Date of provision of advice('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia"
-        ],
-    },
-    {
-        "heading": "Start date (Hospital Provider Spell)",
-        "model_field": "hospital_admission_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Discharge date (Hospital provider spell)",
-        "model_field": "hospital_discharge_date",
-        "model": "Visit",
-    },
-    {
-        "heading": "Reason for admission",
-        "model_field": "hospital_admission_reason",
-        "model": "Visit",
-    },
-    {
-        "heading": "Only complete if DKA selected in previous question: During this DKA admission did the patient receive any of the following therapies?",
-        "model_field": "dka_additional_therapies",
-        "model": "Visit",
-        "alternative_headings": [
-            "During this DKA admission did the patient receive any of the following therapies?"
-        ],
-    },
-    {
-        "heading": "Only complete if OTHER selected: Reason for admission (free text)",
-        "model_field": "hospital_admission_other",
-        "model": "Visit",
-    },
-)
-
-# Combined CSV heading objects (use for backward compatibility)
-CSV_HEADING_OBJECTS_2021 = CSV_HEADING_OBJECTS
-
-CSV_HEADING_OBJECTS_2026 = (
-    # patient
-    {
-        "heading": "Date of Birth",
-        "model_field": "date_of_birth",
-        "model": "Patient",
-        "alternative_headings": ["DOB"],
-    },
-    {
-        "heading": "Postcode of usual address",
-        "model_field": "postcode",
-        "model": "Patient",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Sex assigned at birth",
-        "model_field": "sex",
-        "model": "Patient",
-        "alternative_headings": ["Sex assigned at birth†††"],
-    },
-    {
-        "heading": "Ethnic Category",
-        "model_field": "ethnicity",
-        "model": "Patient",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Diabetes Type",
-        "model_field": "diabetes_type",
-        "model": "Patient",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Date of Diabetes Diagnosis",
-        "model_field": "diagnosis_date",
-        "model": "Patient",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Date of leaving service",
-        "model_field": "date_leaving_service",
-        "model": "Transfer",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Reason for leaving service",
-        "model_field": "reason_leaving_service",
-        "model": "Transfer",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Death Date",
-        "model_field": "death_date",
-        "model": "Patient",
-        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "GP Practice Code",
         "model_field": "gp_practice_ods_code",
         "model": "Patient",
         "alternative_headings": [],
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
     },
-    {
-        "heading": "PDU Number",
-        "model_field": "pdu",
-        #    Reference attached to Transfer in csv_upload
-    },
-    # Visit
     {
         "heading": "Has the patient had a diagnosis of Attention Deficit Hyperactivity Disorder (ADHD) or Autism Spectrum Disorder (ASD)?",
         "model_field": "adhd_asd_status",
         "model": "Patient",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Does the patient have a diagnosis of a learning disability?",
@@ -400,36 +151,58 @@ CSV_HEADING_OBJECTS_2026 = (
         "alternative_headings": [
             "Does the patient have a diagnosis of a learning disability?†"
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
+    {
+        "heading": "PDU Number",
+        "model_field": "pdu",
+        #    Reference attached to Transfer in csv_upload
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
+    },
+    # Visit date field
     {
         "heading": "Visit/Appointment Date",
         "model_field": "visit_date",
         "model": "Visit",
-        "alternative_headings": [],
+        "alternative_headings": ["Visit Date"],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Physical measurement fields
     {
         "heading": "Patient Height (cm)",
         "model_field": "height",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Patient Weight (kg)",
         "model_field": "weight",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Observation Date (Height and weight)",
         "model_field": "height_weight_observation_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Hba1c fields
     {
         "heading": "Hba1c Value",
         "model_field": "hba1c",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Observation Date: HbA1c Value",
@@ -439,12 +212,26 @@ CSV_HEADING_OBJECTS_2026 = (
             "Observation Date: HbA1c Value†",
             "Observation Date: Hba1c Value",
         ],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    {
+        "heading": "HbA1c result format",
+        "model_field": "hba1c_format",
+        "model": "Visit",
+        # Deliberate typo to accomodate the old NPDA CSV template
+        "alternative_headings": ["HB1AC Result Format"],
+        "data_type": "int64",
+        "dataset_years": [2021],
+    },
+    # Treatment and monitoring fields
     {
         "heading": "Insulin regime at time of visit",
         "model_field": "insulin_regimen",
         "model": "Visit",
         "alternative_headings": ["Insulin regime at time of visit†"],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Other (non-insulin) blood glucose lowering medication at time of visit",
@@ -453,6 +240,8 @@ CSV_HEADING_OBJECTS_2026 = (
         "alternative_headings": [
             "Other (non-insulin) blood glucose lowering medication at time of visit†"
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Has lifestyle and dietary modification been recommended to reduce blood glucose levels?",
@@ -461,6 +250,37 @@ CSV_HEADING_OBJECTS_2026 = (
         "alternative_headings": [
             "Has lifestyle and dietary modification been recommended to reduce blood glucose levels?†"
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
+    },
+    {
+        "heading": "Diabetes Treatment at time of Hba1c measurement",
+        "model_field": "treatment",
+        "model": "Visit",
+        "alternative_headings": ["Diabetes Treatment at the time of HbA1c measurement"],
+        "data_type": "int64",
+        "dataset_years": [2021],
+    },
+    {
+        "heading": "If treatment included insulin pump therapy (i.e. option 3 or 6 selected), was this part of a closed loop system?",
+        "model_field": "closed_loop_system",
+        "model": "Visit",
+        "alternative_headings": [
+            # Trailing bracket to accomodate automatically generated Wythenshawe CSVs
+            "If treatment included insulin pump therapy (i.e. option 3 or 6 selected), was this as part of a closed loop system?)"
+        ],
+        "data_type": "int64",
+        "dataset_years": [2021],
+    },
+    {
+        "heading": "At the time of HbA1c measurement, in addition to standard blood glucose monitoring (SBGM), was the patient using any other method of glucose monitoring?",
+        "model_field": "glucose_monitoring",
+        "model": "Visit",
+        "alternative_headings": [
+            "At the time of HbA1c measurement, was the patient using any other method of glucose monitoring?"
+        ],
+        "data_type": "int64",
+        "dataset_years": [2021],
     },
     {
         "heading": "Was the patient using a continuous glucose monitor (CGM) at time of visit?",
@@ -469,159 +289,189 @@ CSV_HEADING_OBJECTS_2026 = (
         "alternative_headings": [
             "Was the patient using a continuous glucose monitor (CGM) at time of visit?†"
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
-    {
-        "heading": "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?",
-        "model_field": "ketone_meter_training",
-        "model": "Visit",
-        "alternative_headings": [
-            "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?††",
-            "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?��",
-        ],
-    },
-    {
-        "heading": "Did the patient receive immunotherapy prior to or after the diagnosis of stage 3 Type 1 diabetes?",
-        "model_field": "immunotherapy_received",
-        "model": "Patient",
-        "alternative_headings": [
-            "Did the patient receive immunotherapy prior to or after the diagnosis of stage 3 Type 1 diabetes?†"
-        ],
-    },
-    {
-        "heading": "Date immunotherapy started",
-        "model_field": "immunotherapy_date",
-        "model": "Patient",
-        "alternative_headings": ["Date immunotherapy started†"],
-    },
+    # Blood pressure fields
     {
         "heading": "Systolic Blood Pressure",
         "model_field": "systolic_blood_pressure",
         "model": "Visit",
+        "data_type": "int64",
         "alternative_headings": ["Systolic Blood Pressure††"],
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Diastolic Blood pressure",
         "model_field": "diastolic_blood_pressure",
         "model": "Visit",
+        "data_type": "int64",
         "alternative_headings": ["Diastolic Blood pressure†"],
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Observation Date (Blood Pressure)",
         "model_field": "blood_pressure_observation_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Foot examination fields
     {
         "heading": "Foot Assessment / Examination Date",
         "model_field": "foot_examination_observation_date",
         "model": "Visit",
-        "alternative_headings": [],
+        "alternative_headings": ["Foot Assessment/Examination Date"],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Retinal screening fields
     {
         "heading": "Retinal Screening date",
         "model_field": "retinal_screening_observation_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Retinal Screening Result",
         "model_field": "retinal_screening_result",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
+    # Albuminuria fields
     {
         "heading": "Urinary Albumin Level (ACR)",
         "model_field": "albumin_creatinine_ratio",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Observation Date: Urinary Albumin Level",
         "model_field": "albumin_creatinine_ratio_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Albuminuria Stage",
         "model_field": "albuminuria_stage",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
+    # Cholesterol fields
     {
         "heading": "Total Cholesterol Level (mmol/l)",
         "model_field": "total_cholesterol",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Observation Date: Total Cholesterol Level",
         "model_field": "total_cholesterol_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Thyroid function fields
     {
         "heading": "Observation Date: Thyroid Function",
         "model_field": "thyroid_function_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "At time of, or following measurement of thyroid function, was the patient prescribed any thyroid treatment?",
         "model_field": "thyroid_treatment_status",
         "model": "Visit",
-        "alternative_headings": [],
+        "alternative_headings": [
+            "At the time of, or following measurement of thyroid function, was the patient prescribed any thyroid treatment?"
+        ],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
+    # Coeliac screening fields
     {
         "heading": "Observation Date: Coeliac Disease Screening",
         "model_field": "coeliac_screen_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Has the patient been recommended a Gluten-free diet?",
         "model_field": "gluten_free_diet",
         "model": "Visit",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Does the patient smoke and/or vape",
-        "model_field": "smoking_vaping_status",
-        "model": "Visit",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Date of offer of smoking cessation advice (if patient is a current smoker)",
-        "model_field": "smoking_cessation_referral_date",
-        "model": "Visit",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Date that influenza immunisation was recommended",
-        "model_field": "flu_immunisation_recommended_date",
-        "model": "Visit",
-        "alternative_headings": [],
-    },
-    {
-        "heading": "Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
-        "model_field": "sick_day_rules_training_date",
-        "model": "Visit",
+        # sic from the old NPDA template (eugh non breaking spaces)
         "alternative_headings": [
-            "Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia††"
+            "Has the patient been\xa0recommended a Gluten-free\xa0diet?"
         ],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
+    },
+    # Psychological screening fields
+    # The official heading diverges between 2021 and 2026. Two separate entries (the same
+    # pattern used for 'sex') ensure csv_parse normalises uploaded CSVs to the year-correct
+    # canonical heading, and get_csv_heading_objects(year) returns the right one per year.
+    {
+        "heading": "Observation Date - Psychological Screening Assessment",
+        "model_field": "psychological_screening_assessment_date",
+        "model": "Visit",
+        # sic from the old NPDA template
+        "alternative_headings": [
+            "Observation Date -Psychological Assessment Screening",
+        ],
+        "data_type": "date",
+        "dataset_years": [2021],
     },
     {
+        # Duplicate model_field — intentional: 2026 heading diverges from 2021.
+        # get_csv_heading_objects deduplicates by model_field, so each year gets its own canonical.
         "heading": "Date of Annual Psychological Screening Assessment",
         "model_field": "psychological_screening_assessment_date",
         "model": "Visit",
-        "alternative_headings": ["Date of Annual Psychological Screening Assessment††"],
+        "alternative_headings": [
+            "Date of Annual Psychological Screening Assessment††",  # dagger variant in 2026 template
+        ],
+        "data_type": "date",
+        "dataset_years": [2026],
+    },
+    # The official heading diverges between 2021 and 2026. Two separate entries ensure
+    # get_csv_heading_objects returns the year-correct canonical heading. See psychological_screening_assessment_date above.
+    {
+        "heading": "Was the patient assessed as requiring additional psychological/CAMHS support outside of MDT clinics?",
+        "model_field": "psychological_additional_support_status",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021],
     },
     {
+        # Duplicate model_field — intentional: 2026 heading diverges from 2021.
+        # get_csv_heading_objects deduplicates by model_field, so each year gets its own canonical.
         "heading": "Following annual psychological screening, was the patient assessed as requiring additional psychological support outside of routine care?",
         "model_field": "psychological_additional_support_status",
         "model": "Visit",
         "alternative_headings": [
-            "Following annual psychological screening, was the patient assessed as requiring additional psychological support outside of routine care?†"
+            "Following annual psychological screening, was the patient assessed as requiring additional psychological support outside of routine care?†",  # dagger variant in 2026 template
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Was the patient offered an additional appointment with a mental health professional as part of the diabetes MDT?",
@@ -630,71 +480,182 @@ CSV_HEADING_OBJECTS_2026 = (
         "alternative_headings": [
             "Was the patient offered an additional appointment with a mental health professional as part of the diabetes MDT?†"
         ],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
+    # Smoking cessation fields
+    {
+        "heading": "Does the patient smoke?",
+        "model_field": "smoking_status",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021],
+    },
+    {
+        "heading": "Does the patient smoke and/or vape",
+        "model_field": "smoking_vaping_status",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2026],
+    },
+    # The official heading diverges between 2021 and 2026. Two separate entries ensure
+    # csv_parse normalises to the year-correct canonical heading. See psychological_screening_assessment_date above.
+    {
+        "heading": "Date of offer of referral to smoking cessation service (if patient is a current smoker)",
+        "model_field": "smoking_cessation_referral_date",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021],
+    },
+    {
+        # Duplicate model_field — intentional: 2026 heading diverges from 2021.
+        # get_csv_heading_objects deduplicates by model_field, so each year gets its own canonical.
+        "heading": "Date of offer of smoking cessation advice (if patient is a current smoker)",
+        "model_field": "smoking_cessation_referral_date",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2026],
+    },
+    # Level 3 carbohydrate counting education fields
     {
         "heading": "Date of Level 3 carbohydrate counting education received",
         "model_field": "carbohydrate_counting_level_three_education_date",
         "model": "Visit",
+        "alternative_headings": [
+            "Date Level 3 carbohydrate counting education received",
+            "Date of Level 3 carbohydrate counting education received",
+        ],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
+    },
+    # The official heading diverges between 2021 and 2026. Two separate entries ensure
+    # get_csv_heading_objects returns the year-correct canonical heading. See psychological_screening_assessment_date above.
+    {
+        "heading": "Was the patient offered an additional appointment with a paediatric dietitian?",
+        "model_field": "dietician_additional_appointment_offered",
+        "model": "Visit",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021],
     },
     {
+        # Duplicate model_field — intentional: 2026 heading diverges from 2021.
+        # get_csv_heading_objects deduplicates by model_field, so each year gets its own canonical.
         "heading": "Was the patient offered an additional appointment with a paediatric dietitian during the audit year?",
         "model_field": "dietician_additional_appointment_offered",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Date of additional appointment with dietitian",
         "model_field": "dietician_additional_appointment_date",
         "model": "Visit",
-        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
+    # Ketone meter training field
+    {
+        "heading": "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?",
+        "model_field": "ketone_meter_training",
+        "model": "Visit",
+        "alternative_headings": [
+            "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?††",
+            "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?��",
+        ],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
+    },
+    # Influenza immunisation recommendation field
+    {
+        "heading": "Date that influenza immunisation was recommended",
+        "model_field": "flu_immunisation_recommended_date",
+        "model": "Visit",
+        "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
+    },
+    # Sick-day rules training field
+    {
+        "heading": "Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
+        "model_field": "sick_day_rules_training_date",
+        "model": "Visit",
+        "alternative_headings": [
+            # Missing spacing before brackets to accomodate automatically generated Wythenshawe CSVs
+            "Date of provision of advice('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
+            "Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia††",
+        ],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
+    },
+    # Hospital admission fields
     {
         "heading": "Start date (Hospital Provider Spell)",
         "model_field": "hospital_admission_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Discharge date (Hospital provider spell)",
         "model_field": "hospital_discharge_date",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "date",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Reason for admission",
         "model_field": "hospital_admission_reason",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Only complete if OTHER selected: Reason for admission (free text)",
         "model_field": "hospital_admission_other",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "string",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Only complete if DKA selected in previous question: During this DKA admission did the patient receive any of the following therapies?",
         "model_field": "dka_additional_therapies",
         "model": "Visit",
-        "alternative_headings": [],
+        "alternative_headings": [
+            "During this DKA admission did the patient receive any of the following therapies?"
+        ],
+        "data_type": "int64",
+        "dataset_years": [2021, 2026],
     },
     {
         "heading": "Initial pH at admission",
         "model_field": "blood_gas_ph",
         "model": "Visit",
         "alternative_headings": ["Initial pH at admission†"],
+        "data_type": "float64",
+        "dataset_years": [2026],
     },
     {
         "heading": "Initial Standard bicarbonate at admission (mmol/l)",
         "model_field": "blood_gas_bicarbonate",
         "model": "Visit",
         "alternative_headings": [],
+        "data_type": "float64",
+        "dataset_years": [2026],
     },
-)
+]
 
 
-def get_csv_heading_objects(dataset_year):
+def get_csv_heading_objects(dataset_year=2021):
     """
     Returns the appropriate CSV heading objects for the given dataset year.
 
@@ -705,21 +666,10 @@ def get_csv_heading_objects(dataset_year):
         tuple: CSV heading objects appropriate for the dataset year
     """
     headings_dict = {}
-    if dataset_year and dataset_year >= 2026:
-        # Merge 2021 base with 2026 additions/changes
-        # Create a dict to handle overrides
-
-        # # Add all 2021 headings
-
-        # Override/add with 2026 versions
-        for item in CSV_HEADING_OBJECTS_2026:
+    for item in ALL_HEADINGS:
+        if dataset_year in item["dataset_years"]:
             headings_dict[item["model_field"]] = item
-
-        return tuple(headings_dict.values())
-    else:
-        for item in CSV_HEADING_OBJECTS_2021:
-            headings_dict[item["model_field"]] = item
-        return tuple(headings_dict.values())
+    return tuple(headings_dict.values())
 
 
 def csv_definition_for(model_field_or_column: str, dataset_year=None):
@@ -739,9 +689,12 @@ def csv_definition_for(model_field_or_column: str, dataset_year=None):
         case "unique_reference_number" | "Unique Reference Number":
             return UNIQUE_IDENTIFIER_JERSEY[0]
         case _:
-            csv_objects = get_csv_heading_objects_for_year_and_unique_identifier(
-                dataset_year, unique_identifier="england"
-            )
+            if dataset_year is not None:
+                csv_objects = get_csv_heading_objects_for_year_and_unique_identifier(
+                    dataset_year, unique_identifier="england"
+                )
+            else:
+                csv_objects = ALL_HEADINGS
             for item in csv_objects:
                 if item["model_field"] == model_field_or_column:
                     return item
@@ -785,6 +738,7 @@ ALL_DATES_2026 = [
     "Date of Diabetes Diagnosis",
     "Date of leaving service",
     "Death Date",
+    "Date immunotherapy started",
     "Visit/Appointment Date",
     "Observation Date (Height and weight)",
     "Observation Date: HbA1c Value",
@@ -818,10 +772,12 @@ def get_all_dates(dataset_year=None):
 
 
 # Visit date field mappings
+# These static lists are retained for backward compatibility (e.g. visit_filters.py).
+# For new code prefer get_all_visit_dates(dataset_year), which derives from ALL_HEADINGS.
 ALL_VISIT_DATES_2021 = [
     ("visit_date", "Visit/Appointment Date"),
     ("height_weight_observation_date", "Observation Date (Height and weight)"),
-    ("hba1c_date", "Observation Date: Hba1c Value"),
+    ("hba1c_date", "Observation Date: HbA1c Value"),  # canonical capitalisation
     ("blood_pressure_observation_date", "Observation Date (Blood Pressure)"),
     ("foot_examination_observation_date", "Foot Assessment / Examination Date"),
     ("retinal_screening_observation_date", "Retinal Screening date"),
@@ -901,10 +857,16 @@ ALL_VISIT_DATES = ALL_VISIT_DATES_2021
 
 
 def get_all_visit_dates(dataset_year=None):
-    """Returns all visit date field mappings for the given dataset year."""
-    if dataset_year and dataset_year >= 2026:
-        return ALL_VISIT_DATES_2026
-    return ALL_VISIT_DATES_2021
+    """
+    Returns all visit date field mappings for the given dataset year as (model_field, heading) tuples.
+    Derived from ALL_HEADINGS — single source of truth. Defaults to 2021 if dataset_year is not supplied.
+    """
+    year = dataset_year if dataset_year is not None else 2021
+    return [
+        (obj["model_field"], obj["heading"])
+        for obj in get_csv_heading_objects(year)
+        if obj.get("data_type") == "date" and obj.get("model") == "Visit"
+    ]
 
 
 # CSV data types
@@ -912,38 +874,6 @@ JERSEY_CSV_DATA_TYPES = {"Unique Reference Number": "string"}
 
 ENGLAND_CSV_DATA_TYPES = {
     "NHS Number": "string",
-}
-
-CSV_DATA_TYPES_MINUS_DATES = {
-    "Postcode of usual address": "string",
-    "Stated gender": "Int64",
-    "Ethnic Category": "string",  # choices are all capital letters
-    "Diabetes Type": "Int64",
-    "Reason for leaving service": "Int64",
-    "GP Practice Code": "string",
-    "PDU Number": "string",
-    "Patient Height (cm)": "float64",
-    "Patient Weight (kg)": "float64",
-    "Hba1c Value": "float64",
-    "HbA1c result format": "Int64",
-    "Diabetes Treatment at time of Hba1c measurement": "Int64",
-    "If treatment included insulin pump therapy (i.e. option 3 or 6 selected), was this part of a closed loop system?": "Int64",
-    "At the time of HbA1c measurement, in addition to standard blood glucose monitoring (SBGM), was the patient using any other method of glucose monitoring?": "Int64",
-    "Systolic Blood Pressure": "Int64",
-    "Diastolic Blood pressure": "Int64",
-    "Retinal Screening Result": "Int64",
-    "Urinary Albumin Level (ACR)": "float64",
-    "Albuminuria Stage": "Int64",
-    "Total Cholesterol Level (mmol/l)": "float64",
-    "At time of, or following measurement of thyroid function, was the patient prescribed any thyroid treatment?": "Int64",
-    "Has the patient been recommended a Gluten-free diet?": "Int64",
-    "Was the patient assessed as requiring additional psychological/CAMHS support outside of MDT clinics?": "Int64",
-    "Does the patient smoke?": "Int64",
-    "Was the patient offered an additional appointment with a paediatric dietitian?": "Int64",
-    "Was the patient using (or trained to use) blood ketone testing equipment at time of visit?": "Int64",
-    "Reason for admission": "Int64",
-    "Only complete if DKA selected in previous question: During this DKA admission did the patient receive any of the following therapies?": "Int64",
-    "Only complete if OTHER selected: Reason for admission (free text)": "string",
 }
 
 NONNULL_FIELDS = [
@@ -962,7 +892,7 @@ def get_csv_heading_objects_for_year_and_unique_identifier(
 
     Args:
         dataset_year: The dataset year (e.g., 2021, 2026). If None, returns 2021 format.
-        unique_identifier: "england" or "jersey" to specify which unique identifier to include.
+        unique_identifier: "england", "jersey", or "all" to specify which unique identifier to include.
 
     Returns:
         tuple: CSV heading objects appropriate for the dataset year and unique identifier
@@ -973,5 +903,11 @@ def get_csv_heading_objects_for_year_and_unique_identifier(
         return UNIQUE_IDENTIFIER_ENGLAND + csv_heading_objects
     elif unique_identifier == "jersey":
         return UNIQUE_IDENTIFIER_JERSEY + csv_heading_objects
+    elif unique_identifier == "all":
+        return (
+            UNIQUE_IDENTIFIER_ENGLAND + UNIQUE_IDENTIFIER_JERSEY + csv_heading_objects
+        )
     else:
-        raise ValueError("unique_identifier must be either 'england' or 'jersey'")
+        raise ValueError(
+            "unique_identifier must be either 'england', 'jersey', or 'all'"
+        )

--- a/project/npda/forms/patient_form.py
+++ b/project/npda/forms/patient_form.py
@@ -124,7 +124,9 @@ class PatientForm(forms.ModelForm):
         self.audit_period = kwargs.pop("audit_period", None)
         self.paediatric_diabetes_unit = kwargs.pop("paediatric_diabetes_unit", None)
         self.override_postcode = kwargs.pop("override_postcode", False)
-
+        self.dataset_year = (
+            self.audit_period.get_dataset_year() if self.audit_period else 2021
+        )
         super().__init__(*args, **kwargs)
         self._init_fields_by_dataset_year()
 

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1393,8 +1393,7 @@ def return_heading_model_field(field):
     """
     Return the heading for a given model field
     """
-
-    for heading in CSV_HEADING_OBJECTS:
-        if heading["model_field"] == field:
-            return heading["heading"]
+    definition = csv_definition_for(field)
+    if definition:
+        return definition["heading"]
     return None

--- a/project/npda/general_functions/csv/csv_download.py
+++ b/project/npda/general_functions/csv/csv_download.py
@@ -7,9 +7,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 
 from ....constants.csv_headings import (
-    CSV_HEADING_OBJECTS,
-    UNIQUE_IDENTIFIER_ENGLAND,
-    UNIQUE_IDENTIFIER_JERSEY,
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 from ....npda.models.visit import Visit
 from ..write_errors_to_xlsx import write_errors_to_xlsx
@@ -60,11 +58,14 @@ def export_as_csv(request, submission):
 
     pz_code = submission.paediatric_diabetes_unit.pz_code
     is_jersey = pz_code == "PZ248"
+    dataset_year = (
+        submission.audit_period.get_dataset_year() if submission.audit_period else 2021
+    )
 
-    if is_jersey:
-        HEADINGS_LIST = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
-    else:
-        HEADINGS_LIST = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+    unique_identifier = "jersey" if is_jersey else "england"
+    HEADINGS_LIST = get_csv_heading_objects_for_year_and_unique_identifier(
+        dataset_year=dataset_year, unique_identifier=unique_identifier
+    )
 
     header = [row["heading"] for row in HEADINGS_LIST]
     writer.writerow(header)

--- a/project/npda/general_functions/csv/csv_header.py
+++ b/project/npda/general_functions/csv/csv_header.py
@@ -2,24 +2,15 @@ import csv
 import io
 
 from project.constants import (
-    CSV_HEADING_OBJECTS,
-    CSV_HEADING_OBJECTS_2026,
-    UNIQUE_IDENTIFIER_ENGLAND,
-    UNIQUE_IDENTIFIER_JERSEY,
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 
 
 def csv_header(is_jersey=False, dataset_year=2021):
-    if dataset_year == 2026:
-        if is_jersey:
-            HEADINGS_LIST = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS_2026
-        else:
-            HEADINGS_LIST = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS_2026
-    else:
-        if is_jersey:
-            HEADINGS_LIST = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
-        else:
-            HEADINGS_LIST = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+    unique_identifier = "jersey" if is_jersey else "england"
+    HEADINGS_LIST = get_csv_heading_objects_for_year_and_unique_identifier(
+        dataset_year=dataset_year, unique_identifier=unique_identifier
+    )
     HEADINGS_LIST = [item["heading"] for item in HEADINGS_LIST]
 
     out = io.StringIO()

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from project.constants.csv_headings import CSV_HEADING_OBJECTS, CSV_HEADING_OBJECTS_2026
+from project.constants.csv_headings import get_csv_heading_objects
 from project.constants.ethnicities import ETHNICITIES
 from project.constants.sex_types import SEX_TYPE
 
@@ -124,9 +124,7 @@ def merge_patient_rows_for_column(
 def merge_rows_for_patient(
     identifier_heading, rows, patient_row_index, errors_to_return, dataset_year
 ):
-    for column in (
-        CSV_HEADING_OBJECTS if dataset_year < 2026 else CSV_HEADING_OBJECTS_2026
-    ):
+    for column in get_csv_heading_objects(dataset_year):
         merge_patient_rows_for_column(
             identifier_heading, column, rows, patient_row_index, errors_to_return
         )

--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -11,15 +11,9 @@ import pandas as pd
 
 # RCPCH imports
 from project.constants import (
-    CSV_DATA_TYPES_MINUS_DATES,
-    CSV_HEADING_OBJECTS,
-    CSV_HEADING_OBJECTS_2026,
-    ENGLAND_CSV_DATA_TYPES,
-    JERSEY_CSV_DATA_TYPES,
     UNIQUE_IDENTIFIER_ENGLAND,
     UNIQUE_IDENTIFIER_JERSEY,
-    csv_definition_for,
-    get_all_dates,
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 
 # Django imports
@@ -61,16 +55,11 @@ def csv_parse(csv_file, dataset_year=2021):
     # The exception is if the first row of the csv file does not match any of the predefined column names, in which case we will reject the csv
     errors_to_return = collections.defaultdict(lambda: collections.defaultdict(list))
 
-    if dataset_year >= 2026:
-        HEADINGS_OBJECTS = (
-            UNIQUE_IDENTIFIER_ENGLAND
-            + UNIQUE_IDENTIFIER_JERSEY
-            + CSV_HEADING_OBJECTS_2026
-        )
-    else:
-        HEADINGS_OBJECTS = (
-            UNIQUE_IDENTIFIER_ENGLAND + UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
-        )
+    HEADINGS_OBJECTS = get_csv_heading_objects_for_year_and_unique_identifier(
+        dataset_year, "all"
+    )  # unique_identifier "all" to include both England and Jersey identifiers, as the CSV may contain either and we will detect which one based on the headers present
+
+    # Extract the heading names into a list for easier comparison with the csv file headers.
     HEADINGS_LIST = [obj["heading"] for obj in HEADINGS_OBJECTS]
 
     # Convert the predefined column names to lowercase
@@ -190,40 +179,45 @@ def csv_parse(csv_file, dataset_year=2021):
         if result and result.group(1) not in duplicate_columns:
             duplicate_columns.append(result.group(1))
 
-    for column in get_all_dates(dataset_year=dataset_year):
-        if column in df.columns:
-            column_before = df[column].copy()
-            # Support DD/MM/YYYY and DD/MM/YY
-            column_after = pd.to_datetime(
-                df[column], format="mixed", dayfirst=True, errors="coerce"
-            )
+    for obj in HEADINGS_OBJECTS:
+        if obj.get("data_type") != "date":
+            continue
+        column = obj["heading"]
+        if column not in df.columns:
+            continue
+        column_before = df[column].copy()
+        # Support DD/MM/YYYY and DD/MM/YY
+        column_after = pd.to_datetime(
+            df[column], format="mixed", dayfirst=True, errors="coerce"
+        )
 
-            for row_index, (value_before, value_after) in enumerate(
-                zip(column_before, column_after, strict=False)
+        for row_index, (value_before, value_after) in enumerate(
+            zip(column_before, column_after, strict=False)
+        ):
+            # Handle empty strings (including spaces) for optional date columns
+            if (
+                not pd.isna(value_before)
+                and pd.isna(value_after)
+                and not (type(value_before) is str and value_before.strip() == "")
             ):
-                # Handle empty strings (including spaces) for optional date columns
-                if (
-                    not pd.isna(value_before)
-                    and pd.isna(value_after)
-                    and not (type(value_before) is str and value_before.strip() == "")
-                ):
-                    try:
-                        model_field = csv_definition_for(
-                            column, dataset_year=dataset_year
-                        )["model_field"]
-                    except Exception:
-                        logger.debug("Unknown date heading")
-                        continue
-                    errors_to_return[row_index][model_field].append(
-                        "Date format is incorrect (expected DD/MM/YYYY)",
-                    )
+                errors_to_return[row_index][obj["model_field"]].append(
+                    "Date format is incorrect (expected DD/MM/YYYY)",
+                )
 
-            df[column] = column_after
+        df[column] = column_after
 
-    if identifier_column == identifier_jersey:
-        datatypes = JERSEY_CSV_DATA_TYPES | CSV_DATA_TYPES_MINUS_DATES
-    else:
-        datatypes = ENGLAND_CSV_DATA_TYPES | CSV_DATA_TYPES_MINUS_DATES
+    # Build dtype map from HEADINGS_OBJECTS — automatically year-correct and
+    # identifier-aware. Normalise "int64" → "Int64" so pandas uses its nullable
+    # integer type (numpy int64 cannot represent NA, common in optional fields).
+    datatypes = {
+        obj["heading"]: (
+            "Int64"
+            if obj.get("data_type") == "int64"
+            else obj.get("data_type", "string")
+        )
+        for obj in HEADINGS_OBJECTS
+        if obj.get("data_type") != "date"
+    }
 
     nullable_int_types = {
         "Int8",
@@ -294,8 +288,16 @@ def csv_parse(csv_file, dataset_year=2021):
             else:
                 parse_type_error_columns.append(column)
 
-    template_columns = [identifier_column] + [
-        obj["heading"] for obj in CSV_HEADING_OBJECTS
+    # HEADINGS_OBJECTS includes both identifiers ("all"); exclude the unused one.
+    unused_identifier = (
+        identifier_jersey
+        if identifier_column == identifier_england
+        else identifier_england
+    )
+    template_columns = [
+        obj["heading"]
+        for obj in HEADINGS_OBJECTS
+        if obj["heading"] != unused_identifier
     ]
 
     return ParsedCSVFile(

--- a/project/npda/general_functions/csv/csv_upload.py
+++ b/project/npda/general_functions/csv/csv_upload.py
@@ -19,10 +19,9 @@ from django.utils import timezone
 
 # RCPCH imports
 from project.constants import (
-    CSV_HEADING_OBJECTS,
-    CSV_HEADING_OBJECTS_2026,
     UNIQUE_IDENTIFIER_ENGLAND,
     UNIQUE_IDENTIFIER_JERSEY,
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 from project.npda.general_functions.csv import gather_unique_patient_and_visit_counts
 
@@ -156,17 +155,15 @@ async def csv_upload(
         )
 
     if pdu.pz_code == "PZ248":
-        if dataset_year == 2026:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS_2026
-        else:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
+        unique_identifier = "jersey"
         identifier_heading = UNIQUE_IDENTIFIER_JERSEY[0]["heading"]
     else:
-        if dataset_year == 2026:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS_2026
-        else:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+        unique_identifier = "england"
         identifier_heading = UNIQUE_IDENTIFIER_ENGLAND[0]["heading"]
+
+    CSV_HEADINGS = get_csv_heading_objects_for_year_and_unique_identifier(
+        dataset_year=dataset_year, unique_identifier=unique_identifier
+    )
 
     # Helper functions
     def csv_value_to_model_value(model_field, value):

--- a/project/npda/general_functions/headings.py
+++ b/project/npda/general_functions/headings.py
@@ -151,23 +151,24 @@ FIELD_HEADINGS_2026 = {**PATIENT_FIELD_HEADINGS_2026, **VISIT_FIELD_HEADINGS_202
 
 def get_field_heading(field_name, dataset_year):
     """
-    Returns the official heading for a field based on dataset year.
-    Works for both Patient and Visit models.
+    Returns the canonical CSV heading for a model field based on dataset year.
+    Delegates to csv_definition_for — ALL_HEADINGS is the single source of truth.
+    Falls back to field_name if not found (matching previous dict.get() behaviour).
 
     Args:
-        field_name: Name of the field to get heading for
+        field_name: Name of the model field
         dataset_year: The dataset year (e.g., 2021, 2026)
 
     Returns:
-        str: The official heading for the field, or the field_name if not found
+        str: The canonical CSV heading for the field, or field_name if not found
 
     Example:
         >>> get_field_heading('sex', 2021)
         'Stated gender'
-        >>> get_field_heading('sex_assigned_at_birth', 2026)
+        >>> get_field_heading('sex', 2026)
         'Sex assigned at birth'
     """
-    if dataset_year and dataset_year >= 2026:
-        return FIELD_HEADINGS_2026.get(field_name, field_name)
-    else:
-        return FIELD_HEADINGS_2021.get(field_name, field_name)
+    from project.constants.csv_headings import csv_definition_for
+
+    defn = csv_definition_for(field_name, dataset_year)
+    return defn["heading"] if defn else field_name

--- a/project/npda/management/commands/create_csv.py
+++ b/project/npda/management/commands/create_csv.py
@@ -99,6 +99,7 @@ from django.utils import timezone
 from project.constants.csv_headings import (
     ENGLAND_CSV_DATA_TYPES,
     JERSEY_CSV_DATA_TYPES,
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.npda.general_functions.audit_period import get_audit_period_for_date
@@ -218,6 +219,12 @@ class Command(BaseCommand):
             type=int,
             help="Audit year for the data.",
             default="2024",
+        )
+        parser.add_argument(
+            "--dataset_year",
+            type=int,
+            help="Dataset year (e.g. 2021 or 2026). Defaults to audit_year if not supplied.",
+            default=None,
         )
 
         # Mutually exclusive group for --build and --coalesce
@@ -504,9 +511,15 @@ class Command(BaseCommand):
 
         # Concatenate the dataframes
         df = pd.concat(dfs, axis=0, join="outer").reset_index(drop=True)
+        # Detect dataset year from columns (2026 CSVs have "Sex assigned at birth";
+        # 2021 CSVs have "Stated gender"). Explicit --dataset_year overrides the sniff.
+        dataset_year = options.get("dataset_year") or (
+            2026 if "Sex assigned at birth" in df.columns else 2021
+        )
         df = self._set_valid_dtypes(
             df,
             is_jersey=is_jersey,
+            dataset_year=dataset_year,
         )
 
         df.info()
@@ -550,14 +563,26 @@ class Command(BaseCommand):
     ) -> pd.DataFrame:
         """Sets the correct data types for the dataframe, making them same as original
         dummy_sheet_invalid.csv file (to ensure we handle errors).
+        Derived from ALL_HEADINGS — single source of truth for headings and dtypes.
         """
-        all_dates = get_all_dates(dataset_year)
         unique_identifier = "jersey" if is_jersey else "england"
         heading_objects = get_csv_heading_objects_for_year_and_unique_identifier(
             dataset_year=dataset_year, unique_identifier=unique_identifier
         )
         TEMPLATE_HEADERS = [obj["heading"] for obj in heading_objects]
-        column_types = get_csv_data_types_minus_dates(dataset_year)
+        all_dates = [
+            obj["heading"] for obj in heading_objects if obj.get("data_type") == "date"
+        ]
+        # Build dtype map from non-date headings, normalising int64 -> Int64
+        column_types = {
+            obj["heading"]: (
+                "Int64"
+                if obj.get("data_type") == "int64"
+                else obj.get("data_type", "string")
+            )
+            for obj in heading_objects
+            if obj.get("data_type") != "date"
+        }
         if is_jersey:
             column_types = JERSEY_CSV_DATA_TYPES | column_types
         else:
@@ -700,6 +725,9 @@ class Command(BaseCommand):
         # flags
         build_flag = options["build"]
 
+        # dataset_year defaults to the audit start year unless explicitly overridden
+        dataset_year = options.get("dataset_year") or audit_start_date.year
+
         return {
             "n_pts_to_seed": n_pts_to_seed,
             "audit_start_date": audit_start_date,
@@ -716,7 +744,7 @@ class Command(BaseCommand):
             "postcode": postcode,
             "postcode_outcode": postcode_outcode,
             "build_flag": build_flag,
-            "dataset_year": audit_start_date.year,
+            "dataset_year": dataset_year,
         }
 
     def _get_file_name(

--- a/project/npda/management/commands/create_csv.py
+++ b/project/npda/management/commands/create_csv.py
@@ -97,13 +97,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from project.constants.csv_headings import (
-    ALL_DATES,
-    CSV_DATA_TYPES_MINUS_DATES,
-    CSV_HEADING_OBJECTS,
     ENGLAND_CSV_DATA_TYPES,
     JERSEY_CSV_DATA_TYPES,
-    UNIQUE_IDENTIFIER_ENGLAND,
-    UNIQUE_IDENTIFIER_JERSEY,
 )
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.npda.general_functions.audit_period import get_audit_period_for_date
@@ -218,6 +213,12 @@ class Command(BaseCommand):
             choices=["0_4", "5_10", "11_15", "16_19", "20_25"],
             help="Age range for patients to be seeded.",
         )
+        parser.add_argument(
+            "--audit_year",
+            type=int,
+            help="Audit year for the data.",
+            default="2024",
+        )
 
         # Mutually exclusive group for --build and --coalesce
         mutex_group = parser.add_mutually_exclusive_group(required=True)
@@ -277,6 +278,7 @@ class Command(BaseCommand):
         pdu = parsed_values["pz_code"]
         output_path = parsed_values["output_path"]
         build_flag = parsed_values["build_flag"]
+        dataset_year = parsed_values["dataset_year"]
 
         # PRINT INFORMATION
         # Header
@@ -288,7 +290,9 @@ class Command(BaseCommand):
             ["Submission Date", submission_date],
             ["Audit Start Date", audit_start_date],
             ["Audit End Date", audit_end_date],
+            ["Audit Year", dataset_year],
         ]
+
         for item in build_info:
             self.print_info(f"{CYAN}{item[0]:<30}{RESET} {item[1]}")
 
@@ -313,6 +317,7 @@ class Command(BaseCommand):
                 postcode or postcode_outcode,
             ],
             ["PZ Code", pdu],
+            ["Audit Year", dataset_year],
         ]
 
         self.print_info("-" * 45)
@@ -343,6 +348,7 @@ class Command(BaseCommand):
             build_flag,
             postcode,
             postcode_outcode,
+            dataset_year,
         )
         self.print_success(f"✨ CSV generated successfully at {self.csv_name}.\n")
         if build_flag:
@@ -363,6 +369,7 @@ class Command(BaseCommand):
         build_flag,
         postcode,
         postcode_outcode,
+        dataset_year=2021,
     ):
 
         # Start csv logic
@@ -401,7 +408,9 @@ class Command(BaseCommand):
         else:
             is_jersey = False
 
-        csv_map = self._get_map_model_csv_heading_field(is_jersey=is_jersey)
+        csv_map = self._get_map_model_csv_heading_field(
+            is_jersey=is_jersey, dataset_year=dataset_year
+        )
 
         # Initialise data list, where each item is a dict relating to a row in the csv
         # Each dict will have keys as csv headings and values as the data
@@ -444,7 +453,9 @@ class Command(BaseCommand):
 
         is_jersey = True if pdu == "PZ248" else False
 
-        df = self._set_valid_dtypes(pd.DataFrame(data), is_jersey)
+        df = self._set_valid_dtypes(
+            pd.DataFrame(data), is_jersey=is_jersey, dataset_year=dataset_year
+        )
 
         self.csv_name = self._get_file_name(
             n_pts_to_seed=n_pts_to_seed,
@@ -534,31 +545,26 @@ class Command(BaseCommand):
 
         return
 
-    def _set_valid_dtypes(self, df: pd.DataFrame, is_jersey=False) -> pd.DataFrame:
+    def _set_valid_dtypes(
+        self, df: pd.DataFrame, is_jersey=False, dataset_year=2021
+    ) -> pd.DataFrame:
         """Sets the correct data types for the dataframe, making them same as original
         dummy_sheet_invalid.csv file (to ensure we handle errors).
         """
+        all_dates = get_all_dates(dataset_year)
+        unique_identifier = "jersey" if is_jersey else "england"
+        heading_objects = get_csv_heading_objects_for_year_and_unique_identifier(
+            dataset_year=dataset_year, unique_identifier=unique_identifier
+        )
+        TEMPLATE_HEADERS = [obj["heading"] for obj in heading_objects]
+        column_types = get_csv_data_types_minus_dates(dataset_year)
         if is_jersey:
-            CSV_DATA_TYPES_MINUS_DATES.update(JERSEY_CSV_DATA_TYPES)
-            TEMPLATE_HEADERS = pd.read_csv(
-                "project/npda/dummy_sheets/npda_csv_submission_template_for_use_from_april_2025.csv"
-            ).columns
+            column_types = JERSEY_CSV_DATA_TYPES | column_types
         else:
-            CSV_DATA_TYPES_MINUS_DATES.update(ENGLAND_CSV_DATA_TYPES)
-            TEMPLATE_HEADERS = pd.read_csv(
-                "project/npda/dummy_sheets/npda_csv_submission_template_for_use_from_april_2021.csv"
-            ).columns
-
-        for header in df.columns:
-            if header in ALL_DATES:
-                continue
-            print(
-                f"Column: {header}, dtype: {df[header].dtype}, unique values: {df[header].unique()}"
-            )
-            print(f"Original dtype: {CSV_DATA_TYPES_MINUS_DATES[header]}")
+            column_types = ENGLAND_CSV_DATA_TYPES | column_types
 
         # Set dtypes for non-date columns
-        df = self.clean_and_cast(df, CSV_DATA_TYPES_MINUS_DATES)
+        df = self.clean_and_cast(df, column_types)
 
         df = (
             df.assign(
@@ -567,7 +573,7 @@ class Command(BaseCommand):
                     date_header: lambda x, date_header=date_header: pd.to_datetime(
                         x[date_header], format="%d/%m/%Y", errors="coerce"
                     )
-                    for date_header in ALL_DATES
+                    for date_header in all_dates
                 },
             )
             # # Reorder columns
@@ -576,7 +582,7 @@ class Command(BaseCommand):
         df = df[TEMPLATE_HEADERS]
 
         # Ensure the formatting is right for validation
-        for date_header in ALL_DATES:
+        for date_header in all_dates:
             df[date_header] = df[date_header].dt.strftime("%d/%m/%Y")
 
         return df
@@ -584,6 +590,8 @@ class Command(BaseCommand):
     def clean_and_cast(self, df, column_types):
         try:
             for column, dtype in column_types.items():
+                if column not in df.columns:
+                    continue
                 if dtype.startswith("Int"):  # Handle nullable integers
                     df[column] = (
                         df[column]
@@ -603,15 +611,13 @@ class Command(BaseCommand):
                     df[column] = df[column].replace({None: np.nan}).astype(dtype)
                 else:
                     raise ValueError(
-                        f"Unsupported dtype from CSV_DATA_TYPES_MINUS_DATES: {dtype}\n (for {column=} {df[column].dtype=})"
+                        f"Unsupported dtype: {dtype}\n (for {column=} {df[column].dtype=})"
                     )
         # Catch and throw error again to log the column and dtype
         # Cant continue
         except Exception as e:
             logger.error(f"ERROR in clean_and_cast: {e}")
-            logger.error(
-                f"CSV_DATA_TYPES_MINUS_DATES {column=} {dtype=}\n{df[column].dtype=}"
-            )
+            logger.error(f"column_types {column=} {dtype=}\n{df[column].dtype=}")
             raise e
 
         return df
@@ -710,6 +716,7 @@ class Command(BaseCommand):
             "postcode": postcode,
             "postcode_outcode": postcode_outcode,
             "build_flag": build_flag,
+            "dataset_year": audit_start_date.year,
         }
 
     def _get_file_name(
@@ -753,7 +760,7 @@ class Command(BaseCommand):
 
         return "".join(rendered_vt_names)
 
-    def _get_map_model_csv_heading_field(self, is_jersey) -> dict:
+    def _get_map_model_csv_heading_field(self, is_jersey, dataset_year=2021) -> dict:
         """Generates dict that looks like:
 
         {
@@ -775,10 +782,10 @@ class Command(BaseCommand):
 
         map_model_csv_heading_field = defaultdict(dict)
 
-        if is_jersey:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_JERSEY + CSV_HEADING_OBJECTS
-        else:
-            CSV_HEADINGS = UNIQUE_IDENTIFIER_ENGLAND + CSV_HEADING_OBJECTS
+        unique_identifier = "jersey" if is_jersey else "england"
+        CSV_HEADINGS = get_csv_heading_objects_for_year_and_unique_identifier(
+            dataset_year=dataset_year, unique_identifier=unique_identifier
+        )
 
         for item in CSV_HEADINGS:
             # pdu no longer has model defined

--- a/project/npda/templatetags/npda_tags.py
+++ b/project/npda/templatetags/npda_tags.py
@@ -9,10 +9,8 @@ from django.contrib.gis.measure import D
 from django.urls import reverse
 from django.utils.html import conditional_escape, mark_safe
 
-from ...constants import (  # VisitCategories,
-    CSV_HEADING_OBJECTS,
-    UNIQUE_IDENTIFIER_ENGLAND,
-    UNIQUE_IDENTIFIER_JERSEY,
+from ...constants import (
+    get_csv_heading_objects_for_year_and_unique_identifier,
 )
 
 register = template.Library()
@@ -40,18 +38,14 @@ class_re = re.compile(r'(?<=class=["\'])(.*)(?=["\'])')
 
 
 @register.simple_tag
-def heading_for_field(pz_code, field):
+def heading_for_field(pz_code, field, dataset_year=2021):
     """
     Returns the heading for a given field
     """
-    if pz_code == "PZ248":
-        # Jersey
-        CSV_HEADINGS = CSV_HEADING_OBJECTS + UNIQUE_IDENTIFIER_JERSEY
-    else:
-        # England
-        CSV_HEADINGS = CSV_HEADING_OBJECTS + UNIQUE_IDENTIFIER_ENGLAND
-
-    CSV_HEADINGS = [item["heading"] for item in CSV_HEADINGS]
+    unique_identifier = "jersey" if pz_code == "PZ248" else "england"
+    CSV_HEADINGS = get_csv_heading_objects_for_year_and_unique_identifier(
+        dataset_year=dataset_year, unique_identifier=unique_identifier
+    )
     for item in CSV_HEADINGS:
         if field == item["model_field"]:
             return item["heading"]

--- a/project/npda/tests/view_tests/test_upload.py
+++ b/project/npda/tests/view_tests/test_upload.py
@@ -86,9 +86,12 @@ def test_generate_csv_upload_to_view(
         csv_file = SimpleUploadedFile(f.name, f.read(), content_type="text/csv")
 
     # Send POST request with CSV file
+    # The audit period slug must match the dataset year inferred from today's date.
+    # create_csv defaults submission_date to today; get_audit_period_for_date(today)
+    # returns the current audit period (2026-2027 from April 2026 onwards).
     url = reverse(
         "pdu-upload-csv",
-        kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"},
+        kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2026-2027"},
     )
     response = client.post(url, {"csv_upload": csv_file})
 


### PR DESCRIPTION
**Fields where 2021 and 2026 official headings differ** are split into two separate entries (the same pattern already used for sex), so `get_csv_heading_objects(year)` always returns the year-correct canonical heading without any special-casing at the call site:

`psychological_screening_assessment_date`
`psychological_additional_support_status`
`smoking_cessation_referral_date`
`dietician_additional_appointment_offered`
| Function | Before | After |
| -- | -- | -- |
| `csv_definition_for(field, dataset_year=None)` | Returned `None` when `dataset_year` was omitted (broken for callers like `test_bad_data_for_integer_fields`) | Falls back to searching `ALL_HEADINGS`  directly when no year given |
| `get_all_visit_dates(dataset_year)` | Returned static `ALL_VISIT_DATES_2021/2026` lists | Derived from `ALL_HEADINGS (filter model == "Visit", data_type == "date")` |

Other fixes in `ALL_HEADINGS`:

- Added "Effective Death Date" to `death_date` alternative headings (used in old NPDA CSV template)
- Fixed `ALL_VISIT_DATES_2021` hba1c heading capitalisation (Hba1c → HbA1c, canonical form)
`headings.py`
- `get_field_heading(field_name, dataset_year)` now delegates to `csv_definition_for()` rather than doing a static dict lookup against `FIELD_HEADINGS_2021/2026`. There is now one source of truth for what heading a field has in any given year: `ALL_HEADINGS`.

The `FIELD_HEADINGS_*` and `PATIENT_FIELD_HEADINGS_*` / `VISIT_FIELD_HEADINGS_*` dicts are retained because `visit_form.py` and `patient_form.py` use their `.keys()` to define which form fields are shown per year — that is a different concern from CSV headings.

`csv_parse.py`
Fully refactored to derive everything from `HEADINGS_OBJECTS:`

Date parsing loop iterates objects where `data_type == "date"` instead of a separate `ALL_DATES` list
Dtype map is built by comprehension over non-date heading objects, normalising int64 → Int64
Downstream import fixes
Five files were importing constants that were deleted (`CSV_HEADING_OBJECTS`, `CSV_HEADING_OBJECTS_2026`):

`csv_upload.py`, `csv_download.py`, `csv_header.py`, `csv_merge.py` — updated to use `get_csv_heading_objects_for_year_and_unique_identifier`
`npda_tags.py`, `visit_form.py` — updated similarly

`create_csv.py`
Added `--dataset_year` CLI argument (optional; defaults to sniffing the dataset year from the generated column names)
`_set_valid_dtypes`: derives date list and dtype map from `ALL_HEADINGS` via `get_csv_heading_objects_for_year_and_unique_identifier`, removing the dependency on the deleted `get_csv_data_types_minus_dates` and `get_all_dates`
`_run_coalesce`: detects dataset year by sniffing columns ("Sex assigned at birth" → 2026, else 2021) rather than using --audit_year (whose default of 2024 is not a valid dataset_years value and silently returned an empty heading set, collapsing the dataframe to 1 column)
patient_form.py
Restored a line lost in the live → dataset merge:

Without this, `_init_fields_by_dataset_year` always used the class-level default of 2021, so the form rendered 2021 fields regardless of audit period.

`test_upload`.py
Updated the upload URL from "2025-2026" to "2026-2027" to match the CSV format generated when submission_date defaults to today (which is now in the 2026-2027 audit period).

367 passed, 0 failed, 11 skipped   (test_csv_upload.py — was 105 failed before this branch)
443 passed, 0 failed, 11 skipped   (test_csv_upload.py + view_tests combined)
 40 passed                          (test_patient_form.py)
lint: ✅ all checks passed

Checklist
 All existing tests pass
 Lint clean
 No parallel dtype/heading structures remain for new fields added in future
`ALL_HEADINGS` entries with diverging 2021/2026 headings have comments explaining the deliberate duplication
