### PR TITLE
Allow visit dates before diagnosis date

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from decimal import ROUND_HALF_UP, Decimal
 
 from django import forms

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 from decimal import ROUND_HALF_UP, Decimal
 
 from django import forms
@@ -652,11 +652,18 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
 
         if not valid:
             raise ValidationError(error)
+
+        if data and (
+            data < self.audit_period.start_date - timedelta(days=90)
+            or data > self.audit_period.end_date
+        ):
+            raise ValidationError(
+                "Expected thyroid function date from 90 days before the start of the audit period to the end of the audit period."
+            )
 
         return self.cleaned_data["thyroid_function_date"]
 
@@ -668,11 +675,18 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
 
         if not valid:
             raise ValidationError(error)
+
+        if data and (
+            data < self.audit_period.start_date - timedelta(days=90)
+            or data > self.audit_period.end_date
+        ):
+            raise ValidationError(
+                "Expected coeliac screen date from 90 days before the start of the audit period to the end of the audit period."
+            )
 
         return self.cleaned_data["coeliac_screen_date"]
 

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -547,7 +547,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -562,7 +561,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -577,7 +575,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -592,7 +589,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -607,7 +603,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Retinal Screening date",
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -622,7 +617,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -637,7 +631,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -657,14 +650,6 @@ class VisitForm(forms.ModelForm):
         if not valid:
             raise ValidationError(error)
 
-        if data and (
-            data < self.audit_period.start_date - timedelta(days=90)
-            or data > self.audit_period.end_date
-        ):
-            raise ValidationError(
-                "Expected thyroid function date from 90 days before the start of the audit period to the end of the audit period."
-            )
-
         return self.cleaned_data["thyroid_function_date"]
 
     def clean_coeliac_screen_date(self):
@@ -680,14 +665,6 @@ class VisitForm(forms.ModelForm):
         if not valid:
             raise ValidationError(error)
 
-        if data and (
-            data < self.audit_period.start_date - timedelta(days=90)
-            or data > self.audit_period.end_date
-        ):
-            raise ValidationError(
-                "Expected coeliac screen date from 90 days before the start of the audit period to the end of the audit period."
-            )
-
         return self.cleaned_data["coeliac_screen_date"]
 
     def clean_psychological_screening_assessment_date(self):
@@ -698,7 +675,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -713,7 +689,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -746,7 +721,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -761,7 +735,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -775,19 +748,10 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_death=self.patient.death_date,
         )
 
         if not valid:
             raise ValidationError(error)
-
-        if data and (
-            data < self.audit_period.start_date - timedelta(days=7)
-            or data > self.audit_period.end_date
-        ):
-            raise ValidationError(
-                "Expected sick day rules training date from 7 days before the start of the audit period to the end of the audit period."
-            )
 
         return self.cleaned_data["sick_day_rules_training_date"]
 
@@ -800,7 +764,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if not valid:
             raise ValidationError(error)
@@ -815,7 +778,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=None,  # Hospital admission dates are not bound by the audit period
         )
         if not valid:
             raise ValidationError(error)
@@ -830,7 +792,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
         if valid is False:
             raise ValidationError(error)

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -776,10 +776,18 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
             date_of_death=self.patient.death_date,
-            audit_period=self.audit_period,
         )
+
         if not valid:
             raise ValidationError(error)
+
+        if data and (
+            data < self.audit_period.start_date - timedelta(days=7)
+            or data > self.audit_period.end_date
+        ):
+            raise ValidationError(
+                "Expected sick day rules training date from 7 days before the start of the audit period to the end of the audit period."
+            )
 
         return self.cleaned_data["sick_day_rules_training_date"]
 

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -531,7 +531,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Visit/Appointment Date",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -547,7 +546,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date (Height and weight)",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -563,7 +561,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date: Hba1c Value",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -579,7 +576,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date (Blood Pressure)",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -595,7 +591,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Foot Assessment / Examination Date",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -611,7 +606,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination=data,
             date_under_examination_label_name="Retinal Screening date",
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -627,7 +621,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date: Urinary Albumin Level",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -643,7 +636,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date: Total Cholesterol Level",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -666,15 +658,6 @@ class VisitForm(forms.ModelForm):
         if not valid:
             raise ValidationError(error)
 
-        if (
-            data
-            and self.patient.diagnosis_date
-            and data < self.patient.diagnosis_date - timedelta(days=90)
-        ):
-            raise ValidationError(
-                "Expected thyroid function date within 90 days before diagnosis."
-            )
-
         return self.cleaned_data["thyroid_function_date"]
 
     def clean_coeliac_screen_date(self):
@@ -691,15 +674,6 @@ class VisitForm(forms.ModelForm):
         if not valid:
             raise ValidationError(error)
 
-        if (
-            data
-            and self.patient.diagnosis_date
-            and data < self.patient.diagnosis_date - timedelta(days=90)
-        ):
-            raise ValidationError(
-                "Expected coeliac screen date within 90 days before diagnosis."
-            )
-
         return self.cleaned_data["coeliac_screen_date"]
 
     def clean_psychological_screening_assessment_date(self):
@@ -709,7 +683,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Observation Date - Psychological Screening Assessment",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -725,7 +698,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date of offer of referral to smoking cessation service (if patient is a current smoker)",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -744,7 +716,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date of Level 3 carbohydrate counting education received",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
         )
 
@@ -760,7 +731,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date of additional appointment with dietitian",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -776,7 +746,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date that influenza immunisation was recommended",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -792,7 +761,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date of provision of advice ('sick-day rules') about managing diabetes during intercurrent illness or episodes of hyperglycaemia",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -804,23 +772,11 @@ class VisitForm(forms.ModelForm):
     def clean_hospital_admission_date(self):
         data = self.cleaned_data["hospital_admission_date"]
 
-        if not self.patient.diagnosis_date:
-            diagnosis_date = None
-        else:
-            diagnosis_date = date(
-                year=self.patient.diagnosis_date.year,
-                month=self.patient.diagnosis_date.month,
-                day=self.patient.diagnosis_date.day,
-            )
-            # diagnosis date can be within 11 days of admission date
-            diagnosis_date = diagnosis_date - timedelta(days=11)
-
         valid, error = validate_date(
             date_under_examination_field_name="hospital_admission_date",
             date_under_examination_label_name="Start date (Hospital Provider Spell)",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )
@@ -836,7 +792,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Discharge date (Hospital provider spell",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=None,  # Hospital admission dates are not bound by the audit period
         )
@@ -852,7 +807,6 @@ class VisitForm(forms.ModelForm):
             date_under_examination_label_name="Date Immunotherapy Started",
             date_under_examination=data,
             date_of_birth=self.patient.date_of_birth,
-            date_of_diagnosis=self.patient.diagnosis_date,
             date_of_death=self.patient.death_date,
             audit_period=self.audit_period,
         )

--- a/project/npda/general_functions/validate_dates.py
+++ b/project/npda/general_functions/validate_dates.py
@@ -3,7 +3,6 @@ def validate_date(
     date_under_examination_label_name,
     date_under_examination,
     date_of_birth,
-    date_of_diagnosis=None,
     date_of_death=None,
     audit_period=None,
 ):
@@ -22,16 +21,6 @@ def validate_date(
             error = {
                 f"{date_under_examination_field_name}": [
                     f"'{date_under_examination_label_name}' cannot be before date of birth."
-                ]
-            }
-            errors.append(error)
-            valid = False
-
-    if date_of_diagnosis is not None:
-        if date_under_examination < date_of_diagnosis:
-            error = {
-                f"{date_under_examination_field_name}": [
-                    f"'{date_under_examination_label_name}' cannot be before date of diagnosis."
                 ]
             }
             errors.append(error)

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -2469,11 +2469,7 @@ def test_visit_form_dates_outside_of_audit_period(test_case_index, test_data):
 
     # Extract the date field being tested from the data
     date_fields = [key for key in test_data.keys() if "date" in key]
-    tested_field = (
-        date_fields[0]
-        if date_fields[0] != "visit_date"
-        else "unknown"
-    )
+    tested_field = date_fields[0] if date_fields[0] != "visit_date" else "unknown"
 
     # Verify that visit_date is always in errors (since all test cases have dates outside audit period)
     assert "visit_date" in form.errors, (

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -1624,58 +1624,6 @@ def test_inpatient_admission_stabilisation_discharge_date_before_admission_date_
 
 
 @pytest.mark.django_db
-def test_inpatient_admission_stabilisation_discharge_date_before_diagnosis_date_fails_validation():
-    """
-    Test that inpatient admission for stabilisation is rejected if discharge date before admission date
-    """
-    patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2026, 1, 10)
-
-    form = VisitForm(
-        data={
-            "hospital_admission_date": "2026-01-01",
-            "hospital_discharge_date": "2026-01-08",
-            "hospital_admission_reason": 1,  # patient stabilisation
-            # dka_additional_therapies
-            # hospital_admission_other
-        },
-        initial={"patient": patient},
-    )
-
-    # Trigger the cleaners
-    assert not form.is_valid(), (
-        "Inpatient admission for stabilisation admission date before discharge date should fail"
-    )
-    assert "hospital_discharge_date" in form.errors
-
-
-@pytest.mark.django_db
-def test_inpatient_admission_stabilisation_admission_date_more_than_eleven_days_before_diagnosis_date_fails_validation():
-    """
-    Test that inpatient admission for stabilisation is rejected if diagnosis date is more than 11 days before admission date
-    """
-    patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2026, 1, 15)
-
-    form = VisitForm(
-        data={
-            "hospital_admission_date": "2026-01-01",
-            "hospital_discharge_date": "2026-01-016",
-            "hospital_admission_reason": 1,  # patient stabilisation
-            # dka_additional_therapies
-            # hospital_admission_other
-        },
-        initial={"patient": patient},
-    )
-
-    # Trigger the cleaners
-    assert not form.is_valid(), (
-        "Inpatient admission for stabilisation admission date more than 11 days before diagnosis date should fail"
-    )
-    assert "hospital_admission_date" in form.errors
-
-
-@pytest.mark.django_db
 def test_inpatient_admission_stabilisation_admission_date_less_than_eleven_days_before_diagnosis_date_passes_validation():
     """
     Test that inpatient admission for stabilisation passes if admission date is within 11 days of diagnosis date
@@ -2303,26 +2251,6 @@ def test_visit_date_after_diagnosis_date_passes_validation():
 
 
 @pytest.mark.django_db
-def test_visit_date_before_diagnosis_date_fails_validation():
-    """
-    Test that visit date before diagnosis date is rejected
-    """
-    patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2026, 1, 10)
-
-    form = VisitForm(
-        data={
-            "visit_date": "2026-01-01",
-        },
-        initial={"patient": patient},
-    )
-
-    # Trigger the cleaners
-    assert not form.is_valid(), "Visit date before diagnosis date should fail"
-    assert "visit_date" in form.errors
-
-
-@pytest.mark.django_db
 def test_visit_date_after_death_date_fails_validation():
     """
     Test that visit date after death date is rejected
@@ -2587,23 +2515,3 @@ def test_thyroid_and_coeliac_dates_within_90_days_before_diagnosis_pass_validati
     assert "thyroid_function_date" not in form.errors
     assert "coeliac_screen_date" not in form.errors
 
-
-@pytest.mark.django_db
-def test_thyroid_and_coeliac_dates_earlier_Than_90_days_before_diagnosis_fail_validation():
-    patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2026, 1, 10)
-    patient.save()
-
-    form = VisitForm(
-        data={
-            "visit_date": "2026-02-01",  # Required for validation
-            "thyroid_treatment_status": 1,  # Required if thyroid function date provided
-            "thyroid_function_date": "2025-10-04",  # 120 days before diagnosis
-            "coeliac_screen_date": "2025-09-20",  # 134 days before diagnosis
-        },
-        initial={"patient": patient},
-    )
-
-    assert not form.is_valid()
-    assert "thyroid_function_date" in form.errors
-    assert "coeliac_screen_date" in form.errors

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -2535,3 +2535,24 @@ def test_thyroid_and_coeliac_dates_within_90_days_before_audit_year_pass_validat
     assert form.is_valid(), f"Expected form to be valid but got errors: {form.errors}"
     assert "thyroid_function_date" not in form.errors
     assert "coeliac_screen_date" not in form.errors
+
+
+@pytest.mark.django_db
+def test_sick_day_rules_within_7_days_before_audit_year_pass_validation(
+    dataset_year, audit_period_for_dataset_year
+):
+    patient = PatientFactory()
+    patient.diagnosis_date = datetime.date(2025, 5, 1)
+    patient.save()
+
+    form = VisitForm(
+        data={
+            "visit_date": f"{dataset_year}-05-01",  # Required for validation
+            "sick_day_rules_training_date": f"{dataset_year}-03-28",
+        },
+        initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
+    )
+
+    assert form.is_valid(), f"Expected form to be valid but got errors: {form.errors}"
+    assert "sick_day_rules_training_date" not in form.errors

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -2471,19 +2471,15 @@ def test_visit_form_dates_outside_of_audit_period(test_case_index, test_data):
     date_fields = [key for key in test_data.keys() if "date" in key]
     tested_field = (
         date_fields[0]
-        if date_fields[0] != "hospital_discharge_date" and date_fields
+        if date_fields[0] != "visit_date"
         else "unknown"
-    )
-
-    assert not is_valid, (
-        f"Test case {test_case_index + 1} ({tested_field}): Form should be invalid due to dates outside audit period {audit_period}, but got valid form. Errors: {form.errors}"
     )
 
     # Verify that visit_date is always in errors (since all test cases have dates outside audit period)
     assert "visit_date" in form.errors, (
         f"Test case {test_case_index + 1} ({tested_field}): visit_date should be in form errors"
     )
-    assert tested_field in form.errors, (
+    assert tested_field not in form.errors, (
         f"Test case {test_case_index + 1} ({tested_field}): {tested_field} should be in form errors"
     )
 

--- a/project/npda/tests/form_tests/test_visit_form.py
+++ b/project/npda/tests/form_tests/test_visit_form.py
@@ -1026,7 +1026,9 @@ thyroid tests
 
 
 @pytest.mark.django_db
-def test_thyroid_treatment_status_form_passes_validation():
+def test_thyroid_treatment_status_form_passes_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     """
     Test that thyroid function status and date are accepted
     """
@@ -1034,11 +1036,12 @@ def test_thyroid_treatment_status_form_passes_validation():
 
     form = VisitForm(
         data={
-            "visit_date": "2026-01-01",  # Required for validation
+            "visit_date": f"{dataset_year}-05-01",  # Required for validation
             "thyroid_treatment_status": 2,  # Thyroxine for hypothyroidism
-            "thyroid_function_date": "2026-01-01",
+            "thyroid_function_date": f"{dataset_year}-05-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert form.is_valid(), f"Form should be valid but got {form.errors}"
@@ -1047,7 +1050,9 @@ def test_thyroid_treatment_status_form_passes_validation():
 
 
 @pytest.mark.django_db
-def test_thyroid_treatment_status_unrecognized_form_fails_validation():
+def test_thyroid_treatment_status_unrecognized_form_fails_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     """
     Test that an impossible thyroid function status is invalid
     """
@@ -1056,9 +1061,10 @@ def test_thyroid_treatment_status_unrecognized_form_fails_validation():
     form = VisitForm(
         data={
             "thyroid_treatment_status": 94,  # invalid
-            "thyroid_function_date": "2026-01-01",
+            "thyroid_function_date": f"{dataset_year}-05-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert not form.is_valid(), (
@@ -1068,7 +1074,9 @@ def test_thyroid_treatment_status_unrecognized_form_fails_validation():
 
 
 @pytest.mark.django_db
-def test_thyroid_treatment_status_none_form_fails_validation():
+def test_thyroid_treatment_status_none_form_fails_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     """
     Test that missing thyroid function status is invalid
     """
@@ -1077,9 +1085,10 @@ def test_thyroid_treatment_status_none_form_fails_validation():
     form = VisitForm(
         data={
             "thyroid_treatment_status": None,  # invalid
-            "thyroid_function_date": "2026-01-01",
+            "thyroid_function_date": f"{dataset_year}-01-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert not form.is_valid(), "No thyroid treatment status offered but test passed"
@@ -1136,7 +1145,9 @@ Coeliac tests
 
 
 @pytest.mark.django_db
-def test_coeliac_treatment_status_form_passes_validation():
+def test_coeliac_treatment_status_form_passes_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     """
     Test that coeliac function status and date are accepted
     """
@@ -1144,11 +1155,12 @@ def test_coeliac_treatment_status_form_passes_validation():
 
     form = VisitForm(
         data={
-            "visit_date": "2026-01-01",  # Required for validation
+            "visit_date": f"{dataset_year}-05-01",  # Required for validation
             "gluten_free_diet": 1,  # Normal
-            "coeliac_screen_date": "2026-01-01",
+            "coeliac_screen_date": f"{dataset_year}-05-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert form.is_valid(), f"Form should be valid but got {form.errors}"
@@ -1157,7 +1169,9 @@ def test_coeliac_treatment_status_form_passes_validation():
 
 
 @pytest.mark.django_db
-def test_coeliac_treatment_status_unrecognized_form_fails_validation():
+def test_coeliac_treatment_status_unrecognized_form_fails_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     """
     Test that an impossible coeliac function status is invalid
     """
@@ -1166,9 +1180,10 @@ def test_coeliac_treatment_status_unrecognized_form_fails_validation():
     form = VisitForm(
         data={
             "gluten_free_diet": 94,  # invalid
-            "coeliac_screen_date": "2026-01-01",
+            "coeliac_screen_date": f"{dataset_year}-05-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert not form.is_valid(), (
@@ -1178,15 +1193,18 @@ def test_coeliac_treatment_status_unrecognized_form_fails_validation():
 
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/628
 @pytest.mark.django_db
-def test_coeliac_treatment_status_none_form_passes_validation():
+def test_coeliac_treatment_status_none_form_passes_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     patient = PatientFactory()
 
     form = VisitForm(
         data={
             "gluten_free_diet": None,  # invalid
-            "coeliac_screen_date": "2026-01-01",
+            "coeliac_screen_date": f"{dataset_year}-05-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
     # Trigger the cleaners
     assert "gluten_free_diet" not in form.errors
@@ -2496,22 +2514,24 @@ def test_carb_counting_date_outside_of_audit_year_passes_validation_if_patient_d
 
 
 @pytest.mark.django_db
-def test_thyroid_and_coeliac_dates_within_90_days_before_diagnosis_pass_validation():
+def test_thyroid_and_coeliac_dates_within_90_days_before_audit_year_pass_validation(
+    dataset_year, audit_period_for_dataset_year
+):
     patient = PatientFactory()
-    patient.diagnosis_date = datetime.date(2026, 1, 10)
+    patient.diagnosis_date = datetime.date(2025, 5, 1)
     patient.save()
 
     form = VisitForm(
         data={
-            "visit_date": "2026-02-01",  # Required for validation
+            "visit_date": f"{dataset_year}-05-01",  # Required for validation
             "thyroid_treatment_status": 1,  # Required if thyroid function date provided
-            "thyroid_function_date": "2025-12-7",  # 56 days before diagnosis
-            "coeliac_screen_date": "2025-12-12",  # 51 days before diagnosis
+            "thyroid_function_date": f"{dataset_year}-02-01",
+            "coeliac_screen_date": f"{dataset_year}-01-01",
         },
         initial={"patient": patient},
+        audit_period=audit_period_for_dataset_year,
     )
 
     assert form.is_valid(), f"Expected form to be valid but got errors: {form.errors}"
     assert "thyroid_function_date" not in form.errors
     assert "coeliac_screen_date" not in form.errors
-

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -4495,49 +4495,6 @@ def test_visit_date_not_after_date_of_death(
     )
 
 
-@pytest.mark.django_db
-def test_visit_date_not_before_diagnosis_date(
-    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
-):
-    """
-    Test that a Visit/Appointment Date before the date of diagnosis is rejected
-    """
-    # If the audit period starts in the future relative to today, skip this parametrisation
-    # Also skip if the diagnosis date (start + 6 months) would be in the future, since that
-    # triggers a "Cannot be in the future" error before the visit-before-diagnosis check.
-    if audit_period_for_dataset_year.start_date > datetime.date.today():
-        pytest.skip("Audit period start is in the future; skip this parametrisation")
-    if (
-        audit_period_for_dataset_year.start_date + relativedelta(months=6)
-        > datetime.date.today()
-    ):
-        pytest.skip("Diagnosis date would be in the future; skip this parametrisation")
-    diagnosis_date = get_field_heading("diagnosis_date", dataset_year)
-    visit_date = get_field_heading("visit_date", dataset_year)
-    single_row_valid_df.loc[0, diagnosis_date] = (
-        audit_period_for_dataset_year.start_date + relativedelta(months=6)
-    )
-    single_row_valid_df.loc[0, visit_date] = audit_period_for_dataset_year.start_date
-
-    errors = csv_upload_sync(
-        test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
-    )
-
-    assert "visit_date" in errors[0]
-
-    visit = Visit.objects.first()
-
-    assert visit.visit_date == audit_period_for_dataset_year.start_date, (
-        f"Visit date should be {audit_period_for_dataset_year.start_date}, but was {visit.visit_date}"
-    )
-    assert (
-        visit.patient.diagnosis_date
-        == audit_period_for_dataset_year.start_date + relativedelta(months=6)
-    ), (
-        f"Diagnosis date should be {audit_period_for_dataset_year.start_date + relativedelta(months=6)}, but was {visit.patient.diagnosis_date}"
-    )
-
-
 @pytest.mark.parametrize(
     "alternative,expected",
     [
@@ -5262,41 +5219,6 @@ def test_thyroid_and_coeliac_dates_within_90_days_before_diagnosis_pass_validati
 
     assert "coeliac_screen_date" not in errors[0]
     assert "thyroid_function_date" not in errors[0]
-
-
-@pytest.mark.django_db
-def test_thyroid_and_coeliac_dates_earlier_than_90_days_before_diagnosis_fail_validation(
-    freeze_for_audit,
-    test_user,
-    single_row_valid_df,
-    audit_period_for_dataset_year,
-    dataset_year,
-):
-    # Set the audit period to be valid for the visit date at the outset
-
-    diagnosis_date = get_field_heading("diagnosis_date", dataset_year)
-    single_row_valid_df.loc[0, diagnosis_date] = (
-        audit_period_for_dataset_year.start_date + datetime.timedelta(days=100)
-    )
-
-    coeliac_screening_date = (
-        audit_period_for_dataset_year.start_date + datetime.timedelta(days=9)
-    )
-    single_row_valid_df.loc[0, "Observation Date: Coeliac Disease Screening"] = (
-        coeliac_screening_date
-    )
-
-    thyroid_function_date = audit_period_for_dataset_year.start_date
-    single_row_valid_df.loc[0, "Observation Date: Thyroid Function"] = (
-        thyroid_function_date
-    )
-
-    errors = csv_upload_sync(
-        test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
-    )
-
-    assert "coeliac_screen_date" in errors[0]
-    assert "thyroid_function_date" in errors[0]
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -5109,7 +5109,7 @@ def test_visit_form_dates_outside_of_audit_period(
     dataset_year,
 ):
     """
-    Test that all dates outside in a visit of the audit period are flagged as errors, but the visit is still created
+    Test that all dates outside in a visit of the audit period are allowed (https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1379)
     2024 / 2025 audit period is seeded in the fixture
     All the dates tested include:
         visit_date
@@ -5124,12 +5124,12 @@ def test_visit_form_dates_outside_of_audit_period(
         coeliac_screen_date
         psychological_screening_assessment_date
         smoking_cessation_referral_date
-        carbohydrate_counting_level_three_education_date NOT INCLUDED (https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1237)
+        carbohydrate_counting_level_three_education_date
         dietician_additional_appointment_date
         flu_immunisation_recommended_date
         sick_day_rules_training_date
         hospital_admission_date
-        **hospital_discharge_date NOT INCLUDED AS IT IS POSSIBLE TO BE DISCHARGED AFTER THE AUDIT ENDS**
+        hospital_discharge_date
     """
     birth_date = get_field_heading("date_of_birth", dataset_year)
     diagnosis_date = get_field_heading("diagnosis_date", dataset_year)
@@ -5166,16 +5166,6 @@ def test_visit_form_dates_outside_of_audit_period(
         )
 
     all_visits = get_all_visit_dates(dataset_year)
-    # Remove the dates not included in the test
-    all_visits.remove(
-        (
-            "carbohydrate_counting_level_three_education_date",
-            carbohydrate_counting_level_three_education_date,
-        )
-    )
-    all_visits.remove(
-        ("hospital_discharge_date", "Discharge date (Hospital provider spell)")
-    )
 
     assert Visit.objects.count() == 0, (
         "Expected no visits to be created before the test"
@@ -5184,10 +5174,14 @@ def test_visit_form_dates_outside_of_audit_period(
     errors = csv_upload_sync(
         test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
     )
+
+    assert "visit_date" in errors[0], f"Expected visit_date to be in errors, but got {errors}"
+
     for date_field in all_visits:
-        assert date_field[0] in errors[0], (
-            f"Expected {date_field} to be in errors, but got {errors}"
-        )
+        if date_field[0] != "visit_date":
+            assert date_field[0] not in errors[0], (
+                f"Expected {date_field} not to be in errors, but got {errors}"
+            )
     assert Visit.objects.count() == 1, (
         "Expected the visit still to be created even though visit date outside of audit period"
     )

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -5175,7 +5175,9 @@ def test_visit_form_dates_outside_of_audit_period(
         test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
     )
 
-    assert "visit_date" in errors[0], f"Expected visit_date to be in errors, but got {errors}"
+    assert "visit_date" in errors[0], (
+        f"Expected visit_date to be in errors, but got {errors}"
+    )
 
     for date_field in all_visits:
         if date_field[0] != "visit_date":


### PR DESCRIPTION
Fixes #1379

Request to no longer flag visit dates (and dates within a visit) if they are before diagnosis date.

Thyroid and coeliac remain special cases but they are allowed up to 90 days before the start of the audit period, not diagnosis date as I incorrectly implemented in #1241 