### PR TITLE
Fix retinal screening inclusion criteria

### DIFF
--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -64,9 +64,6 @@ def build_base_queryset(pdu, audit_period, *, type1_only=True):
             is_gte_12yo=Q(
                 date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
             ),
-            dx_over_1y=Q(
-                diagnosis_date__lte=audit_period.start_date - relativedelta(years=1)
-            ),
             is_incomplete_year_of_care=Case(
                 # Diagnosed within the audit year
                 When(
@@ -196,11 +193,11 @@ def annotate_health_checks(qs, audit_period):
         ),
         passed_retinal_screening=Case(
             When(
-                Q(is_gte_12yo=True) & Q(dx_over_1y=True) & retinal_exists,
+                Q(is_gte_12yo=True) & retinal_exists,
                 then=Value("complete"),
             ),
             When(
-                Q(is_gte_12yo=False) | Q(dx_over_1y=False), then=Value("not_required")
+                Q(is_gte_12yo=False), then=Value("not_required")
             ),
             default=Value(""),
             output_field=CharField(),
@@ -497,35 +494,32 @@ def annotate_care_at_diagnosis(qs, audit_period):
             output_field=DateField(),
         ),
         carbohydrate_counting_education=Case(
-            When(Q(dx_over_1y=False) & carb_on_time, then=True),
-            When(Q(dx_over_1y=True), then=None),
+            When(carb_on_time, then=True),
             default=False,
             output_field=BooleanField(),
         ),
         carbohydrate_counting_missed=Case(
-            When(Q(dx_over_1y=False) & carb_missed, then=True),
+            When(carb_missed, then=True),
             default=False,
             output_field=BooleanField(),
         ),
         coeliac_disease_screening=Case(
-            When(Q(dx_over_1y=False) & coeliac_on_time, then=True),
-            When(Q(dx_over_1y=True), then=None),
+            When(coeliac_on_time, then=True),
             default=False,
             output_field=BooleanField(),
         ),
         coeliac_screen_missed=Case(
-            When(Q(dx_over_1y=False) & coeliac_missed, then=True),
+            When(coeliac_missed, then=True),
             default=False,
             output_field=BooleanField(),
         ),
         thyroid_disease_screening=Case(
-            When(Q(dx_over_1y=False) & thyroid_on_time, then=True),
-            When(Q(dx_over_1y=True), then=None),
+            When(thyroid_on_time, then=True),
             default=False,
             output_field=BooleanField(),
         ),
         thyroid_screen_missed=Case(
-            When(Q(dx_over_1y=False) & thyroid_missed, then=True),
+            When(thyroid_missed, then=True),
             default=False,
             output_field=BooleanField(),
         ),

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -196,9 +196,7 @@ def annotate_health_checks(qs, audit_period):
                 Q(is_gte_12yo=True) & retinal_exists,
                 then=Value("complete"),
             ),
-            When(
-                Q(is_gte_12yo=False), then=Value("not_required")
-            ),
+            When(Q(is_gte_12yo=False), then=Value("not_required")),
             default=Value(""),
             output_field=CharField(),
         ),

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -322,7 +322,6 @@ class TestPatientReportHealthCheckQueries:
 
         assert row["is_gte_12yo"] is True
         assert row["passed_retinal_screening"] == ""
-    
 
     def test_retinal_screening_required_after_first_year_of_diagnosis(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
@@ -351,8 +350,9 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] == "" # we don't fail, just blank (see #1272)
-
+        assert (
+            row["passed_retinal_screening"] == ""
+        )  # we don't fail, just blank (see #1272)
 
     def test_retinal_screening_with_date_but_no_result_is_blank(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -322,6 +322,37 @@ class TestPatientReportHealthCheckQueries:
 
         assert row["is_gte_12yo"] is True
         assert row["passed_retinal_screening"] == "not_required"
+    
+
+    def test_retinal_screening_required_after_first_year_of_diagnosis(
+        self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+    ):
+        user, pdu = self._get_user_and_pdu()
+        audit_period = AuditPeriod.objects.get_default_audit_period()
+
+        patient = PatientFactory(
+            nhs_number="1212121212",
+            diabetes_type=DIABETES_TYPES[0][0],
+            date_of_birth=audit_period.start_date - relativedelta(years=14),
+            diagnosis_date=audit_period.start_date - relativedelta(days=30),
+        )
+
+        VisitFactory(
+            patient=patient,
+            visit_date=audit_period.start_date + relativedelta(days=10),
+            hba1c=55,
+            hba1c_format=HBA1C_FORMATS[0][0],
+            hba1c_date=audit_period.start_date + relativedelta(days=10),
+        )
+
+        self._create_submission(pdu, audit_period, user, [patient])
+
+        rows = self._get_health_check_rows(pdu, audit_period)
+        row = rows[patient.pk]
+
+        assert row["is_gte_12yo"] is True
+        assert row["passed_retinal_screening"] == "" # we don't fail, just blank (see #1272)
+
 
     def test_retinal_screening_with_date_but_no_result_is_blank(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture

--- a/project/npda/tests/general_functions_tests/test_patient_report_queries.py
+++ b/project/npda/tests/general_functions_tests/test_patient_report_queries.py
@@ -294,7 +294,7 @@ class TestPatientReportHealthCheckQueries:
 
         assert row["passed_retinal_screening"] == ""
 
-    def test_retinal_screening_not_required_within_first_year_of_diagnosis(
+    def test_retinal_screening_required_within_first_year_of_diagnosis(
         self, seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
     ):
         user, pdu = self._get_user_and_pdu()
@@ -321,7 +321,7 @@ class TestPatientReportHealthCheckQueries:
         row = rows[patient.pk]
 
         assert row["is_gte_12yo"] is True
-        assert row["passed_retinal_screening"] == "not_required"
+        assert row["passed_retinal_screening"] == ""
     
 
     def test_retinal_screening_required_after_first_year_of_diagnosis(

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -671,6 +671,71 @@ def test_care_at_diagnosis_for_type_1_patient(
     assert not patient["thyroid_disease_screening"]
 
 
+@pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
+@pytest.mark.django_db
+def test_patient_diagnosed_more_than_90_days_before_audit_date_is_not_in_care_at_diagnosis_view(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+    audit_period_slug,
+):
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug=audit_period_slug)
+    audit_period.is_open = True
+    audit_period.save()
+
+    date_of_birth = audit_period.start_date - relativedelta(years=14)
+
+    patient = PatientFactory(
+        nhs_number="4444444444",
+        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
+        date_of_birth=date_of_birth,
+        diagnosis_date=audit_period.start_date
+        - relativedelta(days=91),  # diagnosed more than 90 days before audit date
+    )
+
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        carbohydrate_counting_level_three_education_date=visit_date,
+    )
+
+    submission = Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_year=audit_period.start_date.year,
+        audit_period=audit_period,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+    submission.patients.add(patient)
+
+    url = reverse(
+        "pdu-patient-report",
+        kwargs={
+            "audit_period": audit_period.slug,
+            "pz_code": ALDER_HEY_PZ_CODE,
+        },
+    )
+
+    response = client.get(
+        url + f"?category={TableCategories.CARE_AT_DIAGNOSIS.value}",
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == HTTPStatus.OK
+
+    assert len(response.context["patients"]) == 0
+
+
 # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/1301
 @pytest.mark.parametrize("audit_period_slug", ["2024-2025", "2026-2027"])
 @pytest.mark.django_db

--- a/project/npda/views/patient_report/patient_report.md
+++ b/project/npda/views/patient_report/patient_report.md
@@ -215,7 +215,7 @@ This should involve:
 - Blood pressure: `Exists` visit with `systolic_blood_pressure` and `blood_pressure_observation_date` in audit range; only required if >= 12.
 - Urinary albumin: `Exists` visit with `albumin_creatinine_ratio` and `albumin_creatinine_ratio_date` in audit range; only required if >= 12.
 - Foot exam: `Exists` visit with `foot_examination_observation_date` in audit range; only required if >= 12.
-- Eye screen: `Exists` visit with `retinal_screening_observation_date` and `retinal_screening_result` in audit range; not required if < 12 or diabetes duration < 1 year.
+- Eye screen: `Exists` visit with `retinal_screening_observation_date` and `retinal_screening_result` in audit range; not required if < 12. 
   - If not present, return a blank entry in the report not "incomplete". This is because the screen is only mandatory bi-annually.
 - Total: `num_passed` vs `num_total` (3 for < 12, 6 for >= 12).
 


### PR DESCRIPTION
As part of https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1401 I noticed a related bug with retinal screening introduced in #1340 and #1398.

It was using the same buggy `dx_over_1y` criteria (which we removed from thyroid screening in #1401). Rather than mark patients as failed though it was marking them as "not required" if they were diagnosed in the previous audit year.

This PR removes `dx_over_1y` entirely, adding a test to cover the retinal screening case above. It was a redundant check for the care at diagnosis view as we already filtered the patient queryset to just those diagnosed in the audit year. But for completeness I have added a passing test that patients diagnosed outside the audit year are not present in the care at diagnosis view.