### PR TITLE
fix: date_leaving_service dropped from Transfer when set on a later CSV row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,3 +215,134 @@ When adding a field that is dataset-year-specific:
 ## Notes on Jersey (PZ248)
 
 Patients at the Jersey PDU (`pz_code == "PZ248"`) use `unique_reference_number` as their identifier instead of `nhs_number`. The helper `_patient_identifier_field(pdu)` in `queries.py` handles this. Tests that check `patient_identifier` should be aware of this distinction.
+
+---
+
+## CSV pipeline — `csv_parse` and `csv_headings`
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `project/constants/csv_headings.py` | `ALL_HEADINGS` master list + helper functions |
+| `project/npda/general_functions/csv/csv_parse.py` | Reads a CSV file into a pandas DataFrame, normalises headings, detects the unique identifier, and records parse errors |
+| `project/npda/general_functions/csv/csv_clean.py` | Converts date strings to `pd.Timestamp`, cleans sex/ethnicity/measurement columns |
+
+### `ALL_HEADINGS` structure
+
+Each entry in `ALL_HEADINGS` is a dict with:
+
+```python
+{
+    "heading": "<canonical CSV column name>",
+    "model_field": "<Django model field name>",
+    "model": "Patient" | "Visit" | "Transfer",  # absent for PDU Number
+    "data_type": "string" | "date" | "int64" | "float64",
+    "dataset_years": [2021] | [2026] | [2021, 2026],
+    "alternative_headings": [...],  # optional
+}
+```
+
+Fields shared between both years have `dataset_years: [2021, 2026]`. Year-specific fields have only their year in the list. When a heading *name* changes between years, two separate entries share the same `model_field` (the deduplication in `get_csv_heading_objects` ensures each year's canonical heading is returned once).
+
+### Helper functions in `csv_headings.py`
+
+| Function | Returns |
+|----------|---------|
+| `get_csv_heading_objects(dataset_year)` | Tuple of heading dicts for the given year (deduped by `model_field`) |
+| `get_csv_heading_objects_for_year_and_unique_identifier(dataset_year, unique_identifier)` | Like above but also prepends the correct patient identifier heading (England NHS number, Jersey URN, or both) |
+| `get_all_dates(dataset_year)` | List of CSV column *headings* whose `data_type == "date"` for the given year |
+| `csv_definition_for(model_field_or_column, dataset_year)` | Single heading dict for a model field name or column heading |
+
+### `csv_parse` flow
+
+1. Reads the CSV with `pd.read_csv` (UTF-8, fallback ISO-8859-1).
+2. Strips column whitespace and quotes; renames alternative headings to canonical ones.
+3. Detects the unique-identifier column (NHS Number / URN) — raises if neither or both present.
+4. Validates no row is missing its identifier.
+5. Detects and records duplicate columns (e.g. `"XYZ.1"`).
+6. Parses each column to its declared `data_type` using `pd.to_numeric` / `pd.to_datetime` etc., recording per-row parse errors in `errors_to_return`.
+7. Returns a `ParsedCSVFile` dataclass containing the DataFrame (`df`), identifier column, missing/additional/duplicate columns, and `errors_to_return`.
+
+### `csv_clean` flow
+
+Called inside `csv_upload` after `csv_parse`. Applies:
+- `pd.to_datetime` (day-first, mixed format) to all date columns returned by `get_all_dates(dataset_year)`.
+- Custom cleaners for `sex`, `ethnicity`, `height`, `weight`.
+- Whitespace stripping across all string/object columns.
+
+---
+
+## CSV pipeline — `csv_upload`
+
+### Overview
+
+`csv_upload` is an `async` function that processes an already-parsed-and-cleaned pandas DataFrame and persists the rows as `Patient`, `Transfer`, and `Visit` records. It is parallelised with an `asyncio.TaskGroup` (up to 5 concurrent patients).
+
+### Key file
+
+`project/npda/general_functions/csv/csv_upload.py`
+
+### High-level flow
+
+```
+csv_upload(dataframe, errors_to_return, csv_file_name, submission)
+  │
+  ├─ Infer dataset_year from submission.audit_period.get_dataset_year()
+  │    (sniff 2026-only headings in the dataframe to override if needed)
+  │
+  ├─ Build CSV_HEADINGS for this year + PDU identifier via
+  │    get_csv_heading_objects_for_year_and_unique_identifier()
+  │
+  ├─ csv_clean(dataframe, dataset_year)  — normalise dates, measurements, etc.
+  │
+  ├─ Group rows by patient identifier (NHS Number or URN)
+  │
+  └─ For each patient group (in parallel, semaphore=5):
+       │
+       ├─ merge_rows_for_patient()  — resolve conflicts across multiple rows
+       │                              (e.g. conflicting date-of-birth, diagnosis date,
+       │                               reason_leaving_service)
+       │
+       ├─ validate_patient_using_form(first_row)
+       │    row_to_dict(row, Patient) | row_to_dict(row, Transfer)
+       │    → PatientForm(fields)  — validates patient + transfer fields together
+       │    → validate_patient_async()  — external postcode / GP lookup
+       │
+       ├─ For each visit row:
+       │    validate_visit_using_form(row)
+       │    → VisitForm(fields)
+       │    → validate_visit_async()  — external BMI centile lookup
+       │
+       ├─ get_valid_transfer_fields(first_row, patient_form)
+       │    row_to_dict(row, Transfer)
+       │    Nulls out any Transfer field that has an "invalid" / "invalid_choice"
+       │    validation error on the PatientForm
+       │
+       └─ save_patient_and_transfer(patient_form, transfer_fields)
+            patient_form.save(commit=False) + patient.asave()
+            Transfer.objects.acreate(**transfer_fields)
+            submission.patients.aadd(patient)
+            → save_visits(patient, visit_forms)
+```
+
+### `row_to_dict(row, model)`
+
+Iterates `CSV_HEADINGS` filtering by `model`. For each matching entry it:
+1. Looks up the model field definition via `model._meta.get_field(model_field_name)`.
+2. Reads `row[entry["heading"]]`.
+3. Converts the value via `csv_value_to_model_value()` — handles NaN → None, `pd.Timestamp` → `datetime.date`, numpy scalars → Python scalars, integer-valued floats → int.
+
+### Transfer field handling
+
+`date_leaving_service` and `reason_leaving_service` live on the `Transfer` model but are also declared on `PatientForm` so they can be validated together with patient-level cross-field rules (see `PatientForm.clean()`). The save path is:
+
+1. Both fields enter `validate_patient_using_form` via `row_to_dict(row, Transfer)`.
+2. They are individually cleaned by `PatientForm.clean_date_leaving_service` / `clean_reason_leaving_service`.
+3. Cross-field rules in `PatientForm.clean()` ensure neither is supplied without the other.
+4. `get_valid_transfer_fields` calls `row_to_dict(row, Transfer)` again and nulls any field that has an "invalid" / "invalid_choice" form error.
+5. Both fields are passed to `Transfer.objects.acreate(**transfer_fields)`.
+
+### Error accumulation
+
+Errors are accumulated in `errors_to_return: dict[row_index, dict[field_name, list[str]]]` and come from two sources: `csv_parse` (type-parse errors recorded at read time) and the Django forms (validation errors recorded at upload time). Both sets are merged before being stored on `submission.errors` as JSON.

--- a/project/constants/csv_headings.py
+++ b/project/constants/csv_headings.py
@@ -104,19 +104,19 @@ ALL_HEADINGS = [
         "dataset_years": [2026],
     },
     {
-        "heading": "Date of leaving service",
-        "model_field": "date_leaving_service",
-        "model": "Transfer",
-        "alternative_headings": [],
-        "data_type": "date",
-        "dataset_years": [2021, 2026],
-    },
-    {
         "heading": "Reason for leaving service",
         "model_field": "reason_leaving_service",
         "model": "Transfer",
         "alternative_headings": [],
         "data_type": "int64",
+        "dataset_years": [2021, 2026],
+    },
+    {
+        "heading": "Date of leaving service",
+        "model_field": "date_leaving_service",
+        "model": "Transfer",
+        "alternative_headings": [],
+        "data_type": "date",
         "dataset_years": [2021, 2026],
     },
     {

--- a/project/npda/general_functions/csv/csv_merge.py
+++ b/project/npda/general_functions/csv/csv_merge.py
@@ -97,6 +97,13 @@ def merge_patient_rows_for_column(
                     values_by_date, unknown_value=ETHNICITIES[-1][0]
                 )
 
+            case "date_leaving_service":
+                # reason_leaving_service is processed first (see ALL_HEADINGS order),
+                # so rows with dates still have their original NaT/null values here.
+                # Pick the earliest non-null date across all rows for this patient.
+                rows[heading] = smallest(rows, heading)
+                flag_values = len(unique_values) > 1
+
             case "reason_leaving_service":
                 rows[heading] = smallest_code_with_attached_date(
                     rows, "Reason for leaving service", "Date of leaving service"

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -5723,3 +5723,217 @@ def test_uploading_csv_with_first_row_missing_pdu_number(
         "Submission should be created for upload where first row is missing PDU number but subsequent rows have correct PDU number"
     )
     assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ004"
+
+
+@pytest.mark.django_db
+def test_transfer_date_and_reason_leaving_service_are_saved(
+    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
+):
+    """
+    Regression: both date_leaving_service and reason_leaving_service must be
+    persisted to the Transfer instance when both are present in the CSV.
+
+    This test sets pd.Timestamp directly — it verifies that csv_upload's
+    row_to_dict / PatientForm / get_valid_transfer_fields pipeline works
+    correctly given already-parsed dates.  For the full end-to-end path
+    (including the csv_parse string→Timestamp conversion) see
+    test_transfer_date_and_reason_leaving_service_saved_via_full_parse.
+    """
+    leave_date = date(2022, 6, 1)
+    leave_reason = LEAVE_PDU_REASONS[0][0]  # 1 = Transitioned to adult diabetes service
+
+    single_row_valid_df.loc[0, "Date of leaving service"] = pd.Timestamp(leave_date)
+    single_row_valid_df.loc[0, "Reason for leaving service"] = leave_reason
+
+    errors = csv_upload_sync(
+        test_user,
+        single_row_valid_df,
+        _audit_period=audit_period_for_dataset_year,
+    )
+
+    assert Transfer.objects.count() == 1
+    transfer = Transfer.objects.first()
+
+    assert transfer.date_leaving_service == leave_date, (
+        f"Expected date_leaving_service={leave_date}, got {transfer.date_leaving_service}"
+    )
+    assert transfer.reason_leaving_service == leave_reason, (
+        f"Expected reason_leaving_service={leave_reason}, got {transfer.reason_leaving_service}"
+    )
+
+
+@pytest.mark.django_db
+def test_transfer_date_leaving_service_resolved_from_later_row(
+    test_user, one_patient_with_four_visits
+):
+    """
+    Regression for PZ016: when a patient has multiple rows and only a later
+    row carries date_leaving_service + reason_leaving_service, both must still
+    be saved to the Transfer instance.
+
+    Previously merge_rows_for_patient had no case for date_leaving_service in
+    its match statement.  It correctly resolved reason_leaving_service (via
+    smallest_code_with_attached_date) and wrote the resolved value onto all
+    rows, but left date_leaving_service unmodified — so rows.iloc[0] still had
+    NaT.  PatientForm.clean() then saw reason supplied but no date, added an
+    "invalid"-code error, and get_valid_transfer_fields nulled the date out.
+    """
+    df = one_patient_with_four_visits
+
+    leave_date = date(2022, 6, 1)
+    leave_reason = LEAVE_PDU_REASONS[0][0]  # 1 = Transitioned to adult diabetes service
+
+    # Only the last row carries the transfer date and reason — earlier rows are empty
+    df.loc[0, "Date of leaving service"] = None
+    df.loc[0, "Reason for leaving service"] = None
+    df.loc[1, "Date of leaving service"] = None
+    df.loc[1, "Reason for leaving service"] = None
+    df.loc[2, "Date of leaving service"] = None
+    df.loc[2, "Reason for leaving service"] = None
+    df.loc[3, "Date of leaving service"] = pd.Timestamp(leave_date)
+    df.loc[3, "Reason for leaving service"] = leave_reason
+
+    errors = csv_upload_sync(test_user, df)
+
+    assert Transfer.objects.count() == 1
+    transfer = Transfer.objects.first()
+
+    assert transfer.date_leaving_service == leave_date, (
+        f"date_leaving_service was not resolved from the later row. "
+        f"Expected {leave_date}, got {transfer.date_leaving_service}. "
+        f"Upload errors: {dict(errors)}"
+    )
+    assert transfer.reason_leaving_service == leave_reason, (
+        f"Expected reason_leaving_service={leave_reason}, got {transfer.reason_leaving_service}"
+    )
+
+
+@pytest.mark.django_db
+def test_transfer_date_and_reason_leaving_service_saved_via_full_parse(
+    test_user, dummy_sheet_csv, audit_period_for_dataset_year, dataset_year
+):
+    """
+    Production-faithful regression test: both date_leaving_service and
+    reason_leaving_service must survive the full pipeline:
+      raw CSV string → csv_parse (string→pd.Timestamp) → csv_upload.
+
+    The previous test sets a pd.Timestamp directly, bypassing csv_parse.
+    This one uses modify_raw_csv + read_csv_from_str so the date string
+    "01/06/2022" must be parsed by csv_parse exactly as it would be in
+    production.  If csv_parse silently coerces date_leaving_service to NaT
+    (e.g. wrong format), PatientForm's cross-field validation adds an
+    "invalid" error → get_valid_transfer_fields nulls the field → Transfer
+    has date_leaving_service=None even though reason_leaving_service saved.
+    """
+    leave_date = date(2022, 6, 1)
+    leave_date_str = "01/06/2022"  # DD/MM/YYYY — the format the NPDA template uses
+    leave_reason = LEAVE_PDU_REASONS[0][0]  # 1 = Transitioned to adult diabetes service
+
+    modified_csv = modify_raw_csv(
+        dummy_sheet_csv,
+        replacements=[
+            {
+                "row": 1,
+                "column": "Date of leaving service",
+                "value": leave_date_str,
+            },
+            {
+                "row": 1,
+                "column": "Reason for leaving service",
+                "value": str(leave_reason),
+            },
+        ],
+    )
+
+    parsed = read_csv_from_str(modified_csv, dataset_year=dataset_year)
+    df = parsed.df.head(1)
+
+    errors = csv_upload_sync(
+        test_user,
+        df,
+        _audit_period=audit_period_for_dataset_year,
+    )
+
+    assert Transfer.objects.count() == 1, (
+        f"Expected 1 Transfer, got {Transfer.objects.count()}. Upload errors: {dict(errors)}"
+    )
+    transfer = Transfer.objects.first()
+
+    assert transfer.date_leaving_service == leave_date, (
+        f"date_leaving_service was dropped during csv_parse or csv_upload. "
+        f"Expected {leave_date}, got {transfer.date_leaving_service}. "
+        f"Upload errors: {dict(errors)}"
+    )
+    assert transfer.reason_leaving_service == leave_reason, (
+        f"Expected reason_leaving_service={leave_reason}, got {transfer.reason_leaving_service}"
+    )
+
+
+@pytest.mark.django_db
+def test_reason_leaving_service_without_date_is_silently_dropped(
+    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
+):
+    """
+    A reason_leaving_service with no attached date_leaving_service is silently
+    discarded by the merge step.
+
+    merge_rows_for_patient processes reason_leaving_service via
+    smallest_code_with_attached_date, which does dropna(subset=["Date of
+    leaving service"]).  When no row has a date, it returns None — so the
+    reason is nulled before PatientForm ever sees it.  Both fields arrive at
+    PatientForm as None, so no cross-field validation error is raised and the
+    Transfer is created with both fields null.
+
+    This is the intended gate-keeping behaviour: a reason without a date
+    carries no clinical meaning and is discarded rather than stored
+    inconsistently.
+    """
+    leave_reason = LEAVE_PDU_REASONS[0][0]
+
+    single_row_valid_df.loc[0, "Reason for leaving service"] = leave_reason
+    single_row_valid_df.loc[0, "Date of leaving service"] = None
+
+    errors = csv_upload_sync(
+        test_user,
+        single_row_valid_df,
+        _audit_period=audit_period_for_dataset_year,
+    )
+
+    # No cross-field error — the merge step already discarded the orphaned reason
+    assert "date_leaving_service" not in errors[0]
+    assert "reason_leaving_service" not in errors[0]
+
+    assert Transfer.objects.count() == 1
+    transfer = Transfer.objects.first()
+    assert transfer.date_leaving_service is None
+    assert transfer.reason_leaving_service is None
+
+
+@pytest.mark.django_db
+def test_date_leaving_service_without_reason_raises_error(
+    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
+):
+    """
+    A date_leaving_service supplied without a reason_leaving_service must raise a
+    validation error on reason_leaving_service.  PatientForm.clean() enforces this
+    cross-field rule and the error code is "invalid", so get_valid_transfer_fields
+    nulls reason_leaving_service in the Transfer (it was already None), but date
+    survives because there is no error on that field.
+    """
+    leave_date = date(2022, 6, 1)
+
+    single_row_valid_df.loc[0, "Date of leaving service"] = pd.Timestamp(leave_date)
+    single_row_valid_df.loc[0, "Reason for leaving service"] = None
+
+    errors = csv_upload_sync(
+        test_user,
+        single_row_valid_df,
+        _audit_period=audit_period_for_dataset_year,
+    )
+
+    assert "reason_leaving_service" in errors[0], (
+        "Expected a validation error on reason_leaving_service when date is set without a reason"
+    )
+
+    assert Transfer.objects.count() == 1
+    assert Transfer.objects.first().reason_leaving_service is None


### PR DESCRIPTION
## fix: `date_leaving_service` dropped from Transfer when set on a later CSV row

### Problem

When a patient has multiple rows in an uploaded CSV and only a later row carries both `Date of leaving service` and `Reason for leaving service`, the date was silently lost — only the reason was saved to the `Transfer` instance.

This was confirmed against a real submission (PZ016 Q4 2025/26) where 6 patients had a visit row with no transfer data followed by a later row with both fields populated.

### Root cause

`merge_rows_for_patient` iterates `ALL_HEADINGS` and calls `merge_patient_rows_for_column` for each Patient/Transfer field. The `match` statement had a case for `reason_leaving_service` — `smallest_code_with_attached_date`, which correctly filters to rows that carry a date and picks the smallest reason code — but **no case for `date_leaving_service`**.

This meant `rows.iloc[0]` (the first row, used as the patient row downstream) still held `NaT` for the date after the merge. `PatientForm.clean()` then saw reason supplied with no date, added an `"invalid"`-code `ValidationError` on `date_leaving_service`, and `get_valid_transfer_fields` nulled it out — leaving the Transfer with only the reason.

### Fix

**`project/npda/general_functions/csv/csv_merge.py`** — add the missing `case "date_leaving_service"` using `smallest(rows, heading)`, picking the earliest non-null date across all rows for the patient.

**`project/constants/csv_headings.py`** — swap `reason_leaving_service` before `date_leaving_service` in `ALL_HEADINGS`. This controls merge iteration order and is required because `smallest_code_with_attached_date` reads `"Date of leaving service"` via `dropna` to identify eligible rows. If the date case ran first (writing a resolved scalar back to all rows), `dropna` would find no nulls and could select the wrong reason code in the conflicting-values scenario.

### Tests added (`project/npda/tests/test_csv_upload.py`)

| Test | What it covers |
|------|---------------|
| `test_transfer_date_leaving_service_resolved_from_later_row` | Core regression: date+reason only on last of 4 rows, both must save to Transfer |
| `test_transfer_date_and_reason_leaving_service_are_saved` | Both fields set as `pd.Timestamp` directly; verifies the csv_upload pipeline (2021 & 2026) |
| `test_transfer_date_and_reason_leaving_service_saved_via_full_parse` | Full pipeline including `csv_parse` string→Timestamp conversion (2021 & 2026) |
| `test_reason_leaving_service_without_date_is_silently_dropped` | Reason with no date is discarded at the merge step — not an error |
| `test_date_leaving_service_without_reason_raises_error` | Date with no reason raises a validation error on `reason_leaving_service` via `PatientForm.clean()` |

### Documentation

Added two new sections to `AGENTS.md` covering the full CSV pipeline — `csv_parse`/`csv_headings` structure and the `csv_upload` flow including Transfer field handling — so future agents understand the multi-step parse→merge→validate→save path before touching this code.

closes #1378