### PR TITLE
Case insensitive ethnic category

### DIFF
--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -5,7 +5,7 @@ import unicodedata
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-from project.constants import get_all_dates, ETHNICITIES
+from project.constants import ETHNICITIES, get_all_dates
 from project.npda.general_functions.headings import get_field_heading
 
 """
@@ -39,7 +39,7 @@ def clean_csv_ethnicity(value):
 
         if value in ETHNICITIES:
             return value
-    
+
     return value
 
 
@@ -92,6 +92,7 @@ def clean_date_value(v):
     s = re.sub(r"\s+", " ", s)
     return s
 
+
 # Helper normalisation to robustly match noisy incoming headings
 def normalise_heading(s: str) -> str:
     if not isinstance(s, str):
@@ -110,12 +111,12 @@ def csv_clean(df, dataset_year=2021):
             df[date_col] = pd.to_datetime(
                 cleaned, format="mixed", dayfirst=True, errors="coerce"
             )
-    
+
     fields_to_clean = {
         "sex": clean_csv_sex,
         "ethnicity": clean_csv_ethnicity,
         "height": clean_csv_measurement,
-        "weight": clean_csv_measurement
+        "weight": clean_csv_measurement,
     }
 
     for field, cleaner in fields_to_clean.items():
@@ -127,7 +128,7 @@ def csv_clean(df, dataset_year=2021):
                 if normalise_heading(column) == normalise_heading(heading):
                     df = df.rename(columns={column: heading})
                     break
-        
+
         if heading in df.columns and not is_numeric_dtype(df[heading]):
             df[heading] = df[heading].apply(cleaner)
 

--- a/project/npda/general_functions/csv/csv_clean.py
+++ b/project/npda/general_functions/csv/csv_clean.py
@@ -5,7 +5,7 @@ import unicodedata
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
-from project.constants import get_all_dates
+from project.constants import get_all_dates, ETHNICITIES
 from project.npda.general_functions.headings import get_field_heading
 
 """
@@ -31,6 +31,16 @@ def clean_csv_sex(value):
         case _:
             # Return Not Known. The patient won't save in the database without a numeric value.
             return 0
+
+
+def clean_csv_ethnicity(value):
+    if isinstance(value, str):
+        value = value.strip().upper()
+
+        if value in ETHNICITIES:
+            return value
+    
+    return value
 
 
 def clean_csv_measurement(value):
@@ -66,74 +76,60 @@ def clean_whitespace(x):
     return x
 
 
+# Clean and parse date-like columns early so Django forms receive proper dates
+def clean_date_value(v):
+    if pd.isna(v):
+        return v
+    # Already a datetime-like
+    if isinstance(v, (pd.Timestamp, datetime.date)):
+        return v
+    s = str(v)
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
+    s = s.replace("\u00a0", " ")
+    s = s.strip()
+    s = s.strip("'\"“”‘’`·†")
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+# Helper normalisation to robustly match noisy incoming headings
+def normalise_heading(s: str) -> str:
+    if not isinstance(s, str):
+        return ""
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
+    s = re.sub(r"[^0-9a-zA-Z]+", " ", s)
+    s = re.sub(r"\s+", " ", s).strip().lower()
+    return s
+
+
 def csv_clean(df, dataset_year=2021):
-    # Helper normalisation to robustly match noisy incoming headings
-    def _norm(s: str) -> str:
-        if not isinstance(s, str):
-            return ""
-        s = unicodedata.normalize("NFKD", s)
-        s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
-        s = re.sub(r"[^0-9a-zA-Z]+", " ", s)
-        s = re.sub(r"\s+", " ", s).strip().lower()
-        return s
-
-    sex_heading = get_field_heading("sex", dataset_year)
-
-    # Clean and parse date-like columns early so Django forms receive proper dates
-    def _clean_date_value(v):
-        if pd.isna(v):
-            return v
-        # Already a datetime-like
-        if isinstance(v, (pd.Timestamp, datetime.date)):
-            return v
-        s = str(v)
-        s = unicodedata.normalize("NFKD", s)
-        s = "".join(ch for ch in s if unicodedata.category(ch) != "Mn")
-        s = s.replace("\u00a0", " ")
-        s = s.strip()
-        s = s.strip("'\"“”‘’`·†")
-        s = re.sub(r"\s+", " ", s)
-        return s
-
     for date_col in get_all_dates(dataset_year):
         if date_col in df.columns:
-            cleaned = df[date_col].apply(_clean_date_value)
+            cleaned = df[date_col].apply(clean_date_value)
             df[date_col] = pd.to_datetime(
                 cleaned, format="mixed", dayfirst=True, errors="coerce"
             )
+    
+    fields_to_clean = {
+        "sex": clean_csv_sex,
+        "ethnicity": clean_csv_ethnicity,
+        "height": clean_csv_measurement,
+        "weight": clean_csv_measurement
+    }
 
-    # If the canonical heading isn't present, try to find a noisy match and rename it
-    if sex_heading not in df.columns:
-        match_col = next(
-            (c for c in df.columns if _norm(c) == _norm(sex_heading)), None
-        )
-        if match_col:
-            df = df.rename(columns={match_col: sex_heading})
+    for field, cleaner in fields_to_clean.items():
+        heading = get_field_heading(field, dataset_year)
 
-    if sex_heading in df.columns and not is_numeric_dtype(df[sex_heading]):
-        df[sex_heading] = df[sex_heading].apply(clean_csv_sex)
-
-    # strip whitespace and convert height and weight to numeric, removing any non-numeric characters (eg, "cm", "kg")
-    height_heading = get_field_heading("height", dataset_year)
-    weight_heading = get_field_heading("weight", dataset_year)
-
-    if height_heading not in df.columns:
-        match_col = next(
-            (c for c in df.columns if _norm(c) == _norm(height_heading)), None
-        )
-        if match_col:
-            df = df.rename(columns={match_col: height_heading})
-    if weight_heading not in df.columns:
-        match_col = next(
-            (c for c in df.columns if _norm(c) == _norm(weight_heading)), None
-        )
-        if match_col:
-            df = df.rename(columns={match_col: weight_heading})
-
-    if height_heading in df.columns and not is_numeric_dtype(df[height_heading]):
-        df[height_heading] = df[height_heading].apply(clean_csv_measurement)
-    if weight_heading in df.columns and not is_numeric_dtype(df[weight_heading]):
-        df[weight_heading] = df[weight_heading].apply(clean_csv_measurement)
+        # If the canonical heading isn't present, try to find a noisy match and rename it
+        if heading not in df.columns:
+            for column in df.columns:
+                if normalise_heading(column) == normalise_heading(heading):
+                    df = df.rename(columns={column: heading})
+                    break
+        
+        if heading in df.columns and not is_numeric_dtype(df[heading]):
+            df[heading] = df[heading].apply(cleaner)
 
     # Strip whitespace only fields of whitespaces
     for col in df.select_dtypes(include=["string", "object"]).columns:

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4654,7 +4654,7 @@ def test_case_insensitive_ethnic_category(test_user, dummy_sheet_csv):
     df = read_csv_from_str(one_row_csv).df
 
     errors = csv_upload_sync(test_user, df)
-    assert len(errors) == 0
+    assert "ethnicity" not in errors[0]
 
     patient = Patient.objects.first()
 

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4643,6 +4643,25 @@ def test_bad_data_for_ethnic_category(test_user, dummy_sheet_csv, value):
     assert "ethnicity" in patient.errors
 
 
+@pytest.mark.django_db
+def test_case_insensitive_ethnic_category(test_user, dummy_sheet_csv):
+    one_row_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        end=2,  # exclusive
+        replacements=[{"row": 1, "column": "Ethnic Category", "value": "a"}],
+    )
+
+    df = read_csv_from_str(one_row_csv).df
+
+    errors = csv_upload_sync(test_user, df)
+    assert len(errors) > 0
+
+    patient = Patient.objects.first()
+
+    assert patient.ethnicity == "A"
+    assert "ethnicity" not in patient.errors
+
+
 @pytest.mark.parametrize(
     "model_field",
     [

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4654,12 +4654,12 @@ def test_case_insensitive_ethnic_category(test_user, dummy_sheet_csv):
     df = read_csv_from_str(one_row_csv).df
 
     errors = csv_upload_sync(test_user, df)
-    assert len(errors) > 0
+    assert len(errors) == 0
 
     patient = Patient.objects.first()
 
     assert patient.ethnicity == "A"
-    assert "ethnicity" not in patient.errors
+    assert patient.errors is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PZ105 queried whether ethnic category was case sensitive in the CSV. It is but that seems excessively fussy to me so this PR makes it case insensitive.

I also refactored the cleaner code to remove some duplication and to use a loop with a `break` rather than the `next(..., None)` pattern. Just easier to read for me, functionality exactly the same.