### PR TITLE
Default audit period

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -15,6 +15,7 @@ from project.constants import (
     UNIQUE_IDENTIFIER_JERSEY,
     get_csv_heading_objects_for_year_and_unique_identifier,
 )
+from project.npda.general_functions.headings import get_field_heading
 
 # Django imports
 
@@ -135,6 +136,27 @@ def csv_parse(csv_file, dataset_year=2021):
         else:
             user_error_message = "No unique identifier column is present. Please ensure one of Unique Reference Number or NHS Number is present in the file."
         raise ValueError(user_error_message)
+
+    # Ensure a 2026 dataset is not uploaded with the old template and vice versa - we are using the smoking status field as a canary for this
+    # as smoking status changed to include vaping in the 2026 template and so the heading is different between the two templates.
+    _2026_smoking_heading = get_field_heading("smoking_vaping_status", 2026)
+    _2021_smoking_heading = get_field_heading("smoking_status", 2021)
+    if (
+        _2026_smoking_heading in df.columns
+        and _2021_smoking_heading not in df.columns
+        and dataset_year == 2021
+    ):
+        raise ValueError(
+            "This file appears to be using the 2026 template but you have selected 2021 as the dataset year. Please check your file and upload again."
+        )
+    if (
+        _2026_smoking_heading not in df.columns
+        and _2021_smoking_heading in df.columns
+        and dataset_year == 2026
+    ):
+        raise ValueError(
+            "This file appears to be using the 2021 template but you have selected 2026 as the dataset year. Please check your file and upload again."
+        )
 
     # Set the identifier column
     if identifier_jersey in df.columns:

--- a/project/npda/models/audit_period.py
+++ b/project/npda/models/audit_period.py
@@ -33,7 +33,11 @@ class AuditPeriodManager(models.Manager):
 
             raise e
 
-        if not audit_period.is_visible and not can_view_all_data:
+        if (
+            not audit_period.is_visible
+            and not audit_period.is_open
+            and not can_view_all_data
+        ):
             raise PermissionDenied(f"Audit period {slug} is not visible")
 
         return audit_period

--- a/project/npda/templates/dashboard.html
+++ b/project/npda/templates/dashboard.html
@@ -2,5 +2,31 @@
 {% load static %}
 {% load npda_tags %}
 {% block content %}
+  {% if viewing_stale_period %}
+    <div role="alert" class="alert border-t-4 border-rcpch_light_blue shadow-lg mx-4 mt-4">
+      <i class="fa-solid fa-calendar-plus fa-2xl text-rcpch_light_blue"></i>
+      <div>
+        <h3 class="font-bold font-montserrat">
+          You are viewing {{ audit_period.display_name }}
+          {% if not previous_period_still_accepts %}(closed){% endif %}
+        </h3>
+        <p class="text-sm">
+          {% if previous_period_still_accepts %}
+            The <strong>{{ current_audit_period.display_name }}</strong> audit year has now started.
+            {% if perms.npda.can_submit_csv %}
+              <a href="{{ upload_url_for_current_period }}"
+                 class="font-semibold underline hover:text-rcpch_dark_blue">
+                Click here to submit data for {{ current_audit_period.display_name }}.
+              </a>
+            {% else %}
+              You do not have permission to submit data.
+            {% endif %}
+          {% else %}
+            This audit period is now closed and submissions are no longer accepted.
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  {% endif %}
   {% include 'dashboard/dashboard_base.html' %}
 {% endblock content %}

--- a/project/npda/templates/dashboard/components/cards/audit_details_card.html
+++ b/project/npda/templates/dashboard/components/cards/audit_details_card.html
@@ -30,5 +30,36 @@ Audit Details
     <p class="text-4xl">{{ days_remaining_until_audit_end_date }}</p>
   </div>
 {% endif %}
+{% if viewing_stale_period %}
+  {% include 'dashboard/hr_with_text.html' with hr_rule_text='Note' %}
+  <div class="flex flex-col justify-center items-center pb-4 text-center text-sm gap-2">
+    {% if previous_period_still_accepts %}
+      <p class="font-semibold text-rcpch_dark_blue">
+        <i class="fa-solid fa-circle-info"></i>
+        This audit period still accepts submissions, but the
+        <strong>{{ current_audit_period.display_name }}</strong> audit year has now started.
+      </p>
+      {% if perms.npda.can_submit_csv %}
+        <a href="{{ upload_url_for_current_period }}"
+           class="btn btn-sm rounded-none bg-rcpch_light_blue border-rcpch_light_blue text-white hover:bg-rcpch_dark_blue">
+          <i class="fa-solid fa-file-arrow-up"></i>
+          Submit data for {{ current_audit_period.display_name }}
+        </a>
+      {% else %}
+        <button disabled
+                class="btn btn-sm rounded-none bg-gray-300 border-gray-300 text-gray-500 cursor-not-allowed"
+                title="You do not have permission to submit CSV data">
+          <i class="fa-solid fa-file-arrow-up"></i>
+          Submit data for {{ current_audit_period.display_name }}
+        </button>
+      {% endif %}
+    {% else %}
+      <p class="font-semibold text-gray-500">
+        <i class="fa-solid fa-lock"></i>
+        This audit period is now closed and submissions are no longer accepted.
+      </p>
+    {% endif %}
+  </div>
+{% endif %}
 
 {% endblock %}

--- a/project/npda/templates/dashboard/dashboard_base.html
+++ b/project/npda/templates/dashboard/dashboard_base.html
@@ -18,7 +18,7 @@
     </div>
     <div class="col-span-12 xl:col-span-3">
       <!-- Audit Details Card -->
-      {% include 'dashboard/components/cards/audit_details_card.html' with audit_period=audit_period current_quarter=current_quarter current_date=current_date days_remaining_until_audit_end_date=days_remaining_until_audit_end_date %}
+      {% include 'dashboard/components/cards/audit_details_card.html' with audit_period=audit_period current_quarter=current_quarter current_date=current_date days_remaining_until_audit_end_date=days_remaining_until_audit_end_date viewing_stale_period=viewing_stale_period previous_period_still_accepts=previous_period_still_accepts current_audit_period=current_audit_period upload_url_for_current_period=upload_url_for_current_period %}
     </div>
     <div class="col-span-12 xl:col-span-6">
       <!-- Patient Measurements Card -->

--- a/project/npda/templates/new-home.html
+++ b/project/npda/templates/new-home.html
@@ -9,20 +9,28 @@
       <div>
         <h3 class="font-bold font-montserrat">A new audit year has started — {{ current_audit_period.display_name }}</h3>
         <p class="text-sm">
-          Select the <strong>{{ current_audit_period.display_name }}</strong> audit year from the dropdown below to begin a new submission.
+          {% if perms.npda.can_submit_csv %}
+            Select the <strong>{{ current_audit_period.display_name }}</strong> audit year from the dropdown below to begin a new submission.
+          {% else %}
+            Select the <strong>{{ current_audit_period.display_name }}</strong> audit year from the dropdown below. Contact your coordinator to begin a new submission.
+          {% endif %}
         </p>
       </div>
     </div>
   {% endif %}
 
-  {% if not has_any_submission_in_period %}
+  {% if viewing_current_period and not has_any_submission_in_period %}
     <div role="alert" class="alert alert-warning shadow-lg mx-4 mt-4">
       <i class="fa-solid fa-circle-info fa-2xl"></i>
       <div>
         <h3 class="font-bold font-montserrat">No submissions yet for {{ selected_audit_period_display_name }}</h3>
         <p class="text-sm">
           There are no submissions yet in this audit year for any of your PDUs.
-          Select your PDU below and follow the directions to begin a new submission.
+          {% if perms.npda.can_submit_csv %}
+            Select your PDU below and follow the directions to begin a new submission.
+          {% else %}
+            Contact your coordinator to begin a new submission.
+          {% endif %}
         </p>
       </div>
     </div>
@@ -36,17 +44,25 @@
       class="font-montserrat text-white bg-rcpch_light_blue hover:bg-rcpch_dark_blue border-0 rounded-none px-4 py-2 cursor-pointer text-base"
       onchange="window.location.href = this.value;">
       {% for audit_period in audit_periods %}
-        <option value="{% url 'new-home' audit_period=audit_period.slug %}"
-          {% if audit_period.selected %}selected{% endif %}>
-          {{ audit_period.display_name }}
-        </option>
+        {% if current_audit_period and audit_period.slug == current_audit_period.slug and not has_submissions_for_current_period and not perms.npda.can_submit_csv %}
+          <option disabled
+                  title="You do not have permission to submit data and there are no submissions yet for this period"
+                  {% if audit_period.selected %}selected{% endif %}>
+            {{ audit_period.display_name }} (no data yet)
+          </option>
+        {% else %}
+          <option value="{% url 'new-home' audit_period=audit_period.slug %}"
+            {% if audit_period.selected %}selected{% endif %}>
+            {{ audit_period.display_name }}
+          </option>
+        {% endif %}
       {% endfor %}
     </select>
   </div>
 
   <div class="flex flex-row flex-wrap justify-center gap-4 p-4">
     {% for pdu in active_pdus %}
-      {% include "partials/pdu-card.html" with pdu=pdu %}
+      {% include "partials/pdu-card.html" with pdu=pdu pdus_with_submission_in_period=pdus_with_submission_in_period %}
     {% endfor %}
   </div>
 
@@ -54,7 +70,7 @@
     <h2 class="text-center text-xl font-montserrat text-rcpch_dark_blue mt-4">Inactive</h2>
     <div class="flex flex-row flex-wrap justify-center gap-4 p-4">
       {% for pdu in inactive_pdus %}
-        {% include "partials/pdu-card.html" with pdu=pdu %}
+        {% include "partials/pdu-card.html" with pdu=pdu pdus_with_submission_in_period=pdus_with_submission_in_period %}
       {% endfor %}
     </div>
   {% endif %}

--- a/project/npda/templates/new-home.html
+++ b/project/npda/templates/new-home.html
@@ -2,24 +2,61 @@
 {% load static %}
 {% load npda_tags %}
 {% block content %}
-  <div class="text-center my-4">
-    <h1 class="text-xl">
-      {{selected_audit_period_display_name}}
-      <br />
+
+  {% if show_new_year_banner %}
+    <div role="alert" class="alert border-t-4 border-rcpch_light_blue shadow-lg mx-4 mt-4">
+      <i class="fa-solid fa-calendar-plus fa-2xl text-rcpch_light_blue"></i>
+      <div>
+        <h3 class="font-bold font-montserrat">A new audit year has started — {{ current_audit_period.display_name }}</h3>
+        <p class="text-sm">
+          Select the <strong>{{ current_audit_period.display_name }}</strong> audit year from the dropdown below to begin a new submission.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if not has_any_submission_in_period %}
+    <div role="alert" class="alert alert-warning shadow-lg mx-4 mt-4">
+      <i class="fa-solid fa-circle-info fa-2xl"></i>
+      <div>
+        <h3 class="font-bold font-montserrat">No submissions yet for {{ selected_audit_period_display_name }}</h3>
+        <p class="text-sm">
+          There are no submissions yet in this audit year for any of your PDUs.
+          Select your PDU below and follow the directions to begin a new submission.
+        </p>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="flex flex-col items-center my-6 gap-2">
+    <h1 class="text-xl font-montserrat font-semibold text-rcpch_dark_blue">
       Select your paediatric diabetes unit
     </h1>
+    <select
+      class="font-montserrat text-white bg-rcpch_light_blue hover:bg-rcpch_dark_blue border-0 rounded-none px-4 py-2 cursor-pointer text-base"
+      onchange="window.location.href = this.value;">
+      {% for audit_period in audit_periods %}
+        <option value="{% url 'new-home' audit_period=audit_period.slug %}"
+          {% if audit_period.selected %}selected{% endif %}>
+          {{ audit_period.display_name }}
+        </option>
+      {% endfor %}
+    </select>
   </div>
+
   <div class="flex flex-row flex-wrap justify-center gap-4 p-4">
     {% for pdu in active_pdus %}
       {% include "partials/pdu-card.html" with pdu=pdu %}
     {% endfor %}
   </div>
+
   {% if inactive_pdus %}
-    <h2 class="text-center text-xl">Inactive</h2>
+    <h2 class="text-center text-xl font-montserrat text-rcpch_dark_blue mt-4">Inactive</h2>
     <div class="flex flex-row flex-wrap justify-center gap-4 p-4">
       {% for pdu in inactive_pdus %}
         {% include "partials/pdu-card.html" with pdu=pdu %}
       {% endfor %}
     </div>
   {% endif %}
+
 {% endblock %}

--- a/project/npda/templates/partials/pdu-card.html
+++ b/project/npda/templates/partials/pdu-card.html
@@ -3,11 +3,15 @@
         <h2 class="card-title">{{pdu.pz_code}}</h2>
         <p>{{pdu.lead_organisation_name}} - {{pdu.parent_name}}</p>
         <div class="card-actions justify-end">
+            {% with pdu_has_submission=pdus_with_submission_in_period|default_if_none:"" %}
+            {% if perms.npda.can_submit_csv or pdu.pz_code in pdu_has_submission %}
             <div>
                 <a class="btn bg-rcpch_pink text-white" href="{% url 'pdu-patients' audit_period=audit_period_slug pz_code=pdu.pz_code %}">
                 Patient data
                 </a>
             </div>
+            {% endif %}
+            {% endwith %}
             <div>
                 <a class="btn btn-info" href="{% url 'pdu-dashboard' audit_period=audit_period_slug pz_code=pdu.pz_code %}">
                 Unit Report

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1428,6 +1428,18 @@ def test_old_template_headers(
 
 
 @pytest.mark.django_db
+def test_csv_year_mismatch_raises_error(
+    test_user, dummy_sheet_csv, audit_period_for_dataset_year, dataset_year
+):
+    # dummy_sheet_csv returns the CSV matching dataset_year.
+    # Parsing it with the *opposite* year must raise a ValueError because
+    # csv_parse detects the header/year mismatch.
+    opposite_year = 2021 if dataset_year == 2026 else 2026
+    with pytest.raises(ValueError, match="Please check your file and upload again"):
+        read_csv_from_str(dummy_sheet_csv, dataset_year=opposite_year)
+
+
+@pytest.mark.django_db
 def test_first_row_with_extra_cell_at_the_start(test_user, single_row_valid_df):
     csv = single_row_valid_df.to_csv(index=False, date_format="%d/%m/%Y")
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1215,7 +1215,12 @@ def test_different_column_order(test_user, single_row_valid_df):
 
 @pytest.mark.django_db
 def test_additional_columns_causes_error(
-    single_row_valid_df, tmp_path, client, test_rcpch_user, dataset_year
+    single_row_valid_df,
+    tmp_path,
+    client,
+    test_rcpch_user,
+    dataset_year,
+    audit_period_for_dataset_year,
 ):
     # Add additional columns
     single_row_valid_df["extra_one"] = "ada"
@@ -1232,7 +1237,10 @@ def test_additional_columns_causes_error(
 
     url = reverse(
         "pdu-upload-csv",
-        kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"},
+        kwargs={
+            "pz_code": ALDER_HEY_PZ_CODE,
+            "audit_period": audit_period_for_dataset_year.slug,
+        },
     )
 
     # Feed file to view
@@ -1248,7 +1256,11 @@ def test_additional_columns_causes_error(
 
 @pytest.mark.django_db
 def test_duplicate_columns_causes_error(
-    single_row_valid_df, client, test_rcpch_user, tmp_path
+    single_row_valid_df,
+    client,
+    test_rcpch_user,
+    tmp_path,
+    audit_period_for_dataset_year,
 ):
     single_row_valid_df["NHS Number_2"] = single_row_valid_df["NHS Number"]
     single_row_valid_df["NHS Number_3"] = single_row_valid_df["NHS Number"]
@@ -1273,7 +1285,10 @@ def test_duplicate_columns_causes_error(
 
         url = reverse(
             "pdu-upload-csv",
-            kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"},
+            kwargs={
+                "pz_code": ALDER_HEY_PZ_CODE,
+                "audit_period": audit_period_for_dataset_year.slug,
+            },
         )
 
         response = client.post(url, {"csv_upload": csv_file}, format="multipart")
@@ -1288,7 +1303,11 @@ def test_duplicate_columns_causes_error(
 
 @pytest.mark.django_db
 def test_missing_columns_causes_error(
-    test_rcpch_user, single_row_valid_df, client, tmp_path
+    test_rcpch_user,
+    single_row_valid_df,
+    client,
+    tmp_path,
+    audit_period_for_dataset_year,
 ):
     df = single_row_valid_df.drop(
         columns=["Urinary Albumin Level (ACR)", "Total Cholesterol Level (mmol/l)"]
@@ -1304,7 +1323,10 @@ def test_missing_columns_causes_error(
 
     url = reverse(
         "pdu-upload-csv",
-        kwargs={"pz_code": ALDER_HEY_PZ_CODE, "audit_period": "2025-2026"},
+        kwargs={
+            "pz_code": ALDER_HEY_PZ_CODE,
+            "audit_period": audit_period_for_dataset_year.slug,
+        },
     )
 
     # Feed file into view
@@ -1727,13 +1749,17 @@ def test_bad_date_format_on_date_of_diagnosis(test_user, single_row_valid_df):
 
 
 @pytest.mark.django_db
-def test_bad_date_format_on_optional_column(one_patient_two_visits, dataset_year):
-    df = one_patient_two_visits
+def test_bad_date_format_on_optional_column(dummy_sheet_csv, dataset_year):
+    # Use the year-correct CSV to avoid the 2021/2026 header mismatch check.
+    # Both dummy CSVs have at least 2 rows with the same NHS number first.
+    lines = dummy_sheet_csv.splitlines()
+    csv_two_rows = "\n".join([lines[0]] + lines[1:3])
 
     column = get_field_heading(
         "carbohydrate_counting_level_three_education_date", dataset_year
     )
 
+    df = read_csv_from_str(csv_two_rows, dataset_year=dataset_year).df
     df[column] = df[column].astype(str)
     df[column] = "beep"
 

--- a/project/npda/views/dashboard/dashboard.py
+++ b/project/npda/views/dashboard/dashboard.py
@@ -1,13 +1,16 @@
 # Python imports
 import json
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from django.shortcuts import render
+from django.urls import reverse
 
+from project.npda.general_functions.audit_period import get_quarters_for_audit_period
 from project.npda.general_functions.breadcrumbs import data_breadcrumbs
 from project.npda.general_functions.quarter_for_date import retrieve_quarter_for_date
 from project.npda.kpi_class.kpis import CalculateKPIS
+from project.npda.models.audit_period import AuditPeriod
 from project.npda.views.decorators import check_data_permissions, login_and_otp_required
 
 # LOGGING
@@ -61,6 +64,43 @@ def dashboard(request, audit_period, pdu):
         calculate_kpis.calculate_kpi_2_total_new_diagnoses_stratified_by_quarter()
     )
 
+    # Determine whether the user is viewing a closed period when a newer one is now current.
+    # This banner is only meaningful for non-htmx (full page) loads.
+    today = current_date
+    current_audit_period = AuditPeriod.objects.filter(
+        start_date__lte=today,
+        end_date__gte=today,
+    ).first()
+    viewing_stale_period = (
+        current_audit_period is not None and current_audit_period.pk != audit_period.pk
+    )
+    # Q1 of the current audit period. If today falls within it and the viewed period
+    # is the one that ended immediately before the current period started, submissions
+    # are still accepted for it.
+    in_first_quarter = False
+    if current_audit_period is not None:
+        q1_start, q1_end = get_quarters_for_audit_period(
+            current_audit_period.start_date, current_audit_period.end_date
+        )[0]
+        in_first_quarter = q1_start <= today <= q1_end
+    previous_period_still_accepts = (
+        viewing_stale_period
+        and in_first_quarter
+        and current_audit_period is not None
+        and audit_period.end_date == current_audit_period.start_date - timedelta(days=1)
+    )
+    upload_url_for_current_period = (
+        reverse(
+            "pdu-upload-csv",
+            kwargs={
+                "audit_period": current_audit_period.slug,
+                "pz_code": pdu.pz_code,
+            },
+        )
+        if viewing_stale_period
+        else None
+    )
+
     context = {
         "scatter_plot_select_list": _scatter_plot_select_list("new_diagnoses"),
         "pdu_object": pdu,
@@ -81,6 +121,10 @@ def dashboard(request, audit_period, pdu):
         "breadcrumbs": data_breadcrumbs(
             pdu, audit_period, [("Unit Report", "pdu-dashboard")]
         ),
+        "viewing_stale_period": viewing_stale_period,
+        "previous_period_still_accepts": previous_period_still_accepts,
+        "current_audit_period": current_audit_period,
+        "upload_url_for_current_period": upload_url_for_current_period,
     }
 
     return render(request, template_name=template, context=context)

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -1,5 +1,6 @@
 # Python imports
 import logging
+from datetime import date
 
 # Django imports
 from django.conf import settings
@@ -8,6 +9,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect, render
 
 from project.constants.feature_flags import FEATURE_FLAGS
+from project.npda.general_functions.audit_period import get_audit_period_for_date
 from project.npda.general_functions.csv import csv_header
 from project.npda.general_functions.organisations_adapter import (
     paediatric_diabetes_units_for_user,
@@ -67,20 +69,53 @@ def new_home(request, audit_period):
     )
     sorted_inactive_pdus = sorted(inactive_pdus, key=lambda pdu: pdu.pz_code)
 
-    audit_period = AuditPeriod.objects.get_audit_period_for_request(request)
+    audit_period_obj = AuditPeriod.objects.get_audit_period_for_request(request)
     audit_periods = list(AuditPeriod.objects.all())
 
     if not request.user.is_rcpch_audit_team_member and not request.user.is_superuser:
         audit_periods = [p for p in audit_periods if p.is_visible]
 
     for p in audit_periods:
-        p.selected = p.slug == audit_period.slug
+        p.selected = p.slug == audit_period_obj.slug
+
+    # Determine the calendar-current audit period (based on today's date)
+    today = date.today()
+    current_start, _ = get_audit_period_for_date(today)
+    try:
+        current_audit_period_obj = AuditPeriod.objects.get(start_date=current_start)
+    except AuditPeriod.DoesNotExist:
+        current_audit_period_obj = None
+
+    # Show new-year banner if we are in the first quarter (April–June) of a new audit period
+    # and the user is viewing it but we're not yet looking at that period
+    in_first_quarter = today.month in (4, 5, 6)
+    viewing_current_period = (
+        current_audit_period_obj is not None
+        and audit_period_obj.slug == current_audit_period_obj.slug
+    )
+    show_new_year_banner = (
+        in_first_quarter
+        and current_audit_period_obj is not None
+        and not viewing_current_period
+    )
+
+    # Check whether any of the user's PDUs have a submission in the currently-viewed period
+    all_pdu_codes = [pdu.pz_code for pdu in active_pdus]
+    has_any_submission_in_period = Submission.objects.filter(
+        paediatric_diabetes_unit__pz_code__in=all_pdu_codes,
+        audit_period=audit_period_obj,
+        submission_active=True,
+    ).exists()
 
     context = {
         "active_pdus": sorted_active_pdus,
         "inactive_pdus": sorted_inactive_pdus,
         "audit_periods": audit_periods,
-        "selected_audit_period_display_name": audit_period.display_name,
+        "selected_audit_period_display_name": audit_period_obj.display_name(),
+        "selected_audit_period": audit_period_obj,
+        "current_audit_period": current_audit_period_obj,
+        "show_new_year_banner": show_new_year_banner,
+        "has_any_submission_in_period": has_any_submission_in_period,
     }
 
     template = "new-home.html"

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -9,7 +9,10 @@ from django.http import HttpResponse
 from django.shortcuts import redirect, render
 
 from project.constants.feature_flags import FEATURE_FLAGS
-from project.npda.general_functions.audit_period import get_audit_period_for_date
+from project.npda.general_functions.audit_period import (
+    get_audit_period_for_date,
+    get_quarters_for_audit_period,
+)
 from project.npda.general_functions.csv import csv_header
 from project.npda.general_functions.organisations_adapter import (
     paediatric_diabetes_units_for_user,
@@ -86,9 +89,15 @@ def new_home(request, audit_period):
     except AuditPeriod.DoesNotExist:
         current_audit_period_obj = None
 
-    # Show new-year banner if we are in the first quarter (April–June) of a new audit period
-    # and the user is viewing it but we're not yet looking at that period
-    in_first_quarter = today.month in (4, 5, 6)
+    # Show new-year banner if we are in Q1 of a new audit period
+    # and the user is not already viewing that period
+    in_first_quarter = False
+    if current_audit_period_obj is not None:
+        q1_start, q1_end = get_quarters_for_audit_period(
+            current_audit_period_obj.start_date, current_audit_period_obj.end_date
+        )[0]
+        in_first_quarter = q1_start <= today <= q1_end
+
     viewing_current_period = (
         current_audit_period_obj is not None
         and audit_period_obj.slug == current_audit_period_obj.slug
@@ -99,13 +108,44 @@ def new_home(request, audit_period):
         and not viewing_current_period
     )
 
-    # Check whether any of the user's PDUs have a submission in the currently-viewed period
+    # Always ensure the calendar-current period appears in the dropdown even if
+    # it is not yet marked is_visible (e.g. very start of a new audit year).
+    if (
+        current_audit_period_obj is not None
+        and current_audit_period_obj not in audit_periods
+    ):
+        audit_periods.append(current_audit_period_obj)
+        audit_periods.sort(key=lambda p: p.start_date)
+
+    # For the current period, check whether any PDU has submitted yet and whether
+    # the user can upload — used to decide if the dropdown option should be disabled.
     all_pdu_codes = [pdu.pz_code for pdu in active_pdus]
+    has_submissions_for_current_period = (
+        Submission.objects.filter(
+            paediatric_diabetes_unit__pz_code__in=all_pdu_codes,
+            audit_period=current_audit_period_obj,
+            submission_active=True,
+        ).exists()
+        if current_audit_period_obj is not None
+        else False
+    )
+
+    # Check whether any of the user's PDUs have a submission in the currently-viewed period
     has_any_submission_in_period = Submission.objects.filter(
         paediatric_diabetes_unit__pz_code__in=all_pdu_codes,
         audit_period=audit_period_obj,
         submission_active=True,
     ).exists()
+
+    # Per-PDU set of pz_codes that have a submission for the viewed period —
+    # used in the card to hide the Patient data button for non-uploaders with no data
+    pdus_with_submission_in_period = set(
+        Submission.objects.filter(
+            paediatric_diabetes_unit__pz_code__in=all_pdu_codes,
+            audit_period=audit_period_obj,
+            submission_active=True,
+        ).values_list("paediatric_diabetes_unit__pz_code", flat=True)
+    )
 
     context = {
         "active_pdus": sorted_active_pdus,
@@ -114,8 +154,11 @@ def new_home(request, audit_period):
         "selected_audit_period_display_name": audit_period_obj.display_name(),
         "selected_audit_period": audit_period_obj,
         "current_audit_period": current_audit_period_obj,
+        "viewing_current_period": viewing_current_period,
         "show_new_year_banner": show_new_year_banner,
         "has_any_submission_in_period": has_any_submission_in_period,
+        "has_submissions_for_current_period": has_submissions_for_current_period,
+        "pdus_with_submission_in_period": pdus_with_submission_in_period,
     }
 
     template = "new-home.html"


### PR DESCRIPTION
# Changes: `default-audit-period` branch

This document summarises the changes introduced in the `default-audit-period` branch on top of `dataset`.

**10 files changed — 289 insertions, 15 deletions**

---

## 1. `project/npda/models/audit_period.py`

### Bug fix: 403 raised for open-but-not-yet-visible audit periods

`AuditPeriod.get_audit_period_for_request()` previously raised `PermissionDenied` for any period where `is_visible=False`, even if `is_open=True`. This caused 403 errors at the start of a new audit year when the period was open for uploads but not yet publicly visible in the dropdown.

Fixed by requiring **both** `not is_visible` **and** `not is_open` before denying access:

```python
# Before
if not audit_period.is_visible and not can_view_all_data:
    raise PermissionDenied(...)

# After
if (
    not audit_period.is_visible
    and not audit_period.is_open
    and not can_view_all_data
):
    raise PermissionDenied(...)
```

A new `get_dataset_year()` method was also added to the `AuditPeriod` model to derive the dataset schema year from the period's start date:

```python
def get_dataset_year(self):
    if self.start_date >= date(2026, 4, 1):
        return 2026
    return 2021
```

---

## 2. `project/npda/views/home.py`

### `new_home` view — audit period dropdown, banners, permission gating

The `new_home` view (used by multi-PDU users and superusers) received substantial improvements:

**Q1 detection refactored** — was `today.month in (4, 5, 6)`. Now uses `get_quarters_for_audit_period()` to derive the actual Q1 date range for the current audit period, making it robust to future audit year boundary changes.

**New context variables added:**

| Variable | Description |
|---|---|
| `viewing_current_period` | `True` when the viewed period matches today's calendar period |
| `has_submissions_for_current_period` | Whether any of the user's PDUs have submitted to the *current* period — used to decide if the current-period dropdown option should be disabled for readers |
| `pdus_with_submission_in_period` | A `set` of `pz_code` values that have an active submission for the *viewed* period — passed into PDU card includes |
| `show_new_year_banner` | `True` when in Q1 of the new year and not already viewing it |

**Current period always in dropdown** — if `current_audit_period_obj` is not already in `audit_periods` (e.g. `is_visible=False` at the very start of a new year), it is appended and the list re-sorted. This ensures users can always navigate to the new audit year from day one.

---

## 3. `project/npda/templates/new-home.html`

### Permission-aware banners and audit period selector

**New year banner** — the call-to-action text now varies by permission:
- Users with `npda.can_submit_csv`: *"Select the 2026–2027 audit year from the dropdown below to begin a new submission."*
- Readers without that permission: *"…Contact your coordinator to begin a new submission."*

**No submissions banner** — previously appeared whenever there were no submissions for *any* period being viewed, including historical ones. Now correctly gated on `viewing_current_period` so it only fires when browsing the current period with no data. Also permission-aware for the action text.

**Audit period `<select>`** — the period selector is now a native HTML `<select>` element (the daisyUI dropdown had z-index conflicts with card shadows and was replaced). Navigation is driven by `onchange="window.location.href = this.value;"`.

The current period option is rendered as `disabled` with an explanatory `title` attribute if the user lacks `can_submit_csv` *and* there are no submissions yet for that period — preventing readers from selecting a period they can't do anything with.

**PDU card includes** — both the active and inactive PDU loops now pass `pdus_with_submission_in_period` to the `pdu-card.html` partial.

---

## 4. `project/npda/templates/partials/pdu-card.html`

### Patient data button gated on permission and data existence

The **"Patient data"** button is now only rendered if:
- the user has `npda.can_submit_csv`, **or**
- the PDU already has a submission for the viewed period (`pdu.pz_code in pdus_with_submission_in_period`)

This prevents readers without upload rights from being directed into a dead end on a PDU that has no data to view.

Also fixed: missing newline at end of file.

---

## 5. `project/npda/views/dashboard/dashboard.py`

### Stale period detection context for the PDU dashboard

Four new context variables are computed after the KPI calculations, enabling the dashboard templates to surface messaging when a user is looking at a closed/historical period:

| Variable | Description |
|---|---|
| `viewing_stale_period` | `True` when the viewed period is not the calendar-current period |
| `previous_period_still_accepts` | `True` when in Q1 of the new year *and* the viewed period ended the day before the current one started |
| `current_audit_period` | The DB object for today's calendar-current audit period |
| `upload_url_for_current_period` | `reverse("pdu-upload-csv", ...)` for the current period, or `None` if not stale |

---

## 6. `project/npda/templates/dashboard.html`

### Top-of-page stale period alert banner

When `viewing_stale_period` is `True`, an alert banner now appears above the dashboard content (outside the htmx-swapped partial so it persists across KPI partial refreshes).

- **Q1 / immediately-previous period** (`previous_period_still_accepts`): *"The 2026–2027 audit year has now started. Click here to submit data for 2026–2027."* The link is gated on `npda.can_submit_csv`.
- **Older closed periods**: *"This audit period is now closed and submissions are no longer accepted."* The heading also gains a `(closed)` suffix.

---

## 7. `project/npda/templates/dashboard/dashboard_base.html`

The `{% include %}` call for `audit_details_card.html` was extended to pass the four new stale-period variables: `viewing_stale_period`, `previous_period_still_accepts`, `current_audit_period`, and `upload_url_for_current_period`.

---

## 8. `project/npda/templates/dashboard/components/cards/audit_details_card.html`

### "Note" section at the bottom of the audit details card

When `viewing_stale_period` is `True`, a note section is appended (using the existing `hr_with_text.html` partial):

- **`previous_period_still_accepts`** — shows an info badge and an upload button pointing at the current period. The button is enabled for `can_submit_csv` users; readers see it rendered as a disabled grey button with a `title` explaining why.
- **Otherwise** — shows a lock icon with *"This audit period is now closed and submissions are no longer accepted."* No button is shown.

---

## 9. `project/npda/general_functions/csv/csv_parse.py`

### CSV template year mismatch detection

Added a canary check using the smoking status field heading (which changed from `"Does the patient smoke?"` in 2021 to `"Does the patient smoke and/or vape"` in 2026) to detect when a CSV file was built for one schema year but uploaded against the other:

```python
if _2026_smoking_heading in df.columns and _2021_smoking_heading not in df.columns and dataset_year == 2021:
    raise ValueError(
        "This file appears to be using the 2026 template but you have selected 2021 ..."
    )
if _2026_smoking_heading not in df.columns and _2021_smoking_heading in df.columns and dataset_year == 2026:
    raise ValueError(
        "This file appears to be using the 2021 template but you have selected 2026 ..."
    )
```

Uses `get_field_heading()` (returns a `str`) rather than the previous mistaken call to `csv_definition_for()` (returns a `dict`), fixing a `TypeError: unhashable type: 'dict'`.

---

## 10. `project/npda/tests/test_csv_upload.py`

### `test_csv_year_mismatch_raises_error`

A new parametrized test (runs for both `dataset_year=2021` and `dataset_year=2026`) that verifies the mismatch detection above raises `ValueError` with the expected message when a CSV file for one year is parsed against the opposite year.

```python
@pytest.mark.parametrize("dataset_year", [2021, 2026])
def test_csv_year_mismatch_raises_error(test_user, dummy_sheet_csv, audit_period_for_dataset_year, dataset_year):
    opposite_year = 2021 if dataset_year == 2026 else 2026
    with pytest.raises(ValueError, match="Please check your file and upload again"):
        read_csv_from_str(dummy_sheet_csv, dataset_year=opposite_year)
```
