### PR TITLE
Fix thyroid to apply to all t1 patients with complete year of care

### DIFF
--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -172,8 +172,7 @@ def annotate_health_checks(qs, audit_period):
             output_field=BooleanField(),
         ),
         passed_thyroid_screen=Case(
-            When(Q(dx_over_1y=True) & thyroid_exists, then=True),
-            When(Q(dx_over_1y=False), then=None),
+            When(thyroid_exists, then=True),
             default=False,
             output_field=BooleanField(),
         ),

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -119,7 +119,7 @@ class TestPatientReportHealthCheckQueries:
 
         assert row["is_gte_12yo"] is False
         assert row["passed_thyroid_screen"] is False
-    
+
     # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1399
     def test_thyroid_screening_required_after_first_year_of_diagnosis(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -118,6 +118,33 @@ class TestPatientReportHealthCheckQueries:
 
         assert row["is_gte_12yo"] is False
         assert row["passed_thyroid_screen"] is None
+    
+    # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1399
+    def test_thyroid_screening_required_after_first_year_of_diagnosis(
+        self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+    ):
+        user, pdu = self._get_user_and_pdu()
+        audit_period = AuditPeriod.objects.get_default_audit_period()
+
+        patient = PatientFactory(
+            nhs_number="1111111122",
+            diabetes_type=DIABETES_TYPES[0][0],
+            date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+            diagnosis_date=audit_period.start_date - relativedelta(days=10),
+        )
+        VisitFactory(
+            patient=patient,
+            visit_date=audit_period.start_date + relativedelta(days=10),
+            hba1c=50,
+            hba1c_format=HBA1C_FORMATS[0][0],
+            hba1c_date=audit_period.start_date + relativedelta(days=10),
+        )
+        self._create_submission(pdu, audit_period, user, [patient])
+
+        rows = self._get_health_check_rows(pdu, audit_period)
+        row = rows[patient.pk]
+
+        assert row["passed_thyroid_screen"] is False
 
     def test_retinal_screening_under_12_is_not_required(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -92,9 +92,10 @@ class TestPatientReportHealthCheckQueries:
         assert row["passed_foot_exam"] is None
         assert row["num_total"] == 3
 
-    def test_thyroid_screening_not_required_within_first_year_of_diagnosis(
+    def test_thyroid_screening_required_within_first_year_of_diagnosis(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
+        """Thyroid screen is always required regardless of diabetes duration."""
         user, pdu = self._get_user_and_pdu()
         audit_period = AuditPeriod.objects.get_default_audit_period()
 
@@ -117,7 +118,7 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is False
-        assert row["passed_thyroid_screen"] is None
+        assert row["passed_thyroid_screen"] is False
     
     # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1399
     def test_thyroid_screening_required_after_first_year_of_diagnosis(

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -165,16 +165,6 @@ This shows the mean and median HbA1c (both as IFCC and DCCT) of all visit HbA1cs
 |--------|------------|------------|-------|
 | All HbA1c values | `hba1c` + `hba1c_format` + `hba1c_date` | `hba1c` + `hba1c_date` | In 2026 `hba1c_format` is deprecated; values are always mmol/mol. Queries must not rely on `hba1c_format` being non-null for 2026 data. |
 
-## Shortcomings of the current methodology
-
-1. The queries that power the patient report come from the KPI class which are not optimised for generating patient level views, leading to long queries that are slow to run. The KPI class was originally written for PDU level summaries and does not work well at the patient level.
-2. The patient report should only capture patient visits in the audit period selected
-3. Edge cases appear where patients are flagged as having incomplete measures when they are in fact complete. These include:
-   1. thyroid screening: within the Health Check category, this applies to children with more than 1 year of diagnosis. They must have a thryoid function observation date within the audit year to show complete. If they do not they are incomplete. If they are within the first year of care they should be not required.
-   2. thyroid screening: within the Care at Diagnosis category, this applies to children who have had a thyroid function observation date filled within 90 days of the diagnosis date. If they do not, they are marked as incomplete. If they have had diabetes for more than a year, they are marked as not required.
-   3. eye screening: this is only required in the >=12y olds who have had diabetes more than one year. It is a measure that is captured every two years, so children must have had an eye screening result recorded in the current audit year or the previous to score as complete. If they do not they should be incomplete. If they are within a year of diagnosis, they should flag as not required. If they have transferred into the unit during the audit year they should flag as incomplete year of care.
-   4. carbohydrate counting date. This measure is counted in the Care at Diagnosis category and scores complete if a patient has received carbohydrate counting training within 14 days of diagnosis.
-   5. pH and bicarbonate levels at diagnosis are currently not captured and should be captured in the Care at Diagnosis category. (see issue #485)
 
 ## Implementation
 
@@ -221,7 +211,7 @@ This should involve:
 
 - HbA1c: `Exists` visit with `hba1c` and `hba1c_date` in audit range.
 - BMI: `Exists` visit with `bmi` and `height_weight_observation_date` in audit range.
-- Thyroid screen: `Exists` visit with `thyroid_function_date` in audit range; not required if diabetes duration < 1 year.
+- Thyroid screen: `Exists` visit with `thyroid_function_date` in audit range;
 - Blood pressure: `Exists` visit with `systolic_blood_pressure` and `blood_pressure_observation_date` in audit range; only required if >= 12.
 - Urinary albumin: `Exists` visit with `albumin_creatinine_ratio` and `albumin_creatinine_ratio_date` in audit range; only required if >= 12.
 - Foot exam: `Exists` visit with `foot_examination_observation_date` in audit range; only required if >= 12.

--- a/project/npda/views/patient_report/patient_report.py
+++ b/project/npda/views/patient_report/patient_report.py
@@ -427,7 +427,6 @@ class PatientReportView(
                 "urinary_albumin": "Not required as less than 12 years old",
                 "foot_exam": "Not required as less than 12 years old",
                 "retinal_screening": "Not required as less than 12 years old",
-                "thyroid_screen": "Not required as within 1 year of diagnosis",
             }
 
             qs = self.object_list


### PR DESCRIPTION
#1340 and #1398 incorrectly calculated thyroid screening so patients diagnosed after 1 year *before* the start of the current audit period were not marked as complete.

This PR adds a test specifically for that case and fixes the problem by applying thyroid screen to all t1 patients with a complete year of care.

This likely resolves #1399 but we need to check the other units not just PZ122