### PR TITLE
fix/bring-patient-report-into-line-with-2026-dataset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,211 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repository.
+
+---
+
+## Running tests
+
+**Always run tests inside the Docker container** using the `s/test` script.
+Never call `pytest` directly on the host machine.
+
+```bash
+# Run a specific test
+s/test project/npda/tests/view_tests/test_patient_report.py::test_name
+
+# Run a whole test file
+s/test project/npda/tests/view_tests/test_patient_report.py
+
+# Run all tests
+s/test
+```
+
+The script wraps: `docker compose run --rm django pytest -v $*`
+
+---
+
+## Project structure
+
+### Patient report
+
+The patient report is driven by its own dedicated query layer — **do not reach for the KPI class** when working on it.
+
+| Path | Purpose |
+|------|---------|
+| `project/npda/general_functions/patient_report/queries.py` | All ORM queries that power the patient report (health checks, additional care processes, care at diagnosis, admissions, treatment, outcomes) |
+| `project/npda/views/patient_report/patient_report.py` | View logic, context assembly, sorting, pagination, XLSX export |
+| `project/npda/views/patient_report/patient_report.md` | Design intent, column definitions, edge cases and known shortcomings — **read before making changes** |
+| `project/npda/templates/patient_report/` | Jinja/Django templates per category (e.g. `treatment_table_partial.html`) |
+
+### KPI class
+
+`project/npda/general_functions/calculate_kpis/` — for **PDU-level aggregates only**. Not used directly in the patient report row-level queries.
+
+### Constants
+
+`project/constants/` — canonical choice lists used across models, queries and templates.
+
+| File | Contains |
+|------|---------|
+| `diabetes_treatment.py` | `TREATMENT_TYPES` |
+| `glucose_monitoring_types.py` | `GLUCOSE_MONITORING_TYPES` |
+| `closed_loop_types.py` | `CLOSED_LOOP_TYPES` |
+| `diabetes_types.py` | `DIABETES_TYPES` |
+| `smoking_status.py` | `SMOKING_STATUS` |
+| `hba1c_format.py` | `HBA1C_FORMATS` |
+
+---
+
+## Test conventions
+
+### Required fixtures
+
+All view tests need these three session-scoped fixtures:
+
+```python
+def test_my_test(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+```
+
+### Standard PDU
+
+Use `ALDER_HEY_PZ_CODE` (imported from `project.npda.tests.constants_for_tests`) as the PDU in tests.
+
+### Factories
+
+| Factory | Import path |
+|---------|-------------|
+| `PatientFactory` | `project.npda.tests.factories.patient_factory` |
+| `VisitFactory` | `project.npda.tests.factories.visit_factory` |
+
+**`VisitFactory` has opinionated non-null defaults** for `treatment`, `closed_loop_system` and `glucose_monitoring`. Pass `None` explicitly when testing missing-data behaviour:
+
+```python
+VisitFactory(patient=patient, visit_date=visit_date, treatment=None)
+```
+
+### Authentication
+
+```python
+from project.npda.tests.utils import login_and_verify_user
+
+user = NPDAUser.objects.filter(
+    organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    role=test_user_audit_centre_editor_data.role,
+).first()
+client = login_and_verify_user(client, user)
+```
+
+### Submission wiring
+
+Patients must be added to a `Submission` to appear in patient report queries:
+
+```python
+submission = Submission.objects.create(
+    paediatric_diabetes_unit=user.organisation_employers.first(),
+    audit_year=audit_period.start_date.year,
+    audit_period=audit_period,
+    submission_date=audit_period.start_date,
+    submission_by=user,
+    submission_active=True,
+)
+submission.patients.add(patient)
+```
+
+### Patient report response shape
+
+The patient report view returns patients as a list of dicts in `response.context["patients"]`.
+Keys match the annotation names in `queries.py` (e.g. `"treatment_regimen"`, `"glucose_monitoring"`, `"hcl"`), not the model field names.
+
+---
+
+## `s/` scripts reference
+
+All convenience scripts live in `s/`. They must be run from the repo root.
+
+| Script | What it does |
+|--------|-------------|
+| `s/up` | Start all Docker Compose services |
+| `s/down` | Stop all services |
+| `s/rebuild` | Remove containers/images then bring up fresh |
+| `s/local-clean-reset` | Nuclear reset: removes volumes and images, then `s/up` |
+| `s/start-dev` | Run migrations, seed data, start Django dev server on port 8008 |
+| `s/watch-tailwind` | Compile Tailwind CSS in watch mode |
+| `s/django-shell` | Open Django shell inside the running container |
+| `s/test` | Run pytest in a one-shot container (passes all args to pytest) |
+| `s/lint` | Run ruff formatter + linter in fix mode |
+| `s/lint --check` | Lint check only (used in CI, exits non-zero if unclean) |
+| `s/psql` | Connect to Postgres (local or Azure, see script for options) |
+| `s/create-superuser` | Create a Django superuser inside the container |
+| `s/start-celery-dev` | Start Celery worker for local development |
+
+---
+
+## Linting / formatting
+
+The project uses **ruff** for both formatting and linting.
+
+```bash
+s/lint          # fix in place
+s/lint --check  # CI mode
+```
+
+---
+
+## Datasets
+
+There are two datasets: **2021** and **2026**. The dataset year is derived from the audit period and controls which CSV columns are accepted on upload, which field labels are shown in the UI, and which model fields are active.
+
+### How the dataset year is resolved
+
+`AuditPeriod.get_dataset_year()` returns `2026` if `start_date >= 2026-04-01`, otherwise `2021`. Everything downstream uses this single method — do not hardcode a year.
+
+### Where the dataset year is used
+
+| Location | Purpose |
+|----------|---------|
+| `project/npda/general_functions/headings.py` | `get_field_heading(field_name, dataset_year)` — returns the year-appropriate CSV column heading for a given model field |
+| `project/constants/csv_headings.py` | `ALL_HEADINGS` — master list of every field with a `dataset_years` list indicating which datasets include it |
+| `project/npda/general_functions/csv/csv_upload.py` | Infers `dataset_year` from the submission's audit period (or from column sniffing) before parsing |
+| `project/npda/models/patient.py` | `Patient.get_field_label()`, `get_sex_label()` etc. delegate to `get_field_heading` |
+| `project/npda/models/visit.py` | `Visit.get_field_label()` delegates to `get_field_heading` |
+| `project/npda/forms/patient_form.py` / `visit_form.py` | Form field labels are resolved via `get_field_heading` at form instantiation |
+
+### Key differences between datasets
+
+**Patient model — 2026 only fields:**
+- `sex` heading changes from "Stated gender" → "Sex assigned at birth"
+- `adhd_asd_status` — ADHD/ASD diagnosis
+- `learning_disability_status` — learning disability diagnosis
+- `immunotherapy_received` / `immunotherapy_date` — immunotherapy for stage 3 T1DM
+
+**Visit model — 2021 only fields (replaced in 2026):**
+- `treatment` — combined treatment regimen (replaced by `insulin_regimen` + `non_insulin_medication` + `dietary_lifestyle_modification`)
+- `closed_loop_system` — closed loop flag (still present but linked to `treatment`; logic changes)
+- `glucose_monitoring` — other glucose monitoring method (replaced by `cgm_use`)
+- `hba1c_format` — HbA1c format field (removed in 2026; format is inferred)
+- `smoking_status` — "Does the patient smoke?" (replaced by `smoking_vaping_status`)
+
+**Visit model — 2026 only fields:**
+- `insulin_regimen` — insulin type at time of visit
+- `non_insulin_medication` — other blood glucose lowering medication
+- `dietary_lifestyle_modification` — lifestyle/dietary modification recommended
+- `cgm_use` — CGM use at time of visit
+- `smoking_vaping_status` — "Does the patient smoke and/or vape"
+- `blood_gas_ph` / `blood_gas_bicarbonate` — DKA admission blood gas values
+- `psychological_support_outcome` — whether patient was offered additional mental health appointment
+
+### Adding new fields
+
+When adding a field that is dataset-year-specific:
+1. Add the model field to `Patient` or `Visit` (nullable)
+2. Add an entry to `ALL_HEADINGS` in `project/constants/csv_headings.py` with the correct `dataset_years` list
+3. Add the heading to `PATIENT_FIELD_HEADINGS_202x` / `VISIT_FIELD_HEADINGS_202x` in `project/npda/general_functions/headings.py`
+4. The form, CSV upload, and display layers will pick it up automatically via `get_field_heading`
+
+---
+
+## Notes on Jersey (PZ248)
+
+Patients at the Jersey PDU (`pz_code == "PZ248"`) use `unique_reference_number` as their identifier instead of `nhs_number`. The helper `_patient_identifier_field(pdu)` in `queries.py` handles this. Tests that check `patient_identifier` should be aware of this distinction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,10 @@ The patient report is driven by its own dedicated query layer — **do not reach
 |------|---------|
 | `project/npda/general_functions/patient_report/queries.py` | All ORM queries that power the patient report (health checks, additional care processes, care at diagnosis, admissions, treatment, outcomes) |
 | `project/npda/views/patient_report/patient_report.py` | View logic, context assembly, sorting, pagination, XLSX export |
-| `project/npda/views/patient_report/patient_report.md` | Design intent, column definitions, edge cases and known shortcomings — **read before making changes** |
+| `project/npda/views/patient_report/patient_report.md` | Design intent, column definitions, edge cases, known shortcomings, and **the authoritative 2021/2026 field mapping per category — read this before touching any patient report query** |
 | `project/npda/templates/patient_report/` | Jinja/Django templates per category (e.g. `treatment_table_partial.html`) |
+
+When working on patient report queries, always check `patient_report.md` for the correct field to use for the active dataset year. Several fields changed or were added in 2026 (e.g. `treatment` → `insulin_regimen`, `glucose_monitoring` → `cgm_use`, `smoking_status` → `smoking_vaping_status`). The `audit_period.get_dataset_year()` method is the single source of truth — never hardcode a year.
 
 ### KPI class
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,12 +177,14 @@ There are two datasets: **2021** and **2026**. The dataset year is derived from 
 ### Key differences between datasets
 
 **Patient model — 2026 only fields:**
+
 - `sex` heading changes from "Stated gender" → "Sex assigned at birth"
 - `adhd_asd_status` — ADHD/ASD diagnosis
 - `learning_disability_status` — learning disability diagnosis
 - `immunotherapy_received` / `immunotherapy_date` — immunotherapy for stage 3 T1DM
 
 **Visit model — 2021 only fields (replaced in 2026):**
+
 - `treatment` — combined treatment regimen (replaced by `insulin_regimen` + `non_insulin_medication` + `dietary_lifestyle_modification`)
 - `closed_loop_system` — closed loop flag (still present but linked to `treatment`; logic changes)
 - `glucose_monitoring` — other glucose monitoring method (replaced by `cgm_use`)
@@ -190,6 +192,7 @@ There are two datasets: **2021** and **2026**. The dataset year is derived from 
 - `smoking_status` — "Does the patient smoke?" (replaced by `smoking_vaping_status`)
 
 **Visit model — 2026 only fields:**
+
 - `insulin_regimen` — insulin type at time of visit
 - `non_insulin_medication` — other blood glucose lowering medication
 - `dietary_lifestyle_modification` — lifestyle/dietary modification recommended
@@ -201,6 +204,7 @@ There are two datasets: **2021** and **2026**. The dataset year is derived from 
 ### Adding new fields
 
 When adding a field that is dataset-year-specific:
+
 1. Add the model field to `Patient` or `Visit` (nullable)
 2. Add an entry to `ALL_HEADINGS` in `project/constants/csv_headings.py` with the correct `dataset_years` list
 3. Add the heading to `PATIENT_FIELD_HEADINGS_202x` / `VISIT_FIELD_HEADINGS_202x` in `project/npda/general_functions/headings.py`

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -697,6 +697,7 @@ def annotate_treatment(qs, audit_period):
 
 def annotate_outcomes(qs, audit_period):
     audit_range = (audit_period.start_date, audit_period.end_date)
+    dataset_year = audit_period.get_dataset_year()
 
     latest_hba1c_date = Subquery(
         Visit.objects.filter(
@@ -718,53 +719,77 @@ def annotate_outcomes(qs, audit_period):
         .values("visit_date")[1:2]
     )
 
-    latest_hba1c_mmol_mol = Subquery(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            hba1c__isnull=False,
-        )
-        .annotate(
-            hba1c_mmol_mol=Case(
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[0][0]),
-                    then=F("hba1c"),
-                ),
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                    then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
-                ),
-                default=None,
-                output_field=DecimalField(max_digits=5, decimal_places=2),
+    if dataset_year == 2026:
+        # 2026: hba1c_format deprecated — values always stored as mmol/mol
+        latest_hba1c_mmol_mol = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                hba1c__isnull=False,
             )
+            .annotate(hba1c_mmol_mol=F("hba1c"))
+            .order_by("-visit_date")
+            .values("hba1c_mmol_mol")[:1]
         )
-        .order_by("-visit_date")
-        .values("hba1c_mmol_mol")[:1]
-    )
 
-    previous_hba1c_mmol_mol = Subquery(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            hba1c__isnull=False,
-        )
-        .annotate(
-            hba1c_mmol_mol=Case(
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[0][0]),
-                    then=F("hba1c"),
-                ),
-                When(
-                    Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                    then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
-                ),
-                default=None,
-                output_field=DecimalField(max_digits=5, decimal_places=2),
+        previous_hba1c_mmol_mol = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                hba1c__isnull=False,
             )
+            .annotate(hba1c_mmol_mol=F("hba1c"))
+            .order_by("-visit_date")
+            .values("hba1c_mmol_mol")[1:2]
         )
-        .order_by("-visit_date")
-        .values("hba1c_mmol_mol")[1:2]
-    )
+    else:
+        latest_hba1c_mmol_mol = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                hba1c__isnull=False,
+            )
+            .annotate(
+                hba1c_mmol_mol=Case(
+                    When(
+                        Q(hba1c_format=HBA1C_FORMATS[0][0]),
+                        then=F("hba1c"),
+                    ),
+                    When(
+                        Q(hba1c_format=HBA1C_FORMATS[1][0]),
+                        then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
+                    ),
+                    default=None,
+                    output_field=DecimalField(max_digits=5, decimal_places=2),
+                )
+            )
+            .order_by("-visit_date")
+            .values("hba1c_mmol_mol")[:1]
+        )
+
+        previous_hba1c_mmol_mol = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                hba1c__isnull=False,
+            )
+            .annotate(
+                hba1c_mmol_mol=Case(
+                    When(
+                        Q(hba1c_format=HBA1C_FORMATS[0][0]),
+                        then=F("hba1c"),
+                    ),
+                    When(
+                        Q(hba1c_format=HBA1C_FORMATS[1][0]),
+                        then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
+                    ),
+                    default=None,
+                    output_field=DecimalField(max_digits=5, decimal_places=2),
+                )
+            )
+            .order_by("-visit_date")
+            .values("hba1c_mmol_mol")[1:2]
+        )
 
     return qs.annotate(
         latest_hba1c_date=latest_hba1c_date,

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -239,6 +239,7 @@ def annotate_health_checks(qs, audit_period):
 
 def annotate_additional_care_processes(qs, audit_period):
     audit_range = (audit_period.start_date, audit_period.end_date)
+    dataset_year = audit_period.get_dataset_year()
 
     hba1c_count = Count(
         "visit",
@@ -256,30 +257,55 @@ def annotate_additional_care_processes(qs, audit_period):
         )
     )
 
-    smoking_status_exists = Exists(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            smoking_status__in=[1, 2],
+    if dataset_year == 2026:
+        # 2026: smoking_vaping_status replaces smoking_status
+        # Values: 1=non-smoker/non-vaper, 2=smoker/non-vaper, 3=vaper/non-smoker, 4=smoker+vaper
+        smoking_status_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_vaping_status__in=[1, 2, 3, 4],
+            )
         )
-    )
-
-    smoker_exists = Exists(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            smoking_status=2,
+        smoker_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_vaping_status__in=[2, 4],  # current smoker (with or without vaping)
+            )
         )
-    )
-
-    smoking_referral_exists = Exists(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            smoking_status=2,
-            smoking_cessation_referral_date__range=audit_range,
+        smoking_referral_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_vaping_status__in=[2, 4],
+                smoking_cessation_referral_date__range=audit_range,
+            )
         )
-    )
+    else:
+        # 2021: smoking_status field
+        smoking_status_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_status__in=[1, 2],
+            )
+        )
+        smoker_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_status=2,
+            )
+        )
+        smoking_referral_exists = Exists(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                smoking_status=2,
+                smoking_cessation_referral_date__range=audit_range,
+            )
+        )
 
     dietetic_offered_exists = Exists(
         Visit.objects.filter(

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -271,7 +271,10 @@ def annotate_additional_care_processes(qs, audit_period):
             Visit.objects.filter(
                 patient=OuterRef("pk"),
                 visit_date__range=audit_range,
-                smoking_vaping_status__in=[2, 4],  # current smoker (with or without vaping)
+                smoking_vaping_status__in=[
+                    2,
+                    4,
+                ],  # current smoker (with or without vaping)
             )
         )
         smoking_referral_exists = Exists(
@@ -757,7 +760,8 @@ def annotate_outcomes(qs, audit_period):
                     ),
                     When(
                         Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                        then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
+                        then=(F("hba1c") - Round(Decimal("2.152")))
+                        / Decimal("0.09148"),
                     ),
                     default=None,
                     output_field=DecimalField(max_digits=5, decimal_places=2),
@@ -781,7 +785,8 @@ def annotate_outcomes(qs, audit_period):
                     ),
                     When(
                         Q(hba1c_format=HBA1C_FORMATS[1][0]),
-                        then=(F("hba1c") - Round(Decimal("2.152"))) / Decimal("0.09148"),
+                        then=(F("hba1c") - Round(Decimal("2.152")))
+                        / Decimal("0.09148"),
                     ),
                     default=None,
                     output_field=DecimalField(max_digits=5, decimal_places=2),

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -26,10 +26,12 @@ from django.db.models import (
 )
 
 from project.constants import TREATMENT_TYPES
+from project.constants.diabetes_treatment import INSULIN_TREATMENT
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.constants.glucose_monitoring_types import GLUCOSE_MONITORING_TYPES
 from project.constants.hba1c_format import HBA1C_FORMATS
 from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REASONS
+from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 from project.npda.models import Patient, Transfer, Visit
 from project.npda.models.db_functions import Round
 
@@ -533,79 +535,138 @@ def annotate_admissions(qs, audit_period):
 
 def annotate_treatment(qs, audit_period):
     audit_range = (audit_period.start_date, audit_period.end_date)
+    dataset_year = audit_period.get_dataset_year()
 
-    latest_visit = (
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
+    if dataset_year == 2026:
+        # 2026 dataset: insulin_regimen (INSULIN_TREATMENT), cgm_use (YES_NO_UNKNOWN)
+        # HCL is encoded as insulin_regimen == 5 (Hybrid closed loop)
+        latest_insulin_regimen = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                insulin_regimen__isnull=False,
+            )
+            .order_by("-visit_date")
+            .values("insulin_regimen")[:1]
         )
-        .order_by("-visit_date")
-        .values("visit_date")
-    )
 
-    latest_treatment = Subquery(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            treatment__isnull=False,
+        latest_cgm_use = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                cgm_use__isnull=False,
+            )
+            .order_by("-visit_date")
+            .values("cgm_use")[:1]
         )
-        .order_by("-visit_date")
-        .values("treatment")[:1]
-    )
 
-    latest_glucose_monitoring = Subquery(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            glucose_monitoring__isnull=False,
+        treatment_case = Case(
+            *[
+                When(latest_insulin_regimen=val, then=Value(label))
+                for val, label in INSULIN_TREATMENT
+            ],
+            default=Value("No treatment regimen"),
+            output_field=CharField(),
         )
-        .order_by("-visit_date")
-        .values("glucose_monitoring")[:1]
-    )
 
-    latest_closed_loop = Subquery(
-        Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=audit_range,
-            closed_loop_system__isnull=False,
+        glucose_case = Case(
+            *[
+                When(latest_cgm_use=val, then=Value(label))
+                for val, label in YES_NO_UNKNOWN
+            ],
+            default=Value("No glucose monitoring"),
+            output_field=CharField(),
         )
-        .order_by("-visit_date")
-        .values("closed_loop_system")[:1]
-    )
 
-    treatment_case = Case(
-        *[
-            When(latest_treatment=val, then=Value(label))
-            for val, label in TREATMENT_TYPES
-        ],
-        default=Value("No treatment regimen"),
-        output_field=CharField(),
-    )
+        hcl_case = Case(
+            When(latest_insulin_regimen=5, then=Value("Yes")),  # 5 = Hybrid closed loop
+            default=Value("No"),
+            output_field=CharField(),
+        )
 
-    glucose_case = Case(
-        *[
-            When(latest_glucose_monitoring=val, then=Value(label))
-            for val, label in GLUCOSE_MONITORING_TYPES
-        ],
-        default=Value("No glucose monitoring"),
-        output_field=CharField(),
-    )
+        return qs.annotate(
+            latest_insulin_regimen=latest_insulin_regimen,
+            latest_cgm_use=latest_cgm_use,
+            treatment_regimen=treatment_case,
+            glucose_monitoring=glucose_case,
+            hcl=hcl_case,
+        )
 
-    hcl_case = Case(
-        When(latest_closed_loop__in=[2, 3, 4], then=Value("Yes")),
-        default=Value("No"),
-        output_field=CharField(),
-    )
+    else:
+        # 2021 dataset: treatment (TREATMENT_TYPES), glucose_monitoring (GLUCOSE_MONITORING_TYPES)
+        # HCL: closed_loop_system in [2, 3, 4]
+        latest_visit = (
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+            )
+            .order_by("-visit_date")
+            .values("visit_date")
+        )
 
-    return qs.annotate(
-        latest_visit_date=Subquery(latest_visit[:1]),
-        latest_treatment=latest_treatment,
-        latest_glucose_monitoring=latest_glucose_monitoring,
-        latest_closed_loop=latest_closed_loop,
-        treatment_regimen=treatment_case,
-        glucose_monitoring=glucose_case,
-        hcl=hcl_case,
-    )
+        latest_treatment = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                treatment__isnull=False,
+            )
+            .order_by("-visit_date")
+            .values("treatment")[:1]
+        )
+
+        latest_glucose_monitoring = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                glucose_monitoring__isnull=False,
+            )
+            .order_by("-visit_date")
+            .values("glucose_monitoring")[:1]
+        )
+
+        latest_closed_loop = Subquery(
+            Visit.objects.filter(
+                patient=OuterRef("pk"),
+                visit_date__range=audit_range,
+                closed_loop_system__isnull=False,
+            )
+            .order_by("-visit_date")
+            .values("closed_loop_system")[:1]
+        )
+
+        treatment_case = Case(
+            *[
+                When(latest_treatment=val, then=Value(label))
+                for val, label in TREATMENT_TYPES
+            ],
+            default=Value("No treatment regimen"),
+            output_field=CharField(),
+        )
+
+        glucose_case = Case(
+            *[
+                When(latest_glucose_monitoring=val, then=Value(label))
+                for val, label in GLUCOSE_MONITORING_TYPES
+            ],
+            default=Value("No glucose monitoring"),
+            output_field=CharField(),
+        )
+
+        hcl_case = Case(
+            When(latest_closed_loop__in=[2, 3, 4], then=Value("Yes")),
+            default=Value("No"),
+            output_field=CharField(),
+        )
+
+        return qs.annotate(
+            latest_visit_date=Subquery(latest_visit[:1]),
+            latest_treatment=latest_treatment,
+            latest_glucose_monitoring=latest_glucose_monitoring,
+            latest_closed_loop=latest_closed_loop,
+            treatment_regimen=treatment_case,
+            glucose_monitoring=glucose_case,
+            hcl=hcl_case,
+        )
 
 
 def annotate_outcomes(qs, audit_period):

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -35,7 +35,7 @@ from project.constants.hba1c_format import HBA1C_FORMATS
 from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REASONS
 from project.constants.leave_pdu_reasons import LEAVE_PDU_REASONS
 from project.constants.retinal_screening_results import RETINAL_SCREENING_RESULTS
-from project.constants.smoking_status import SMOKING_STATUS, SMOKING_VAPING_STATUS
+from project.constants.smoking_status import SMOKING_STATUS
 from project.constants.types.kpi_types import (
     KPICalculationsObject,
     KPIResult,
@@ -3029,7 +3029,9 @@ class CalculateKPIS:
         # Get the visits that match the valid Smoking Cessation Referral date
         # 2026 dataset uses smoking_vaping_status; 2021 uses smoking_status
         if self.audit_start_date >= date(2026, 4, 1):
-            smoker_filter = Q(smoking_vaping_status__in=[2, 4])  # smoker (with or without vaping)
+            smoker_filter = Q(
+                smoking_vaping_status__in=[2, 4]
+            )  # smoker (with or without vaping)
         else:
             smoker_filter = Q(smoking_status=2)  # Current smoker
         smoke_cessation_visits = Visit.objects.filter(

--- a/project/npda/kpi_class/kpis.py
+++ b/project/npda/kpi_class/kpis.py
@@ -35,7 +35,7 @@ from project.constants.hba1c_format import HBA1C_FORMATS
 from project.constants.hospital_admission_reasons import HOSPITAL_ADMISSION_REASONS
 from project.constants.leave_pdu_reasons import LEAVE_PDU_REASONS
 from project.constants.retinal_screening_results import RETINAL_SCREENING_RESULTS
-from project.constants.smoking_status import SMOKING_STATUS
+from project.constants.smoking_status import SMOKING_STATUS, SMOKING_VAPING_STATUS
 from project.constants.types.kpi_types import (
     KPICalculationsObject,
     KPIResult,
@@ -3027,11 +3027,16 @@ class CalculateKPIS:
         total_ineligible = self.total_patients_count - total_eligible
 
         # Get the visits that match the valid Smoking Cessation Referral date
+        # 2026 dataset uses smoking_vaping_status; 2021 uses smoking_status
+        if self.audit_start_date >= date(2026, 4, 1):
+            smoker_filter = Q(smoking_vaping_status__in=[2, 4])  # smoker (with or without vaping)
+        else:
+            smoker_filter = Q(smoking_status=2)  # Current smoker
         smoke_cessation_visits = Visit.objects.filter(
-            patient=OuterRef("pk"),
-            visit_date__range=self.AUDIT_DATE_RANGE,
-            smoking_status=2,  # Current smoker
-            smoking_cessation_referral_date__range=self.AUDIT_DATE_RANGE,
+            Q(patient=OuterRef("pk"))
+            & Q(visit_date__range=self.AUDIT_DATE_RANGE)
+            & smoker_filter
+            & Q(smoking_cessation_referral_date__range=self.AUDIT_DATE_RANGE),
         )
         # Find patients with a valid entry for Smoking Cessation Referral
         eligible_pts_annotated_smoke_screen_visits = eligible_patients.annotate(

--- a/project/npda/templates/patient_report/health_checks_table_partial.html
+++ b/project/npda/templates/patient_report/health_checks_table_partial.html
@@ -44,7 +44,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  BMI ({{ total_passed_bmi|percentage:total_eligible_bmi }} complete)
+  BMI ({{ total_passed_bmi|percentage:total_eligible_bmi }} complete - {{ total_passed_bmi}}/{{total_eligible_bmi }})
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_bmi&order=desc"
           hx-target="#table-area"
@@ -61,7 +61,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Thyroid Screen ({{ total_passed_thyroid_screen|percentage:total_eligible_thyroid_screen }} complete)
+  Thyroid Screen ({{ total_passed_thyroid_screen|percentage:total_eligible_thyroid_screen }} complete - {{ total_passed_thyroid_screen}}/{{total_eligible_thyroid_screen }})
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_thyroid_screen&order=desc"
           hx-target="#table-area"
@@ -78,7 +78,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Blood Pressure ({{ total_passed_blood_pressure|percentage:total_eligible_blood_pressure }} complete)
+  Blood Pressure ({{ total_passed_blood_pressure|percentage:total_eligible_blood_pressure }} complete - {{ total_passed_blood_pressure}}/{{total_eligible_blood_pressure }})
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_blood_pressure&order=desc"
           hx-target="#table-area"
@@ -95,7 +95,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Urinary Albumin ({{ total_passed_urinary_albumin|percentage:total_eligible_urinary_albumin }} complete)
+  Urinary Albumin ({{ total_passed_urinary_albumin|percentage:total_eligible_urinary_albumin }} complete - {{ total_passed_urinary_albumin}}/{{total_eligible_urinary_albumin }})
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_urinary_albumin&order=desc"
           hx-target="#table-area"
@@ -112,7 +112,7 @@
   </div>
 </th>
 <th class="whitespace-normal break-words">
-  Foot Exam ({{ total_passed_foot_exam|percentage:total_eligible_foot_exam }} complete)
+  Foot Exam ({{ total_passed_foot_exam|percentage:total_eligible_foot_exam }} complete - {{ total_passed_foot_exam}}/{{total_eligible_foot_exam }})
   <div class="block">
     <span hx-get="?category=health_checks&sort=passed_foot_exam&order=desc"
           hx-target="#table-area"

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -38,7 +38,6 @@ from project.npda.tests.factories import (
     test_user_rcpch_audit_team_data,
 )
 from project.npda.tests.factories.patient_factory import PatientFactory
-from project.npda.tests.factories.transfer_factory import TransferFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.urls import patient_report_urlpatterns

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -31,12 +31,14 @@ from project.npda.models import NPDAUser
 from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.patient import Patient
 from project.npda.models.submission import Submission
+from project.npda.models.transfer import Transfer
 from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
 from project.npda.tests.factories import (
     test_user_audit_centre_editor_data,
     test_user_rcpch_audit_team_data,
 )
 from project.npda.tests.factories.patient_factory import PatientFactory
+from project.npda.tests.factories.transfer_factory import TransferFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
 from project.npda.tests.utils import login_and_verify_user
 from project.npda.urls import patient_report_urlpatterns
@@ -1155,6 +1157,190 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
 
     assert patient["patient_identifier"] == "4444444444"
     assert patient["influenza_immunisation_recommended"] is True
+
+
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
+@pytest.mark.django_db
+def test_incomplete_year_patient_diagnosed_in_audit_year_excluded_from_totals(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+):
+    """
+    Patients diagnosed within the audit year have is_complete_year_of_care=False.
+    They should still appear as rows in the table, but must not be counted in the
+    column header totals (total_eligible_*, total_passed_*).
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
+    audit_period.is_open = True
+    audit_period.save()
+
+    dob = audit_period.start_date - relativedelta(years=14)
+
+    # Complete-year patient: diagnosed before the audit period
+    complete_patient = PatientFactory(
+        nhs_number="5555555551",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=dob,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+    VisitFactory(
+        patient=complete_patient,
+        visit_date=visit_date,
+        hba1c=50,
+        hba1c_format=HBA1C_FORMATS[0][0],
+        hba1c_date=visit_date,
+    )
+
+    # Incomplete-year patient: diagnosed inside the audit year
+    incomplete_patient = PatientFactory(
+        nhs_number="5555555552",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=dob,
+        diagnosis_date=audit_period.start_date + relativedelta(days=5),
+    )
+    visit_date2 = audit_period.start_date + relativedelta(days=15)
+    VisitFactory(
+        patient=incomplete_patient,
+        visit_date=visit_date2,
+        hba1c=60,
+        hba1c_format=HBA1C_FORMATS[0][0],
+        hba1c_date=visit_date2,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(complete_patient, incomplete_patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+    )
+    response = client.get(
+        url + f"?category={TableCategories.HEALTH_CHECKS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    # Both patients appear as rows
+    assert len(response.context["patients"]) == 2
+
+    # Totals count only the complete-year patient
+    assert response.context["total_eligible_hba1c"] == 1, (
+        "Incomplete-year patient (diagnosed in audit year) must not count in total_eligible"
+    )
+    assert response.context["total_passed_hba1c"] == 1, (
+        "Incomplete-year patient (diagnosed in audit year) must not count in total_passed"
+    )
+
+
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
+@pytest.mark.django_db
+def test_incomplete_year_patient_transferred_out_excluded_from_totals(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+):
+    """
+    Patients who transferred out during the audit year have is_complete_year_of_care=False.
+    They should still appear as rows in the table, but must not be counted in the
+    column header totals (total_eligible_*, total_passed_*).
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
+    audit_period.is_open = True
+    audit_period.save()
+
+    dob = audit_period.start_date - relativedelta(years=14)
+
+    # Complete-year patient
+    complete_patient = PatientFactory(
+        nhs_number="5555555553",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=dob,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+    VisitFactory(
+        patient=complete_patient,
+        visit_date=visit_date,
+        hba1c=50,
+        hba1c_format=HBA1C_FORMATS[0][0],
+        hba1c_date=visit_date,
+    )
+
+    # Incomplete-year patient: transferred out within the audit year
+    transferred_patient = PatientFactory(
+        nhs_number="5555555554",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=dob,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date2 = audit_period.start_date + relativedelta(days=20)
+    VisitFactory(
+        patient=transferred_patient,
+        visit_date=visit_date2,
+        hba1c=60,
+        hba1c_format=HBA1C_FORMATS[0][0],
+        hba1c_date=visit_date2,
+    )
+    # Set the transfer date to within the audit year
+    Transfer.objects.filter(patient=transferred_patient).update(
+        date_leaving_service=audit_period.start_date + relativedelta(days=30)
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(complete_patient, transferred_patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={"audit_period": audit_period.slug, "pz_code": ALDER_HEY_PZ_CODE},
+    )
+    response = client.get(
+        url + f"?category={TableCategories.HEALTH_CHECKS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    # Both patients appear as rows
+    assert len(response.context["patients"]) == 2
+
+    # Totals count only the complete-year patient
+    assert response.context["total_eligible_hba1c"] == 1, (
+        "Transferred-out patient must not count in total_eligible"
+    )
+    assert response.context["total_passed_hba1c"] == 1, (
+        "Transferred-out patient must not count in total_passed"
+    )
 
 
 @pytest.mark.parametrize(

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -11,10 +11,11 @@ from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 
 from project.constants.closed_loop_types import CLOSED_LOOP_TYPES
-from project.constants.diabetes_treatment import TREATMENT_TYPES
+from project.constants.diabetes_treatment import INSULIN_TREATMENT, TREATMENT_TYPES
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.constants.glucose_monitoring_types import GLUCOSE_MONITORING_TYPES
 from project.constants.hba1c_format import HBA1C_FORMATS
+from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 
 # Python imports
 from project.constants.smoking_status import SMOKING_STATUS
@@ -2009,4 +2010,255 @@ def test_hcl_missing_penultimate_visit_counted(
     patient_data = patients[0]
     assert patient_data["patient_identifier"] == "5555555557"
     # Should use the earlier visit's closed loop value, not the default "No"
+    assert patient_data["hcl"] == "Yes"
+
+
+# ── 2026 dataset treatment fallback tests ─────────────────────────────────────
+# These three tests cover the same "fall back to most recent non-null visit"
+# behaviour as the 2021 tests above, but for the 2026 dataset fields:
+#   treatment        → insulin_regimen
+#   glucose_monitoring → cgm_use  (YES_NO_UNKNOWN)
+#   closed_loop_system → insulin_regimen == 5  (HCL embedded in insulin regimen)
+#
+# They are expected to FAIL until annotate_treatment branches on dataset_year.
+
+
+@pytest.mark.django_db
+def test_insulin_regimen_2026_missing_penultimate_visit_counted(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: when the most recent visit has no insulin_regimen value, the
+    treatment_regimen annotation should fall back to the most recent visit that
+    does have a value.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=10)
+
+    patient = PatientFactory(
+        nhs_number="6666666661",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit WITH insulin_regimen data (4 = "Insulin pump (standalone)")
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        insulin_regimen=INSULIN_TREATMENT[3][0],  # 4 = "Insulin pump (standalone)"
+        treatment=None,
+    )
+
+    # Most recent visit WITHOUT insulin_regimen — earlier value should still be used
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=30),
+        insulin_regimen=None,
+        treatment=None,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": audit_period.slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.TREATMENT.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    patients = response.context["patients"]
+    assert len(patients) == 1
+
+    patient_data = patients[0]
+    assert patient_data["patient_identifier"] == "6666666661"
+    # Should use the earlier visit's insulin_regimen, not "No treatment regimen"
+    assert patient_data["treatment_regimen"] == INSULIN_TREATMENT[3][1]  # "Insulin pump (standalone)"
+
+
+@pytest.mark.django_db
+def test_cgm_use_2026_missing_penultimate_visit_counted(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: when the most recent visit has no cgm_use value, the
+    glucose_monitoring annotation should fall back to the most recent visit that
+    does have a value.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=10)
+
+    patient = PatientFactory(
+        nhs_number="6666666662",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit WITH cgm_use data (1 = "Yes")
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        cgm_use=YES_NO_UNKNOWN[0][0],  # 1 = "Yes"
+        glucose_monitoring=None,
+    )
+
+    # Most recent visit WITHOUT cgm_use — earlier value should still be used
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=30),
+        cgm_use=None,
+        glucose_monitoring=None,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": audit_period.slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.TREATMENT.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    patients = response.context["patients"]
+    assert len(patients) == 1
+
+    patient_data = patients[0]
+    assert patient_data["patient_identifier"] == "6666666662"
+    # Should use the earlier visit's cgm_use, not "No glucose monitoring"
+    assert patient_data["glucose_monitoring"] == YES_NO_UNKNOWN[0][1]  # "Yes"
+
+
+@pytest.mark.django_db
+def test_hcl_from_insulin_regimen_2026_missing_penultimate_visit_counted(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: HCL is encoded as insulin_regimen == 5 ("Hybrid closed loop").
+    When the most recent visit has no insulin_regimen, the hcl annotation should
+    fall back to the most recent visit that does have a value, and derive
+    hcl="Yes" from insulin_regimen==5.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=10)
+
+    patient = PatientFactory(
+        nhs_number="6666666663",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit WITH insulin_regimen == 5 (Hybrid closed loop → hcl = "Yes")
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        insulin_regimen=INSULIN_TREATMENT[4][0],  # 5 = "Hybrid closed loop"
+        treatment=None,
+    )
+
+    # Most recent visit WITHOUT insulin_regimen — earlier value should still be used
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=30),
+        insulin_regimen=None,
+        treatment=None,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": audit_period.slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.TREATMENT.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    patients = response.context["patients"]
+    assert len(patients) == 1
+
+    patient_data = patients[0]
+    assert patient_data["patient_identifier"] == "6666666663"
+    # insulin_regimen == 5 means HCL, should derive hcl = "Yes"
     assert patient_data["hcl"] == "Yes"

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -135,7 +135,7 @@ def test_no_duplicate_patients_in_report(
 
 
 @pytest.mark.django_db
-def _create_outcomes_test_setup(client):
+def _create_outcomes_test_setup(client, audit_period_slug=None):
     """Helper function to create common test setup for outcomes tests."""
     # Login as RCPCH Audit Team user
     ah_rcpch_audit_team_user = NPDAUser.objects.filter(
@@ -145,7 +145,10 @@ def _create_outcomes_test_setup(client):
     client = login_and_verify_user(client, ah_rcpch_audit_team_user)
 
     # Get audit period and ensure it's open
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    if audit_period_slug is not None:
+        audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
+    else:
+        audit_period = AuditPeriod.objects.get_default_audit_period()
     audit_period.is_open = True
     audit_period.save()
 
@@ -165,12 +168,14 @@ def _create_outcomes_test_setup(client):
     return ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_outcomes_no_hba1c_measurements(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
+    audit_period_slug,
 ):
     """
     Test outcomes view for patient with no HbA1c measurements.
@@ -179,7 +184,7 @@ def test_outcomes_no_hba1c_measurements(
     has visits but no HbA1c data recorded.
     """
     ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
-        _create_outcomes_test_setup(client)
+        _create_outcomes_test_setup(client, audit_period_slug)
     )
 
     # Create patient with no HbA1c measurements (T1DM)
@@ -210,7 +215,7 @@ def test_outcomes_no_hba1c_measurements(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -401,9 +406,10 @@ def test_outcomes_multiple_hba1c_measurements(
     assert patient_data["days_delta_between_latest_and_previous_hba1c"] == 10
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_report_for_patients_turning_12_in_audit_year(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -412,7 +418,7 @@ def test_report_for_patients_turning_12_in_audit_year(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -448,7 +454,7 @@ def test_report_for_patients_turning_12_in_audit_year(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -475,7 +481,7 @@ def test_report_for_patients_turning_12_in_audit_year(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -496,9 +502,10 @@ def test_report_for_patients_turning_12_in_audit_year(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1197
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_report_for_sick_day_rules(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -507,7 +514,7 @@ def test_report_for_sick_day_rules(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -542,7 +549,7 @@ def test_report_for_sick_day_rules(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -562,9 +569,10 @@ def test_report_for_sick_day_rules(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1199
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_care_at_diagnosis_for_type_1_patient(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -573,7 +581,7 @@ def test_care_at_diagnosis_for_type_1_patient(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -608,7 +616,7 @@ def test_care_at_diagnosis_for_type_1_patient(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -633,9 +641,10 @@ def test_care_at_diagnosis_for_type_1_patient(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1301
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_carb_counting_countdown_when_no_date_entered(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -644,7 +653,7 @@ def test_carb_counting_countdown_when_no_date_entered(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -676,7 +685,7 @@ def test_carb_counting_countdown_when_no_date_entered(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -696,9 +705,13 @@ def test_carb_counting_countdown_when_no_date_entered(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1301
+# Note: uses 2025-2026 (not 2026-2027) as the second period — these tests derive
+# diagnosis_date from kpi_calculation_date() - N days, so they only work when the
+# period has been running for at least N days. 2025-2026 is always a completed period.
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2025-2026"])
 @pytest.mark.django_db
 def test_coeliac_screening_countdown_when_no_date_entered(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -707,7 +720,7 @@ def test_coeliac_screening_countdown_when_no_date_entered(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -739,7 +752,7 @@ def test_coeliac_screening_countdown_when_no_date_entered(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -759,9 +772,11 @@ def test_coeliac_screening_countdown_when_no_date_entered(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1301
+# Note: uses 2025-2026 (not 2026-2027) — same reason as test_coeliac_screening_countdown.
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2025-2026"])
 @pytest.mark.django_db
 def test_thyroid_screening_overdue_when_threshold_passed(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -770,7 +785,7 @@ def test_thyroid_screening_overdue_when_threshold_passed(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -802,7 +817,7 @@ def test_thyroid_screening_overdue_when_threshold_passed(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -821,9 +836,10 @@ def test_thyroid_screening_overdue_when_threshold_passed(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1301
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -832,7 +848,7 @@ def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -866,7 +882,7 @@ def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -886,9 +902,10 @@ def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1199
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -897,7 +914,7 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -932,7 +949,7 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -947,9 +964,10 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -958,7 +976,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -995,7 +1013,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1015,9 +1033,10 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
 
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1242
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenza_immunisation_recommended(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1026,7 +1045,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1061,7 +1080,7 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1213,9 +1232,10 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
 # Retinal screening tests
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_under_12yo_shows_ineligible(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     """
     Test that patients under 12 years old show as ineligible for retinal screening.
@@ -1228,7 +1248,7 @@ def test_retinal_screening_under_12yo_shows_ineligible(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1286,9 +1306,10 @@ def test_retinal_screening_under_12yo_shows_ineligible(
     assert patient_data["passed_retinal_screening"] == "not_required"
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_with_data_passes(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     """
     Test that patients 12+ years old with valid retinal screening data show as passed.
@@ -1301,7 +1322,7 @@ def test_retinal_screening_over_12yo_with_data_passes(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1359,9 +1380,10 @@ def test_retinal_screening_over_12yo_with_data_passes(
     assert patient_data["passed_retinal_screening"] == "complete"
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_with_data_fails(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     """
     Test that patients 12+ years old who are eligible but don't pass show as failed.
@@ -1374,7 +1396,7 @@ def test_retinal_screening_over_12yo_with_data_fails(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1432,9 +1454,10 @@ def test_retinal_screening_over_12yo_with_data_fails(
     assert patient_data["passed_retinal_screening"] == ""
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_without_data_shows_blank(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
 ):
     """
     Test that patients 12+ years old with NO retinal screening data show as blank.
@@ -1447,7 +1470,7 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -15,10 +15,10 @@ from project.constants.diabetes_treatment import INSULIN_TREATMENT, TREATMENT_TY
 from project.constants.diabetes_types import DIABETES_TYPES
 from project.constants.glucose_monitoring_types import GLUCOSE_MONITORING_TYPES
 from project.constants.hba1c_format import HBA1C_FORMATS
-from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 
 # Python imports
 from project.constants.smoking_status import SMOKING_STATUS, SMOKING_VAPING_STATUS
+from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 from project.npda.general_functions.data_generator_extended import (
     AgeRange,
     FakePatientCreator,
@@ -242,12 +242,21 @@ def test_outcomes_no_hba1c_measurements(
     assert patient_data["days_delta_between_latest_and_previous_hba1c"] is None
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, hba1c_format_val",
+    [
+        ("2024-2025", HBA1C_FORMATS[0][0]),
+        ("2026-2027", None),  # 2026: hba1c_format deprecated, values always mmol/mol
+    ],
+)
 @pytest.mark.django_db
 def test_outcomes_single_hba1c_measurement(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
+    audit_period_slug,
+    hba1c_format_val,
 ):
     """
     Test outcomes view for patient with single HbA1c measurement.
@@ -256,7 +265,7 @@ def test_outcomes_single_hba1c_measurement(
     previous values remain None, and no delta calculations are performed.
     """
     ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
-        _create_outcomes_test_setup(client)
+        _create_outcomes_test_setup(client, audit_period_slug)
     )
 
     # Create patient with single HbA1c measurement (T2DM)
@@ -269,7 +278,7 @@ def test_outcomes_single_hba1c_measurement(
         patient=patient,
         visit_date=AUDIT_START_DATE + relativedelta(days=5),
         hba1c=50,  # 50 mmol/mol
-        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_format=hba1c_format_val,
         hba1c_date=AUDIT_START_DATE + relativedelta(days=5),
     )
 
@@ -287,7 +296,7 @@ def test_outcomes_single_hba1c_measurement(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -316,12 +325,21 @@ def test_outcomes_single_hba1c_measurement(
     assert patient_data["days_delta_between_latest_and_previous_hba1c"] is None
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, hba1c_format_val",
+    [
+        ("2024-2025", HBA1C_FORMATS[0][0]),
+        ("2026-2027", None),  # 2026: hba1c_format deprecated, values always mmol/mol
+    ],
+)
 @pytest.mark.django_db
 def test_outcomes_multiple_hba1c_measurements(
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
     client,
+    audit_period_slug,
+    hba1c_format_val,
 ):
     """
     Test outcomes view for patient with multiple HbA1c measurements.
@@ -331,7 +349,7 @@ def test_outcomes_multiple_hba1c_measurements(
     percentage change between measurements.
     """
     ah_rcpch_audit_team_user, audit_period, AUDIT_START_DATE, eligible_criteria = (
-        _create_outcomes_test_setup(client)
+        _create_outcomes_test_setup(client, audit_period_slug)
     )
 
     # Create patient with multiple HbA1c measurements (Other/MODY)
@@ -345,7 +363,7 @@ def test_outcomes_multiple_hba1c_measurements(
         patient=patient,
         visit_date=AUDIT_START_DATE + relativedelta(days=10),
         hba1c=60,  # 60 mmol/mol
-        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_format=hba1c_format_val,
         hba1c_date=AUDIT_START_DATE + relativedelta(days=10),
     )
     # Latest hba1c
@@ -353,7 +371,7 @@ def test_outcomes_multiple_hba1c_measurements(
         patient=patient,
         visit_date=AUDIT_START_DATE + relativedelta(days=20),
         hba1c=45,  # 45 mmol/mol
-        hba1c_format=HBA1C_FORMATS[0][0],  # mmol/mol format
+        hba1c_format=hba1c_format_val,
         hba1c_date=AUDIT_START_DATE + relativedelta(days=20),
     )
 
@@ -371,7 +389,7 @@ def test_outcomes_multiple_hba1c_measurements(
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -409,7 +427,11 @@ def test_outcomes_multiple_hba1c_measurements(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_report_for_patients_turning_12_in_audit_year(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -505,7 +527,11 @@ def test_report_for_patients_turning_12_in_audit_year(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_report_for_sick_day_rules(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -572,7 +598,11 @@ def test_report_for_sick_day_rules(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_care_at_diagnosis_for_type_1_patient(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -644,7 +674,11 @@ def test_care_at_diagnosis_for_type_1_patient(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_carb_counting_countdown_when_no_date_entered(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -711,7 +745,11 @@ def test_carb_counting_countdown_when_no_date_entered(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2025-2026"])
 @pytest.mark.django_db
 def test_coeliac_screening_countdown_when_no_date_entered(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -776,7 +814,11 @@ def test_coeliac_screening_countdown_when_no_date_entered(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2025-2026"])
 @pytest.mark.django_db
 def test_thyroid_screening_overdue_when_threshold_passed(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -839,7 +881,11 @@ def test_thyroid_screening_overdue_when_threshold_passed(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -905,7 +951,11 @@ def test_coeliac_and_thyroid_screening_on_time_when_dates_present(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -967,7 +1017,11 @@ def test_non_type_1_patients_do_not_appear_in_care_at_diagnosis(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_healthcheck(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1036,7 +1090,11 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_hba1c_he
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenza_immunisation_recommended(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1103,13 +1161,24 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
     [
         ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
-        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+        (
+            "2026-2027",
+            "smoking_vaping_status",
+            SMOKING_VAPING_STATUS[0][0],
+            SMOKING_VAPING_STATUS[1][0],
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screened(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
-    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+    smoking_field,
+    non_smoker_val,
+    smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1175,13 +1244,24 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
     "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
     [
         ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
-        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+        (
+            "2026-2027",
+            "smoking_vaping_status",
+            SMOKING_VAPING_STATUS[0][0],
+            SMOKING_VAPING_STATUS[1][0],
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessation_referral(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
-    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+    smoking_field,
+    non_smoker_val,
+    smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1251,7 +1331,11 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_under_12yo_shows_ineligible(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     """
     Test that patients under 12 years old show as ineligible for retinal screening.
@@ -1325,7 +1409,11 @@ def test_retinal_screening_under_12yo_shows_ineligible(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_with_data_passes(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     """
     Test that patients 12+ years old with valid retinal screening data show as passed.
@@ -1399,7 +1487,11 @@ def test_retinal_screening_over_12yo_with_data_passes(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_with_data_fails(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     """
     Test that patients 12+ years old who are eligible but don't pass show as failed.
@@ -1473,7 +1565,11 @@ def test_retinal_screening_over_12yo_with_data_fails(
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db
 def test_retinal_screening_over_12yo_without_data_shows_blank(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client, audit_period_slug
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
 ):
     """
     Test that patients 12+ years old with NO retinal screening data show as blank.
@@ -1548,13 +1644,24 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
     "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
     [
         ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
-        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+        (
+            "2026-2027",
+            "smoking_vaping_status",
+            SMOKING_VAPING_STATUS[0][0],
+            SMOKING_VAPING_STATUS[1][0],
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row_in_the_patient_report(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
-    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+    smoking_field,
+    non_smoker_val,
+    smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1629,13 +1736,24 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
     "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
     [
         ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
-        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+        (
+            "2026-2027",
+            "smoking_vaping_status",
+            SMOKING_VAPING_STATUS[0][0],
+            SMOKING_VAPING_STATUS[1][0],
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_has_one_row_in_the_patient_report(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
-    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+    smoking_field,
+    non_smoker_val,
+    smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1708,13 +1826,24 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
     "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
     [
         ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
-        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+        (
+            "2026-2027",
+            "smoking_vaping_status",
+            SMOKING_VAPING_STATUS[0][0],
+            SMOKING_VAPING_STATUS[1][0],
+        ),
     ],
 )
 @pytest.mark.django_db
 def test_smoking_cessation_referral_column_denominator_is_smokers_only(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
-    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+    smoking_field,
+    non_smoker_val,
+    smoker_val,
 ):
     """
     The 'Referral to smoking cessation service' column header facet should
@@ -2163,7 +2292,9 @@ def test_insulin_regimen_2026_missing_penultimate_visit_counted(
     patient_data = patients[0]
     assert patient_data["patient_identifier"] == "6666666661"
     # Should use the earlier visit's insulin_regimen, not "No treatment regimen"
-    assert patient_data["treatment_regimen"] == INSULIN_TREATMENT[3][1]  # "Insulin pump (standalone)"
+    assert (
+        patient_data["treatment_regimen"] == INSULIN_TREATMENT[3][1]
+    )  # "Insulin pump (standalone)"
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -18,7 +18,7 @@ from project.constants.hba1c_format import HBA1C_FORMATS
 from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 
 # Python imports
-from project.constants.smoking_status import SMOKING_STATUS
+from project.constants.smoking_status import SMOKING_STATUS, SMOKING_VAPING_STATUS
 from project.npda.general_functions.data_generator_extended import (
     AgeRange,
     FakePatientCreator,
@@ -1099,9 +1099,17 @@ def test_patient_with_incomplete_year_of_care_can_still_show_as_passing_influenz
     assert patient["influenza_immunisation_recommended"] is True
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
+    [
+        ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
+        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+    ],
+)
 @pytest.mark.django_db
 def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screened(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
+    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1110,7 +1118,7 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1128,7 +1136,7 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
     VisitFactory(
         patient=patient,
         visit_date=visit_date,
-        smoking_status=SMOKING_STATUS[0][0],  # non smoker
+        **{smoking_field: non_smoker_val},
     )
 
     submission = Submission.objects.create(
@@ -1144,7 +1152,7 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1163,9 +1171,17 @@ def test_patient_under_12yo_should_show_as_ineligible_for_smoking_status_screene
     assert patient["smoking_status"] is None
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
+    [
+        ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
+        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+    ],
+)
 @pytest.mark.django_db
 def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessation_referral(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
+    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1174,7 +1190,7 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1192,8 +1208,8 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
     VisitFactory(
         patient=patient,
         visit_date=visit_date,
-        smoking_status=SMOKING_STATUS[0][0],  # non smoker
         smoking_cessation_referral_date=None,
+        **{smoking_field: non_smoker_val},
     )
 
     submission = Submission.objects.create(
@@ -1209,7 +1225,7 @@ def test_patient_over_12yo_non_smoker_should_not_be_eligible_for_smoking_cessati
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1528,9 +1544,17 @@ def test_retinal_screening_over_12yo_without_data_shows_blank(
     assert patient_data["passed_retinal_screening"] == ""
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
+    [
+        ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
+        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+    ],
+)
 @pytest.mark.django_db
 def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row_in_the_patient_report(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
+    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1539,7 +1563,7 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1559,14 +1583,14 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
     VisitFactory(
         patient=patient,
         visit_date=visit_date_1,
-        smoking_status=None,
+        **{smoking_field: None},
     )
 
     # Second visit WITH smoking status
     VisitFactory(
         patient=patient,
         visit_date=visit_date_2,
-        smoking_status=SMOKING_STATUS[0][0],  # non smoker
+        **{smoking_field: non_smoker_val},
     )
 
     submission = Submission.objects.create(
@@ -1582,7 +1606,7 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1601,9 +1625,17 @@ def test_patient_with_two_visits_one_with_smoking_status_one_without_has_one_row
     assert patient["smoking_status"] is True  # from the second visit
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
+    [
+        ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
+        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+    ],
+)
 @pytest.mark.django_db
 def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_has_one_row_in_the_patient_report(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
+    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
 ):
     user = NPDAUser.objects.filter(
         organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
@@ -1612,7 +1644,7 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
 
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1632,8 +1664,8 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
     VisitFactory(
         patient=patient,
         visit_date=visit_date_1,
-        smoking_status=SMOKING_STATUS[1][0],  # smoker
         smoking_cessation_referral_date=visit_date_1,
+        **{smoking_field: smoker_val},
     )
 
     # Second visit WITHOUT smoking data
@@ -1652,7 +1684,7 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
     url = reverse(
         "pdu-patient-report",
         kwargs={
-            "audit_period": AuditPeriod.objects.get_default_audit_period().slug,
+            "audit_period": audit_period.slug,
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
@@ -1672,9 +1704,17 @@ def test_smoker_with_two_visits_one_with_smoking_cessation_referral_one_without_
     assert patient["smoking_cessation_referral"] == "True"  # from the first visit
 
 
+@pytest.mark.parametrize(
+    "audit_period_slug, smoking_field, non_smoker_val, smoker_val",
+    [
+        ("2024-2025", "smoking_status", SMOKING_STATUS[0][0], SMOKING_STATUS[1][0]),
+        ("2026-2027", "smoking_vaping_status", SMOKING_VAPING_STATUS[0][0], SMOKING_VAPING_STATUS[1][0]),
+    ],
+)
 @pytest.mark.django_db
 def test_smoking_cessation_referral_column_denominator_is_smokers_only(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client,
+    audit_period_slug, smoking_field, non_smoker_val, smoker_val,
 ):
     """
     The 'Referral to smoking cessation service' column header facet should
@@ -1697,7 +1737,7 @@ def test_smoking_cessation_referral_column_denominator_is_smokers_only(
     ).first()
     client = login_and_verify_user(client, user)
 
-    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
     audit_period.is_open = True
     audit_period.save()
 
@@ -1721,8 +1761,8 @@ def test_smoking_cessation_referral_column_denominator_is_smokers_only(
         patient=patient_smoker_referred,
         visit_date=start + relativedelta(days=10),
         height_weight_observation_date=start + relativedelta(days=10),
-        smoking_status=SMOKING_STATUS[1][0],  # current smoker
         smoking_cessation_referral_date=start + relativedelta(days=10),
+        **{smoking_field: smoker_val},
     )
 
     # ≥12 yo, smoker, no cessation referral → should FAIL (still in denominator)
@@ -1735,8 +1775,8 @@ def test_smoking_cessation_referral_column_denominator_is_smokers_only(
         patient=patient_smoker_no_ref,
         visit_date=start + relativedelta(days=10),
         height_weight_observation_date=start + relativedelta(days=10),
-        smoking_status=SMOKING_STATUS[1][0],  # current smoker
         smoking_cessation_referral_date=None,
+        **{smoking_field: smoker_val},
     )
 
     # ≥12 yo, non-smoker → NOT required, must NOT be counted in denominator
@@ -1748,8 +1788,8 @@ def test_smoking_cessation_referral_column_denominator_is_smokers_only(
     VisitFactory(
         patient=patient_non_smoker,
         visit_date=start + relativedelta(days=10),
-        smoking_status=SMOKING_STATUS[0][0],  # non-smoker
         smoking_cessation_referral_date=None,
+        **{smoking_field: non_smoker_val},
     )
 
     # <12 yo → NOT required (age), must NOT be counted in denominator

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -48,6 +48,18 @@ Note: Excludes Retinal Screening, which only needs to be completed every 2 years
 
 Note retinal screening is counted only every 2 years (see issue #1285) and only apply to patients over 12y who have more than 1 of diabetes.
 
+**Dataset field mapping — unchanged between 2021 and 2026:**
+
+| Column | Model field | Notes |
+|--------|-------------|-------|
+| HbA1c | `hba1c` + `hba1c_date` | Both datasets |
+| BMI | `bmi` + `height_weight_observation_date` | Both datasets |
+| Thyroid screen | `thyroid_function_date` | Both datasets |
+| Blood pressure | `systolic_blood_pressure` + `blood_pressure_observation_date` | Both datasets; ≥12 only |
+| Urinary albumin | `albumin_creatinine_ratio` + `albumin_creatinine_ratio_date` | Both datasets; ≥12 only |
+| Foot exam | `foot_examination_observation_date` | Both datasets; ≥12 only |
+| Eye screen | `retinal_screening_observation_date` + `retinal_screening_result` | Both datasets; ≥12, dx >1y, biannual |
+
 ### Additional Care Processes
 
 - NHS Number
@@ -60,12 +72,21 @@ Note retinal screening is counted only every 2 years (see issue #1285) and only 
 - Influenza immunisation recommended
 - Sick day rules advice
 
-These measures are all scored with flags, as in the Health Checks category. HbA1c 4+ reflects if a patient has had 4 HbA1c values (and associated date) within the audit period to get a complete. Incomplete is otherwise scored unless the patient has an incomplete year of care. Note that smoking status screened and referral to smoking status are only scored in children >= 12y. Smoking status is incomplete if they are scored as a smoker but a referral date is not provided. 
+These measures are all scored with flags, as in the Health Checks category. HbA1c 4+ reflects if a patient has had 4 HbA1c values (and associated date) within the audit period to get a complete. Incomplete is otherwise scored unless the patient has an incomplete year of care. Note that smoking status screened and referral to smoking status are only scored in children >= 12y. Smoking status is incomplete if they are scored as a smoker but a referral date is not provided.
 
-In the 2026 dataset changes include:
+**Dataset field mapping:**
 
-- smoking status is changed to Does the patient smoke and/or vape.
-- Following annual psychological screening, was the patient assessed as requiring additional psychological support outside of routine care? has been added
+| Column | 2021 field | 2026 field | Notes |
+|--------|------------|------------|-------|
+| HbA1c 4+ | `hba1c` + `hba1c_date` | same | Both datasets |
+| Psychological assessment | `psychological_screening_assessment_date` | same | Both datasets |
+| Smoking status screened | `smoking_status` (1=non-smoker, 2=smoker) | `smoking_vaping_status` (same integer values) | ≥12 only |
+| Referral to smoking cessation | `smoking_cessation_referral_date` (when smoker) | same field, same logic | ≥12, smokers only |
+| Additional dietetic appt offered | `dietician_additional_appointment_offered` | same | Both datasets |
+| Patients attending additional dietetic appt | `dietician_additional_appointment_date` | same | Both datasets |
+| Influenza immunisation | `flu_immunisation_recommended_date` | same | Both datasets |
+| Sick day rules advice | `sick_day_rules_training_date` | same | Both datasets |
+| Psychological support outcome | *(absent)* | `psychological_support_outcome` | 2026 only — new column |
 
 ### Care at Diagnosis
 
@@ -86,6 +107,14 @@ The same methodology applies to carbohydrate counting, though the threshold is 1
 - [ ] It is preferable for there to be an extra column here with a countdown in days til this measure is due. (see issue #1301)
 - [ ] It is also preferable that carbohydrate counting, coeliac and thyroid screening that are incomplete (that is where there is a date but not within the time frame) are rather labelled as 'missed' than 'incomplete'. (see issue #1301)
 
+**Dataset field mapping — unchanged between 2021 and 2026:**
+
+| Column | Model field | Notes |
+|--------|-------------|-------|
+| Carbohydrate counting | `carbohydrate_counting_level_three_education_date` | Both datasets; within 14 days of diagnosis |
+| Coeliac screening | `coeliac_screen_date` | Both datasets; within 90 days of diagnosis |
+| Thyroid screening | `thyroid_function_date` | Both datasets; within 90 days of diagnosis |
+
 ### Admissions
 
 - NHS Number
@@ -96,21 +125,28 @@ The same methodology applies to carbohydrate counting, though the threshold is 1
 
 This category relates only to patients that have had a hospital admission during the audit period, but excluding the first 90 days after diagnosis. There are no flags as seen in Health Checks, only the values listed. The counts are totals during the audit period.
 
-In 2026 there are two extra fields here:
+**Dataset field mapping:**
 
-- Initial pH at admission
-- Initial Standard bicarbonate at admission (mmol/l)
+| Column | 2021 field | 2026 field | Notes |
+|--------|------------|------------|-------|
+| Number of admissions | `hospital_admission_date` / `hospital_admission_reason` | same | Both datasets |
+| Number of DKA admissions | `hospital_admission_reason` (DKA value) | same | Both datasets |
+| Initial pH at admission | *(absent)* | `blood_gas_ph` | 2026 only; display value from DKA visit |
+| Initial bicarbonate at admission | *(absent)* | `blood_gas_bicarbonate` | 2026 only; display value from DKA visit |
 
 ### Treatment
 
-- NHS Number
-- Treatment regimen
-- Glucose monitoring
-- HCL (hybrid closed loop)
+This reflects what treatment the patient is currently on. Note that measures here are not scored with flags, but reflect the most recent visit in the audit period where each field is not null. This means that if a patient's latest visit has no entry for a field, the system looks back to the most recent earlier visit where that field was recorded.
 
-This reflects what treatment the patient is currently on. Note that measures here are not scored with flags, but reflect the most recent visit in the audit period where each field is not null. This means that if a patient's latest visit has no entry for treatment regimen, glucose monitoring, or HCL, the system looks back to the most recent earlier visit where that field was recorded. HCL (hybrid closed loop) is either a yes or a no. Glucose monitoring.
+**Dataset field mapping:**
 
-Note the headings for these columns change between 2021 and 2026.
+| Column | 2021 field | 2026 field | Notes |
+|--------|------------|------------|-------|
+| Treatment regimen | `treatment` (`TREATMENT_TYPES`) | `insulin_regimen` (`INSULIN_TREATMENT`) | Different constants |
+| Glucose monitoring | `glucose_monitoring` (`GLUCOSE_MONITORING_TYPES`) | `cgm_use` (`YES_NO_UNKNOWN`) | 2026 is a simpler yes/no/unknown |
+| HCL (hybrid closed loop) | `closed_loop_system in [2,3,4]` → "Yes" | `insulin_regimen == 5` → "Yes" | In 2026 HCL is encoded in the insulin regimen |
+| Non-insulin medication | *(absent)* | `non_insulin_medication` (`NON_INSULIN_TREATMENT`) | 2026 only — new column |
+| Dietary/lifestyle modification | *(absent)* | `dietary_lifestyle_modification` (`YES_NO_UNKNOWN`) | 2026 only — new column |
 
 ### Outcomes
 
@@ -122,6 +158,12 @@ Note the headings for these columns change between 2021 and 2026.
 - Mean HbA1c mmol/mol (%)
 
 This shows the mean and median HbA1c (both as IFCC and DCCT) of all visit HbA1cs in the audit period. The % change reflects the % change in the absolute value of the most recent from the penultimate HbA1c measured as either a positive or negative value, rounded to an integer. Negative is rendered green, positive is rendered amber.
+
+**Dataset field mapping:**
+
+| Column | 2021 field | 2026 field | Notes |
+|--------|------------|------------|-------|
+| All HbA1c values | `hba1c` + `hba1c_format` + `hba1c_date` | `hba1c` + `hba1c_date` | In 2026 `hba1c_format` is deprecated; values are always mmol/mol. Queries must not rely on `hba1c_format` being non-null for 2026 data. |
 
 ## Shortcomings of the current methodology
 

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -260,10 +260,10 @@ This should involve:
 
 ##### Treatment
 
-- Use the latest visit in the audit period to derive:
-   - Treatment regimen
-   - Glucose monitoring
-   - HCL (hybrid closed loop)
+- Use the latest `EXISTS` visit in the audit period to derive:
+  - Treatment regimen
+  - Glucose monitoring
+  - HCL (hybrid closed loop)
 - Column headings vary by audit period; apply conditional labeling by audit period year.
 
 ##### Outcomes

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -435,25 +435,37 @@ class PatientReportView(
             complete_year = qs.filter(is_complete_year_of_care=True)
             complete_year_12plus = complete_year.filter(is_gte_12yo=True)
 
-            context["total_passed_hba1c"] = complete_year.filter(passed_hba1c=True).count()
+            context["total_passed_hba1c"] = complete_year.filter(
+                passed_hba1c=True
+            ).count()
             context["total_eligible_hba1c"] = complete_year.count()
 
             context["total_passed_bmi"] = complete_year.filter(passed_bmi=True).count()
             context["total_eligible_bmi"] = complete_year.count()
 
-            context["total_passed_thyroid_screen"] = complete_year.filter(passed_thyroid_screen=True).count()
+            context["total_passed_thyroid_screen"] = complete_year.filter(
+                passed_thyroid_screen=True
+            ).count()
             context["total_eligible_thyroid_screen"] = complete_year.count()
 
-            context["total_passed_blood_pressure"] = complete_year_12plus.filter(passed_blood_pressure=True).count()
+            context["total_passed_blood_pressure"] = complete_year_12plus.filter(
+                passed_blood_pressure=True
+            ).count()
             context["total_eligible_blood_pressure"] = complete_year_12plus.count()
 
-            context["total_passed_urinary_albumin"] = complete_year_12plus.filter(passed_urinary_albumin=True).count()
+            context["total_passed_urinary_albumin"] = complete_year_12plus.filter(
+                passed_urinary_albumin=True
+            ).count()
             context["total_eligible_urinary_albumin"] = complete_year_12plus.count()
 
-            context["total_passed_foot_exam"] = complete_year_12plus.filter(passed_foot_exam=True).count()
+            context["total_passed_foot_exam"] = complete_year_12plus.filter(
+                passed_foot_exam=True
+            ).count()
             context["total_eligible_foot_exam"] = complete_year_12plus.count()
 
-            context["total_passed_retinal_screening"] = complete_year.filter(passed_retinal_screening="complete").count()
+            context["total_passed_retinal_screening"] = complete_year.filter(
+                passed_retinal_screening="complete"
+            ).count()
             context["total_eligible_retinal_screening"] = complete_year.count()
 
         elif self.selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
@@ -473,29 +485,57 @@ class PatientReportView(
                 smoking_cessation_referral__in=["True", "False"]
             )
 
-            context["total_passed_hba1c_4plus"] = complete_year.filter(hba1c_4plus=True).count()
+            context["total_passed_hba1c_4plus"] = complete_year.filter(
+                hba1c_4plus=True
+            ).count()
             context["total_eligible_hba1c_4plus"] = complete_year.count()
 
-            context["total_passed_psychological_assessment"] = complete_year.filter(psychological_assessment=True).count()
+            context["total_passed_psychological_assessment"] = complete_year.filter(
+                psychological_assessment=True
+            ).count()
             context["total_eligible_psychological_assessment"] = complete_year.count()
 
-            context["total_passed_additional_dietetic_appt_offered"] = complete_year.filter(additional_dietetic_appt_offered=True).count()
-            context["total_eligible_additional_dietetic_appt_offered"] = complete_year.count()
+            context["total_passed_additional_dietetic_appt_offered"] = (
+                complete_year.filter(additional_dietetic_appt_offered=True).count()
+            )
+            context["total_eligible_additional_dietetic_appt_offered"] = (
+                complete_year.count()
+            )
 
-            context["total_passed_pts_attending_additional_dietetic_appt"] = complete_year.filter(pts_attending_additional_dietetic_appt=True).count()
-            context["total_eligible_pts_attending_additional_dietetic_appt"] = complete_year.count()
+            context["total_passed_pts_attending_additional_dietetic_appt"] = (
+                complete_year.filter(
+                    pts_attending_additional_dietetic_appt=True
+                ).count()
+            )
+            context["total_eligible_pts_attending_additional_dietetic_appt"] = (
+                complete_year.count()
+            )
 
-            context["total_passed_influenza_immunisation_recommended"] = complete_year.filter(influenza_immunisation_recommended=True).count()
-            context["total_eligible_influenza_immunisation_recommended"] = complete_year.count()
+            context["total_passed_influenza_immunisation_recommended"] = (
+                complete_year.filter(influenza_immunisation_recommended=True).count()
+            )
+            context["total_eligible_influenza_immunisation_recommended"] = (
+                complete_year.count()
+            )
 
-            context["total_passed_sick_day_rules_advice"] = complete_year.filter(sick_day_rules_advice=True).count()
+            context["total_passed_sick_day_rules_advice"] = complete_year.filter(
+                sick_day_rules_advice=True
+            ).count()
             context["total_eligible_sick_day_rules_advice"] = complete_year.count()
 
-            context["total_passed_smoking_status"] = complete_year_12plus.filter(smoking_status=True).count()
+            context["total_passed_smoking_status"] = complete_year_12plus.filter(
+                smoking_status=True
+            ).count()
             context["total_eligible_smoking_status"] = complete_year_12plus.count()
 
-            context["total_passed_smoking_cessation_referral"] = complete_year_smokers_12plus.filter(smoking_cessation_referral="True").count()
-            context["total_eligible_smoking_cessation_referral"] = complete_year_smokers_12plus.count()
+            context["total_passed_smoking_cessation_referral"] = (
+                complete_year_smokers_12plus.filter(
+                    smoking_cessation_referral="True"
+                ).count()
+            )
+            context["total_eligible_smoking_cessation_referral"] = (
+                complete_year_smokers_12plus.count()
+            )
 
         context["breadcrumbs"] = data_breadcrumbs(
             self.pdu, self.audit_period, [("Patient Report", "pdu-patient-report")]

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -138,7 +138,6 @@ class TableCategories(Enum):
 def calculate_queryset(
     pdu, audit_period: AuditPeriod, selected_category: str
 ) -> QuerySet[Patient]:
-    pz_code = pdu.pz_code
     base_qs = patient_report_queries.build_base_queryset(pdu, audit_period)
     patient_identifier = patient_report_queries._patient_identifier_field(pdu)
 

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from enum import Enum
 
 import pandas as pd
-from dateutil.relativedelta import relativedelta
 from django.db.models import QuerySet
 
 # Django imports
@@ -16,7 +15,6 @@ from project.npda.general_functions.breadcrumbs import data_breadcrumbs
 from project.npda.general_functions.patient_report import (
     queries as patient_report_queries,
 )
-from project.npda.kpi_class.kpis import CalculateKPIS
 from project.npda.models import AuditPeriod, Patient
 from project.npda.views.decorators import check_data_permissions, login_and_otp_required
 from project.npda.views.mixins import LoginAndOTPRequiredMixin, PDUPermissionMixin
@@ -141,14 +139,6 @@ def calculate_queryset(
     pdu, audit_period: AuditPeriod, selected_category: str
 ) -> QuerySet[Patient]:
     pz_code = pdu.pz_code
-    calculation_date = audit_period.kpi_calculation_date()
-
-    calculate_kpis = CalculateKPIS(
-        calculation_date=calculation_date,
-        return_pt_querysets=True,
-        is_jersey=pz_code == "PZ248",
-    )
-    calculate_kpis.set_patients_for_calculation(pz_codes=[pz_code])
     base_qs = patient_report_queries.build_base_queryset(pdu, audit_period)
     patient_identifier = patient_report_queries._patient_identifier_field(pdu)
 
@@ -182,7 +172,7 @@ def calculate_queryset(
                 "latest_retinal_screening_date",
             )
         )
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     if selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
         pt_qs = (
@@ -216,7 +206,7 @@ def calculate_queryset(
                 "sick_day_rules_advice",
             )
         )
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     if selected_category == TableCategories.CARE_AT_DIAGNOSIS.value:
         pt_qs = (
@@ -236,7 +226,7 @@ def calculate_queryset(
                 "carbohydrate_counting_education",
             )
         )
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     if selected_category == TableCategories.ADMISSIONS.value:
         pt_qs = patient_report_queries.annotate_admissions(
@@ -249,7 +239,7 @@ def calculate_queryset(
             "number_of_dka_admissions",
         )
         pt_qs = patient_report_queries.calculate_hba1c_values(pt_qs, audit_period)
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     if selected_category == TableCategories.TREATMENT.value:
         pt_qs = patient_report_queries.annotate_treatment(base_qs, audit_period).values(
@@ -260,7 +250,7 @@ def calculate_queryset(
             "glucose_monitoring",
             "hcl",
         )
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     if selected_category == TableCategories.OUTCOMES.value:
         outcomes_qs = patient_report_queries.build_base_queryset(
@@ -281,7 +271,7 @@ def calculate_queryset(
             "previous_to_latest_hba1c_date",
             "days_delta_between_latest_and_previous_hba1c",
         )
-        return pt_qs, calculate_kpis, patient_identifier
+        return pt_qs, patient_identifier
 
     raise ValueError(f"Unknown category: {selected_category}")
 
@@ -310,12 +300,9 @@ class PatientReportView(
         self.selected_category = category
         pz_code = self.pdu.pz_code
 
-        pt_qs, calculate_kpis, patient_identifier = calculate_queryset(
+        pt_qs, patient_identifier = calculate_queryset(
             self.pdu, self.audit_period, category
         )
-
-        # Save to use later in get_context_data
-        self.calculate_kpis = calculate_kpis
 
         allowed_sort_fields = {
             TableCategories.HEALTH_CHECKS.value: {
@@ -444,62 +431,30 @@ class PatientReportView(
                 "thyroid_screen": "Not required as within 1 year of diagnosis",
             }
 
-            def get_patient_ids_and_count(**kwargs):
-                patient_queryset = self.object_list.filter(**kwargs)
-                return (
-                    patient_queryset.values_list("pk", flat=True),
-                    patient_queryset.count(),
-                )
+            qs = self.object_list
+            complete_year = qs.filter(is_complete_year_of_care=True)
+            complete_year_12plus = complete_year.filter(is_gte_12yo=True)
 
-            def add_kpi_total(
-                context, kpi_name, kpi_result, patient_ids, patient_count
-            ):
-                context[f"total_passed_{kpi_name}"] = (
-                    kpi_result.patient_querysets["passed"]
-                    .filter(pk__in=patient_ids)
-                    .count()
-                )
-                context[f"total_eligible_{kpi_name}"] = patient_count
+            context["total_passed_hba1c"] = complete_year.filter(passed_hba1c=True).count()
+            context["total_eligible_hba1c"] = complete_year.count()
 
-            complete_year = get_patient_ids_and_count(is_complete_year_of_care=True)
+            context["total_passed_bmi"] = complete_year.filter(passed_bmi=True).count()
+            context["total_eligible_bmi"] = complete_year.count()
 
-            # For age-specific checks (12+ years old at start of audit period)
-            complete_year_12plus = get_patient_ids_and_count(
-                is_complete_year_of_care=True,
-                date_of_birth__lte=self.audit_period.start_date
-                - relativedelta(years=12),
-            )
+            context["total_passed_thyroid_screen"] = complete_year.filter(passed_thyroid_screen=True).count()
+            context["total_eligible_thyroid_screen"] = complete_year.count()
 
-            for kpi_name, kpi_result, (patient_ids, patient_count) in [
-                ("hba1c", self.calculate_kpis.calculate_kpi_25_hba1c(), complete_year),
-                ("bmi", self.calculate_kpis.calculate_kpi_26_bmi(), complete_year),
-                (
-                    "thyroid_screen",
-                    self.calculate_kpis.calculate_kpi_27_thyroid_screen(),
-                    complete_year,
-                ),
-                (
-                    "blood_pressure",
-                    self.calculate_kpis.calculate_kpi_28_blood_pressure(),
-                    complete_year_12plus,
-                ),
-                (
-                    "urinary_albumin",
-                    self.calculate_kpis.calculate_kpi_29_urinary_albumin(),
-                    complete_year_12plus,
-                ),
-                (
-                    "foot_exam",
-                    self.calculate_kpis.calculate_kpi_31_foot_examination(),
-                    complete_year_12plus,
-                ),
-                (
-                    "retinal_screening",
-                    self.calculate_kpis.calculate_kpi_30_retinal_screening(),
-                    complete_year,
-                ),
-            ]:
-                add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count)
+            context["total_passed_blood_pressure"] = complete_year_12plus.filter(passed_blood_pressure=True).count()
+            context["total_eligible_blood_pressure"] = complete_year_12plus.count()
+
+            context["total_passed_urinary_albumin"] = complete_year_12plus.filter(passed_urinary_albumin=True).count()
+            context["total_eligible_urinary_albumin"] = complete_year_12plus.count()
+
+            context["total_passed_foot_exam"] = complete_year_12plus.filter(passed_foot_exam=True).count()
+            context["total_eligible_foot_exam"] = complete_year_12plus.count()
+
+            context["total_passed_retinal_screening"] = complete_year.filter(passed_retinal_screening="complete").count()
+            context["total_eligible_retinal_screening"] = complete_year.count()
 
         elif self.selected_category == TableCategories.ADDITIONAL_CARE_PROCESSES.value:
             context["ineligible_reasons"] = {
@@ -510,84 +465,37 @@ class PatientReportView(
                 },
             }
 
-            def get_patient_ids_and_count(**kwargs):
-                patient_queryset = self.object_list.filter(**kwargs)
-                return (
-                    patient_queryset.values_list("pk", flat=True),
-                    patient_queryset.count(),
-                )
-
-            def add_kpi_total(
-                context, kpi_name, kpi_result, patient_ids, patient_count
-            ):
-                context[f"total_passed_{kpi_name}"] = (
-                    kpi_result.patient_querysets["passed"]
-                    .filter(pk__in=patient_ids)
-                    .count()
-                )
-                context[f"total_eligible_{kpi_name}"] = patient_count
-
-            complete_year = get_patient_ids_and_count(is_complete_year_of_care=True)
-
-            # For age-specific checks (12+ years old at start of audit period)
-            complete_year_12plus = get_patient_ids_and_count(
-                is_complete_year_of_care=True,
-                date_of_birth__lte=self.audit_period.start_date
-                - relativedelta(years=12),
+            qs = self.object_list
+            complete_year = qs.filter(is_complete_year_of_care=True)
+            complete_year_12plus = complete_year.filter(is_gte_12yo=True)
+            # Smokers ≥12: "True" = referred, "False" = eligible but not referred
+            complete_year_smokers_12plus = complete_year_12plus.filter(
+                smoking_cessation_referral__in=["True", "False"]
             )
 
-            # Smoking cessation denominator: only smokers ≥12 (non-smokers are
-            # "not required" and must not inflate the column header count)
-            complete_year_smokers_12plus = get_patient_ids_and_count(
-                is_complete_year_of_care=True,
-                date_of_birth__lte=self.audit_period.start_date
-                - relativedelta(years=12),
-                smoking_cessation_referral__in=["True", "False"],
-            )
+            context["total_passed_hba1c_4plus"] = complete_year.filter(hba1c_4plus=True).count()
+            context["total_eligible_hba1c_4plus"] = complete_year.count()
 
-            for kpi_name, kpi_result, (patient_ids, patient_count) in [
-                (
-                    "hba1c_4plus",
-                    self.calculate_kpis.calculate_kpi_33_hba1c_4plus(),
-                    complete_year,
-                ),
-                (
-                    "psychological_assessment",
-                    self.calculate_kpis.calculate_kpi_34_psychological_assessment(),
-                    complete_year,
-                ),
-                (
-                    "additional_dietetic_appt_offered",
-                    self.calculate_kpis.calculate_kpi_37_additional_dietetic_appointment_offered(),
-                    complete_year,
-                ),
-                (
-                    "pts_attending_additional_dietetic_appt",
-                    self.calculate_kpis.calculate_kpi_38_patients_attending_additional_dietetic_appointment(),
-                    complete_year,
-                ),
-                (
-                    "influenza_immunisation_recommended",
-                    self.calculate_kpis.calculate_kpi_39_influenza_immunisation_recommended(),
-                    complete_year,
-                ),
-                (
-                    "sick_day_rules_advice",
-                    self.calculate_kpis.calculate_kpi_40_sick_day_rules_advice(),
-                    complete_year,
-                ),
-                (
-                    "smoking_status",
-                    self.calculate_kpis.calculate_kpi_35_smoking_status_screened(),
-                    complete_year_12plus,
-                ),
-                (
-                    "smoking_cessation_referral",
-                    self.calculate_kpis.calculate_kpi_36_referral_to_smoking_cessation_service(),
-                    complete_year_smokers_12plus,
-                ),
-            ]:
-                add_kpi_total(context, kpi_name, kpi_result, patient_ids, patient_count)
+            context["total_passed_psychological_assessment"] = complete_year.filter(psychological_assessment=True).count()
+            context["total_eligible_psychological_assessment"] = complete_year.count()
+
+            context["total_passed_additional_dietetic_appt_offered"] = complete_year.filter(additional_dietetic_appt_offered=True).count()
+            context["total_eligible_additional_dietetic_appt_offered"] = complete_year.count()
+
+            context["total_passed_pts_attending_additional_dietetic_appt"] = complete_year.filter(pts_attending_additional_dietetic_appt=True).count()
+            context["total_eligible_pts_attending_additional_dietetic_appt"] = complete_year.count()
+
+            context["total_passed_influenza_immunisation_recommended"] = complete_year.filter(influenza_immunisation_recommended=True).count()
+            context["total_eligible_influenza_immunisation_recommended"] = complete_year.count()
+
+            context["total_passed_sick_day_rules_advice"] = complete_year.filter(sick_day_rules_advice=True).count()
+            context["total_eligible_sick_day_rules_advice"] = complete_year.count()
+
+            context["total_passed_smoking_status"] = complete_year_12plus.filter(smoking_status=True).count()
+            context["total_eligible_smoking_status"] = complete_year_12plus.count()
+
+            context["total_passed_smoking_cessation_referral"] = complete_year_smokers_12plus.filter(smoking_cessation_referral="True").count()
+            context["total_eligible_smoking_cessation_referral"] = complete_year_smokers_12plus.count()
 
         context["breadcrumbs"] = data_breadcrumbs(
             self.pdu, self.audit_period, [("Patient Report", "pdu-patient-report")]


### PR DESCRIPTION
## Patient report: 2026 dataset support + KPI class refactor

In addition to the items below this PR also adds a new `agents.md` document which we should build over time. This reduces the exploration time any agents need to navigate the code base.

### Summary

This PR makes the patient report fully aware of the 2026 dataset, where several fields were renamed or deprecated. It also removes a significant source of redundant database queries by eliminating the `CalculateKPIS` class from the patient report view, and adds tests proving that incomplete-year patients are correctly excluded from column header totals.

All changes were developed test-first (TDD): RED tests were written and committed before each fix, so every commit in the history documents the failing state before the implementation.

---

### Background: 2026 dataset field changes

The 2026 dataset (audit periods starting on or after 2026-04-01) introduces breaking changes to several `Visit` model fields:

| Area | 2021 field | 2026 field |
|---|---|---|
| Treatment regimen | `treatment` | `insulin_regimen` |
| Glucose monitoring | `glucose_monitoring` | `cgm_use` |
| Smoking/vaping status | `smoking_status` | `smoking_vaping_status` |
| HbA1c format | `hba1c_format` (mmol/mol or %) | deprecated — always mmol/mol |

The dataset year is determined by `audit_period.get_dataset_year()`, which returns `2026` if `start_date >= 2026-04-01`, otherwise `2021`.

---

### Changes

#### `project/npda/general_functions/patient_report/queries.py`

**`annotate_treatment`** — branched on `dataset_year`:
- 2026: uses `insulin_regimen` (labels from `INSULIN_TREATMENT`), `cgm_use` (labels from `YES_NO_UNKNOWN`), and `insulin_regimen == 5` for hybrid closed loop detection
- 2021: unchanged — uses `treatment`, `glucose_monitoring`, `closed_loop_system`

**`annotate_additional_care_processes`** — smoking subqueries branched on `dataset_year`:
- 2026: `smoking_vaping_status__in=[1, 2, 3, 4]` for screened; `__in=[2, 4]` for smoker (values 2 = smoker/non-vaper, 4 = smoker+vaper)
- 2021: unchanged — `smoking_status__in=[1, 2]` / `== 2`

**`annotate_outcomes`** — HbA1c subqueries branched on `dataset_year`:
- 2026: `hba1c_format` is deprecated; all values stored as mmol/mol, so `hba1c_mmol_mol=F("hba1c")` directly. The previous `Case` expression fell to `default=None` when `hba1c_format` was null, making all outcome values null.
- 2021: unchanged — format-aware `Case` converting % → mmol/mol where needed

#### `project/npda/kpi_class/kpis.py`

**`_calculate_kpi_36_referral_to_smoking_cessation_service`** — smoker filter branched on `self.audit_start_date`:
- 2026: `smoking_vaping_status__in=[2, 4]`
- 2021: `smoking_status=2`

This keeps the KPI dashboard correct for 2026 audit periods (this method is still used for PDU-level KPI calculations outside the patient report).

#### `project/npda/views/patient_report/patient_report.py`

**Removed `CalculateKPIS` from the patient report view entirely.**

Previously, the view instantiated `CalculateKPIS` on every page load and called 15 separate KPI methods (7 for Health Checks, 8 for Additional Care Processes) to derive column header totals. This was redundant: `annotate_health_checks` and `annotate_additional_care_processes` in `queries.py` already annotate every patient row with the same pass/fail information.

Replaced with direct `filter(annotation=True).count()` aggregates on `self.object_list`:

```python
# Before (per metric, ×15):
kpi_result = self.calculate_kpis.calculate_kpi_25_hba1c()
context["total_passed_hba1c"] = (
    kpi_result.patient_querysets["passed"].filter(pk__in=patient_ids).count()
)

# After:
context["total_passed_hba1c"] = complete_year.filter(passed_hba1c=True).count()
context["total_eligible_hba1c"] = complete_year.count()
```

Benefits:
- Eliminates ~15 redundant DB queries per patient report page load
- Removes `CalculateKPIS` instantiation overhead (`return_pt_querysets=True` caused heavy queryset materialisation)
- Removes the `date_of_birth__lte` age cutoff duplication — `is_gte_12yo` annotation from the base queryset is used directly instead
- Removes the `relativedelta` import (no longer needed in the view)
- Makes the 2026 dataset support automatic — the annotations already branch correctly, so no further changes are needed in the view layer

No template changes, no context key renames.

---

### Tests

**`project/npda/tests/view_tests/test_patient_report.py`**

All existing tests were parametrised to run against both `2024-2025` (2021 dataset) and `2026-2027` (2026 dataset) audit periods:

- 15 year-agnostic tests now run against both dataset years
- 5 smoking tests parametrised with `(audit_period_slug, smoking_field, non_smoker_val, smoker_val)` — dynamically sets `smoking_status` or `smoking_vaping_status` via `**{smoking_field: val}`
- 2 outcomes HbA1c tests parametrised with `(audit_period_slug, hba1c_format_val)` — `hba1c_format_val=None` for 2026

Two new tests added to document and prove incomplete-year patient exclusion from totals:

- `test_incomplete_year_patient_diagnosed_in_audit_year_excluded_from_totals` — patient diagnosed within the audit year (`is_complete_year_of_care=False`) appears in the row list but is excluded from `total_eligible_*` and `total_passed_*`
- `test_incomplete_year_patient_transferred_out_excluded_from_totals` — same for a patient who transferred out during the audit year

Both run against `2024-2025` and `2026-2027`.

**Final test count: 56 passing, 0 failing.**

---

### Commits

| Commit | Description |
|---|---|
| `41e4815c` | test: RED — 2026 treatment fallback tests (step 1) |
| `5ee70824` | test: parametrise 15 year-agnostic tests for both dataset years (step 2) |
| `e45e855a` | test: parametrise smoking tests for 2026 dataset (step 3) |
| `1b78b2a5` | test: RED — 2026 outcomes HbA1c tests (step 4) |
| `15df5b50` | fix: `annotate_treatment` branched for 2026 dataset (step 5) |
| `0c4dbcc2` | fix: smoking fields use `smoking_vaping_status` for 2026 in queries + kpis (step 6) |
| `5af074e1` | refactor: replace KPI class with direct annotation counts in patient report view |
| `fa45446c` | fix: `annotate_outcomes` uses `F("hba1c")` directly for 2026 dataset (step 7) |
| `2a2052e5` | test: verify incomplete-year patients excluded from column header totals |