### PR TITLE
Fix downloading patient report

### DIFF
--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -583,7 +583,7 @@ def download_patient_report(request, audit_period, pdu):
 
     with pd.ExcelWriter(contents, engine="openpyxl") as writer:
         for category in TableCategories:
-            pt_qs, _, patient_identifier = calculate_queryset(
+            pt_qs, patient_identifier = calculate_queryset(
                 pdu=pdu,
                 audit_period=audit_period,
                 selected_category=category.value,
@@ -703,6 +703,7 @@ def download_patient_report(request, audit_period, pdu):
                         data["hba1c_percent_change"].append(row["hba1c_delta"])
 
             df = pd.DataFrame(data=data)
+
             df.to_excel(writer, sheet_name=category.value, index=False)
 
     timestamp = datetime.now().strftime("%y%m%d-%H%M")


### PR DESCRIPTION
Refactor in #1380 didn't also update the code that builds the spreadsheet to download.

This led to a crash (seen in live telemetry) when downloading the patient report:

```
django-1            | Traceback (most recent call last):                                       
django-1            |   File "/app/project/npda/views/patient_report/patient_report.py", line 586, in download_patient_report                                                                 
django-1            |     pt_qs, _, patient_identifier = calculate_queryset(
django-1            |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                        
django-1            | ValueError: not enough values to unpack (expected 3, got 2)                                                                                                             
django-1            |                                                                                                                                                                         
django-1            | During handling of the above exception, another exception occurred:                                                                                                     
django-1            |                                                                                                                                                                         
django-1            | Traceback (most recent call last):                                                                                                                                      
django-1            |   File "/usr/local/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner                                                                   
django-1            |     response = get_response(request)                                                                                                                                    
django-1            |                ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                    
django-1            |   File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response                                                               
django-1            |     response = wrapped_callback(request, *callback_args, **callback_kwargs)                                                                                             
django-1            |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                             
django-1            |   File "/usr/local/lib/python3.12/site-packages/django/contrib/auth/decorators.py", line 59, in _view_wrapper                                                           
django-1            |     return view_func(request, *args, **kwargs)                                                                                                                          
django-1            |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                          
django-1            |   File "/app/project/npda/views/decorators.py", line 54, in sync_login_and_otp_required                                                                                 
django-1            |     return view(request, *args, **kwargs)                                                                                                                               django-1            |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                               
django-1            |   File "/app/project/npda/views/decorators.py", line 80, in sync_check_data_permissions                                                                                 
django-1            |     return view(request, *args, **next_kwargs)                                                                                                                          
django-1            |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                          django-1            |   File "/app/project/npda/views/patient_report/patient_report.py", line 584, in download_patient_report
django-1            |     with pd.ExcelWriter(contents, engine="openpyxl") as writer:          
django-1            |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-1            |   File "/usr/local/lib/python3.12/site-packages/pandas/io/excel/_base.py", line 1353, in __exit__
django-1            |     self.close()
django-1            |   File "/usr/local/lib/python3.12/site-packages/pandas/io/excel/_base.py", line 1357, in close
django-1            |     self._save()
django-1            |   File "/usr/local/lib/python3.12/site-packages/pandas/io/excel/_openpyxl.py", line 110, in _save
django-1            |     self.book.save(self._handles.handle)
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/workbook/workbook.py", line 386, in save
django-1            |     save_workbook(self, filename)
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/writer/excel.py", line 294, in save_workbook
django-1            |     writer.save()
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/writer/excel.py", line 275, in save
django-1            |     self.write_data()
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/writer/excel.py", line 89, in write_data
django-1            |     archive.writestr(ARC_WORKBOOK, writer.write())
django-1            |                                    ^^^^^^^^^^^^^^
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/workbook/_writer.py", line 150, in write
django-1            |     self.write_views()
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/workbook/_writer.py", line 137, in write_views
django-1            |     active = get_active_sheet(self.wb)
django-1            |              ^^^^^^^^^^^^^^^^^^^^^^^^^
django-1            |   File "/usr/local/lib/python3.12/site-packages/openpyxl/workbook/_writer.py", line 35, in get_active_sheet
django-1            |     raise IndexError("At least one sheet must be visible")
django-1            | IndexError: At least one sheet must be visible
django-1            | 172.24.0.1 - incubator@rcpch.ac.uk [10/04/26:16:18:00 +0100] "POST /period/2025-2026/pdu/PZ999/patient_report/download" 500 143167 "https://npda.localhost/period/2025-2
026/pdu/PZ999/patient_report" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36" 135 rss_start=217628 rss_end=221980 rss_diff=4352
django-1            | ERROR [django.server] "POST /period/2025-2026/pdu/PZ999/patient_report/download HTTP/1.1" 500 143167
django-1            | Exception ignored in: <function ZipFile.__del__ at 0x7e09c7544d60>
django-1            | Traceback (most recent call last):
django-1            |   File "/usr/local/lib/python3.12/zipfile/__init__.py", line 1966, in __del__
django-1            |     self.close()
django-1            |   File "/usr/local/lib/python3.12/zipfile/__init__.py", line 1983, in close
django-1            |     self.fp.seek(self.start_dir)
django-1            | ValueError: I/O operation on closed file.

```