### PR TITLE
Memory logging

### DIFF
--- a/envs/example.env
+++ b/envs/example.env
@@ -61,6 +61,7 @@ REDIS_DATABASE_NUMBER=0
 AUTO_LOGOUT_IDLE_TIME_SECONDS=86400 # 1 day
 
 ENABLE_REQUEST_LOGGING="True"
+ENABLE_MEMORY_LOGGING=False
 
 # Comma separated email addresses to receive notifications on changes like creating new users and assigning them to PDUs
 CHANGE_NOTIFICATION_EMAILS=""

--- a/project/npda/logging.py
+++ b/project/npda/logging.py
@@ -3,6 +3,7 @@
 # the user in thread-local storage.
 
 import logging
+import resource
 from datetime import datetime
 from threading import local
 from timeit import default_timer as timer
@@ -66,12 +67,20 @@ class NPDARequestLoggingMiddleware:
     def __call__(self, request):
         start = timer()
 
+        rss_start = None
+        if settings.ENABLE_MEMORY_LOGGING:
+            rss_start = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
         response = self.get_response(request)
 
         end = timer()
 
         duration = end - start
         duration_ms = round(duration * 1000)
+
+        rss_end = None
+        if settings.ENABLE_MEMORY_LOGGING:
+            rss_end = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 
         # The dev server already does request logging
         if settings.ENABLE_REQUEST_LOGGING:
@@ -82,8 +91,16 @@ class NPDARequestLoggingMiddleware:
 
             username_to_log = "-" if request.user.is_anonymous else request.user.email
 
+            rss_message = ""
+            if (
+                settings.ENABLE_MEMORY_LOGGING
+                and rss_start is not None
+                and rss_end is not None
+            ):
+                rss_message = f" rss_start={rss_start} rss_end={rss_end} rss_diff={rss_end - rss_start}"
+
             request_logger.info(
-                f'{request.META.get("HTTP_X_FORWARDED_FOR", "")} - {username_to_log} [{gunicorn_formatted_datetime}] "{request.method} {request.get_full_path()}" {response.status_code} {response.get("Content-Length", "-")} "{request.META.get("HTTP_REFERER", "-")}" "{request.META.get("HTTP_USER_AGENT", "-")}" {duration_ms}'
+                f'{request.META.get("HTTP_X_FORWARDED_FOR", "")} - {username_to_log} [{gunicorn_formatted_datetime}] "{request.method} {request.get_full_path()}" {response.status_code} {response.get("Content-Length", "-")} "{request.META.get("HTTP_REFERER", "-")}" "{request.META.get("HTTP_USER_AGENT", "-")}" {duration_ms}{rss_message}'
             )
 
         return response

--- a/project/settings.py
+++ b/project/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import gc
 import logging
 import os
 from datetime import timedelta
@@ -391,8 +392,7 @@ ENABLE_REQUEST_LOGGING = os.getenv("ENABLE_REQUEST_LOGGING", "False") == "True"
 ENABLE_MEMORY_LOGGING = os.getenv("ENABLE_MEMORY_LOGGING", "False") == "True"
 if ENABLE_MEMORY_LOGGING:
     logger.info("Memory logging is ENABLED")
-    # Deliberately don't use gc.DEBUG_LEAK so we don't do gc.DEBUG_SAVE_ALL
-    gc.set_debug(gc.DEBUG_COLLECTABLE | gc.DEBUG_UNCOLLECTABLE)
+    gc.set_debug(gc.DEBUG_UNCOLLECTABLE)
 
 SILKY_AUTHENTICATION = True  # User must login
 SILKY_AUTHORISATION = True  # User must have permissions

--- a/project/settings.py
+++ b/project/settings.py
@@ -388,6 +388,12 @@ SECURE_HSTS_PRELOAD = os.environ.get("SECURE_HSTS_PRELOAD")
 
 ENABLE_REQUEST_LOGGING = os.getenv("ENABLE_REQUEST_LOGGING", "False") == "True"
 
+ENABLE_MEMORY_LOGGING = os.getenv("ENABLE_MEMORY_LOGGING", "False") == "True"
+if ENABLE_MEMORY_LOGGING:
+    logger.info("Memory logging is ENABLED")
+    # Deliberately don't use gc.DEBUG_LEAK so we don't do gc.DEBUG_SAVE_ALL
+    gc.set_debug(gc.DEBUG_COLLECTABLE | gc.DEBUG_UNCOLLECTABLE)
+
 SILKY_AUTHENTICATION = True  # User must login
 SILKY_AUTHORISATION = True  # User must have permissions
 


### PR DESCRIPTION
Try to debug #1353 further by:

- Logging when GC finds uncollectable objects
- Log RSS (i.e. operating system level) memory usage before and after each request
  - At the OS level to try and debug even if it's not the Python heap that's growing but some native allocations instead
  - My aim is to use Azure log monitor to try and find the "heavy hitter" requests that regularly cause the RSS to jump
  - Obviously the nature of GC means that this is noisy, especially at start up