### PR TITLE
HCL dashboard and patient report fixes

### DIFF
--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -647,11 +647,13 @@ def annotate_treatment(qs, audit_period):
             .values("glucose_monitoring")[:1]
         )
 
+        # Anchored to the same visit as the latest treatment so that closed_loop_system
+        # reflects the patient's current regimen, not a historical visit.
         latest_closed_loop = Subquery(
             Visit.objects.filter(
                 patient=OuterRef("pk"),
                 visit_date__range=audit_range,
-                closed_loop_system__isnull=False,
+                treatment__isnull=False,
             )
             .order_by("-visit_date")
             .values("closed_loop_system")[:1]
@@ -675,8 +677,12 @@ def annotate_treatment(qs, audit_period):
             output_field=CharField(),
         )
 
+        # HCL requires both a pump treatment AND a closed loop system on that same visit.
         hcl_case = Case(
-            When(latest_closed_loop__in=[2, 3, 4], then=Value("Yes")),
+            When(
+                Q(latest_treatment__in=[3, 6]) & Q(latest_closed_loop__in=[2, 3, 4]),
+                then=Value("Yes"),
+            ),
             default=Value("No"),
             output_field=CharField(),
         )

--- a/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
+++ b/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
@@ -349,6 +349,194 @@ def test_count_hcl_use_2026_insulin_regimen_5_is_passed(
 
 
 # ---------------------------------------------------------------------------
+# count_hcl_use — regression: patients who reverted from HCL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_count_hcl_use_2021_reverted_patient_excluded_from_total(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2021 dataset regression: a patient whose earliest visit was HCL (pump +
+    closed loop) but whose most recent treatment visit is back on injections
+    must NOT be counted in the HCL total.
+
+    Three patients:
+      - currently_on_hcl:  latest visit = pump + licensed closed loop → passed
+      - reverted_to_injections: earlier visit = pump + licensed closed loop,
+                                 latest visit = injections               → NOT passed
+      - never_on_hcl:     only ever on injections                       → NOT passed
+
+    Expected: passed=1, eligible=3
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    currently_on_hcl = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+    reverted_to_injections = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+    never_on_hcl = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # currently_on_hcl: single visit, pump + closed loop
+    VisitFactory(
+        patient=currently_on_hcl,
+        visit_date=visit_date,
+        treatment=3,  # insulin pump
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = licensed
+    )
+
+    # reverted_to_injections: first visit was HCL, latest is injections
+    VisitFactory(
+        patient=reverted_to_injections,
+        visit_date=visit_date,
+        treatment=3,  # pump
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = licensed
+    )
+    VisitFactory(
+        patient=reverted_to_injections,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=2,  # four or more injections/day — no longer on pump
+        closed_loop_system=CLOSED_LOOP_TYPES[0][0],  # 1 = No
+    )
+
+    # never_on_hcl: only ever on injections
+    VisitFactory(
+        patient=never_on_hcl,
+        visit_date=visit_date,
+        treatment=2,
+        closed_loop_system=CLOSED_LOOP_TYPES[0][0],  # 1 = No
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(currently_on_hcl, reverted_to_injections, never_on_hcl)
+
+    passed, eligible = count_hcl_use(pdu, audit_period)
+
+    assert eligible == 3
+    assert passed == 1  # only currently_on_hcl passes
+
+
+@pytest.mark.django_db
+def test_count_hcl_use_2021_closed_loop_on_older_visit_not_counted(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2021 dataset regression: a patient whose latest treatment visit records a
+    pump but has no closed_loop_system value (None) on that visit must NOT be
+    counted, even if an older visit recorded a closed loop system.
+
+    The closed_loop_system value must come from the same visit as the latest
+    treatment.
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # Older visit: pump + closed loop recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=3,
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = licensed
+    )
+    # Latest visit: still on pump, but closed_loop_system not recorded this time
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=3,
+        closed_loop_system=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    passed, eligible = count_hcl_use(pdu, audit_period)
+
+    assert eligible == 1
+    assert passed == 0  # closed_loop_system is null on the latest treatment visit
+
+
+@pytest.mark.django_db
+def test_count_hcl_use_2026_reverted_patient_excluded_from_total(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2026 dataset regression: a patient whose earlier visit had insulin_regimen=5
+    (HCL) but whose most recent insulin_regimen visit is a standalone pump (4)
+    must NOT be counted in the HCL total.
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    still_on_hcl = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+    reverted_to_pump = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # still_on_hcl: single visit, insulin_regimen=5
+    VisitFactory(
+        patient=still_on_hcl,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        insulin_regimen=5,  # Hybrid closed loop
+    )
+
+    # reverted_to_pump: first visit was HCL, latest is standalone pump
+    VisitFactory(
+        patient=reverted_to_pump,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        insulin_regimen=5,  # Hybrid closed loop
+    )
+    VisitFactory(
+        patient=reverted_to_pump,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        insulin_regimen=4,  # Standalone pump — no longer HCL
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(still_on_hcl, reverted_to_pump)
+
+    passed, eligible = count_hcl_use(pdu, audit_period)
+
+    assert eligible == 2
+    assert passed == 1  # only still_on_hcl passes
+
+
+# ---------------------------------------------------------------------------
 # count_pump_use — 2021 dataset
 # ---------------------------------------------------------------------------
 

--- a/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
+++ b/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
@@ -738,6 +738,228 @@ def test_count_cgm_use_2026_cgm_use_yes_is_passed(
 
 
 # ---------------------------------------------------------------------------
+# count_cgm_use — regression: patients who reverted from CGM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_count_cgm_use_2021_reverted_patient_excluded_from_total(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2021 dataset regression: a patient whose earlier visit recorded real-time CGM
+    (glucose_monitoring=4) but whose most recent non-null glucose_monitoring visit
+    shows a different monitoring type must NOT be counted in the CGM total.
+
+    Two patients:
+      - still_on_cgm:    latest glucose_monitoring=4 → passed
+      - reverted_to_flash: earlier=4, latest=2 (flash) → NOT passed
+
+    Expected: passed=1, eligible=2
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    still_on_cgm = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+    reverted_to_flash = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # still_on_cgm: single visit, real-time CGM
+    VisitFactory(
+        patient=still_on_cgm,
+        visit_date=visit_date,
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM
+    )
+
+    # reverted_to_flash: earlier visit was CGM, latest is flash
+    VisitFactory(
+        patient=reverted_to_flash,
+        visit_date=visit_date,
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM
+    )
+    VisitFactory(
+        patient=reverted_to_flash,
+        visit_date=visit_date + relativedelta(days=90),
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[1][0],  # 2 = flash
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(still_on_cgm, reverted_to_flash)
+
+    passed, eligible = count_cgm_use(pdu, audit_period)
+
+    assert eligible == 2
+    assert passed == 1  # only still_on_cgm passes
+
+
+@pytest.mark.django_db
+def test_count_cgm_use_2021_later_visit_null_falls_back_to_earlier_cgm(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2021 dataset: a patient whose earlier visit recorded real-time CGM
+    (glucose_monitoring=4) and whose later visit has glucose_monitoring=None
+    (not recorded) must still be counted — the subquery falls back to the
+    most recent visit with a non-null value.
+
+    Expected: passed=1, eligible=1
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # Earlier visit: CGM recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM
+    )
+    # Later visit: glucose_monitoring not recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        glucose_monitoring=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    passed, eligible = count_cgm_use(pdu, audit_period)
+
+    assert eligible == 1
+    assert passed == 1  # falls back to the earlier CGM visit
+
+
+@pytest.mark.django_db
+def test_count_cgm_use_2026_reverted_patient_excluded_from_total(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2026 dataset regression: a patient whose earlier visit had cgm_use=1 (Yes)
+    but whose most recent non-null cgm_use visit shows No (2) must NOT be counted.
+
+    Two patients:
+      - still_on_cgm:   latest cgm_use=1 → passed
+      - reverted_to_no: earlier=1, latest=2 → NOT passed
+
+    Expected: passed=1, eligible=2
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    still_on_cgm = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+    reverted_to_no = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # still_on_cgm: single visit, cgm_use=Yes
+    VisitFactory(
+        patient=still_on_cgm,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=1,  # Yes
+    )
+
+    # reverted_to_no: earlier visit was Yes, latest is No
+    VisitFactory(
+        patient=reverted_to_no,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=1,  # Yes
+    )
+    VisitFactory(
+        patient=reverted_to_no,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=2,  # No
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(still_on_cgm, reverted_to_no)
+
+    passed, eligible = count_cgm_use(pdu, audit_period)
+
+    assert eligible == 2
+    assert passed == 1  # only still_on_cgm passes
+
+
+@pytest.mark.django_db
+def test_count_cgm_use_2026_later_visit_null_falls_back_to_earlier_cgm(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """
+    2026 dataset: a patient whose earlier visit had cgm_use=1 (Yes) and whose
+    later visit has cgm_use=None (not recorded) must still be counted — the
+    subquery falls back to the most recent non-null visit.
+
+    Expected: passed=1, eligible=1
+    """
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(days=1),
+    )
+
+    # Earlier visit: cgm_use=Yes
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=1,  # Yes
+    )
+    # Later visit: cgm_use not recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    passed, eligible = count_cgm_use(pdu, audit_period)
+
+    assert eligible == 1
+    assert passed == 1  # falls back to the earlier Yes visit
+
+
+# ---------------------------------------------------------------------------
 # count_admissions
 # ---------------------------------------------------------------------------
 

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -2938,7 +2938,9 @@ def test_cgm_2021_on_cgm_is_annotated_correctly(
     VisitFactory(
         patient=patient,
         visit_date=audit_period.start_date + relativedelta(days=10),
-        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM with alarms
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][
+            0
+        ],  # 4 = real-time CGM with alarms
     )
     _make_submission(user, audit_period, patient)
 

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -2906,3 +2906,286 @@ def test_hcl_from_insulin_regimen_2026_missing_penultimate_visit_counted(
     assert patient_data["patient_identifier"] == "6666666663"
     # insulin_regimen == 5 means HCL, should derive hcl = "Yes"
     assert patient_data["hcl"] == "Yes"
+
+
+# ── 2021 dataset CGM tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cgm_2021_on_cgm_is_annotated_correctly(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: a single visit with glucose_monitoring=4 (real-time CGM with
+    alarms) should annotate glucose_monitoring as the matching label.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777771",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM with alarms
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["glucose_monitoring"] == GLUCOSE_MONITORING_TYPES[3][1]
+
+
+@pytest.mark.django_db
+def test_cgm_2021_reverted_from_cgm_shows_latest_value(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: patient was on real-time CGM at an earlier visit
+    (glucose_monitoring=4) but their most recent non-null glucose_monitoring
+    visit shows flash (glucose_monitoring=2). The annotation must reflect the
+    latest non-null visit — flash, not CGM.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777772",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit: on real-time CGM
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM
+    )
+    # Most recent visit: downgraded to flash
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[1][0],  # 2 = flash
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    # Latest non-null is flash, not CGM
+    assert patients[0]["glucose_monitoring"] == GLUCOSE_MONITORING_TYPES[1][1]
+
+
+@pytest.mark.django_db
+def test_cgm_2021_later_visit_null_cgm_falls_back_to_earlier_cgm(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: patient's earlier visit has glucose_monitoring=4 (CGM) but a
+    later visit has glucose_monitoring=None (not recorded). The annotation must
+    fall back to the most recent visit that *does* have a value — the earlier CGM
+    visit — and still show CGM.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777773",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit: CGM recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        glucose_monitoring=GLUCOSE_MONITORING_TYPES[3][0],  # 4 = real-time CGM
+    )
+    # Later visit: glucose_monitoring not recorded at all
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        glucose_monitoring=None,
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    # Latest non-null falls back to the earlier CGM visit
+    assert patients[0]["glucose_monitoring"] == GLUCOSE_MONITORING_TYPES[3][1]
+
+
+# ── 2026 dataset CGM tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_cgm_2026_on_cgm_is_annotated_correctly(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: a single visit with cgm_use=1 (Yes) should annotate
+    glucose_monitoring as "Yes".
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777774",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=YES_NO_UNKNOWN[0][0],  # 1 = Yes
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["glucose_monitoring"] == YES_NO_UNKNOWN[0][1]  # "Yes"
+
+
+@pytest.mark.django_db
+def test_cgm_2026_reverted_from_cgm_shows_latest_value(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: patient had cgm_use=1 (Yes) at an earlier visit but their most
+    recent non-null cgm_use visit shows No (2). The annotation must reflect the
+    latest non-null visit — No, not Yes.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777775",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit: on CGM
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=YES_NO_UNKNOWN[0][0],  # 1 = Yes
+    )
+    # Most recent visit: no longer on CGM
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=YES_NO_UNKNOWN[1][0],  # 2 = No
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    # Latest non-null shows No
+    assert patients[0]["glucose_monitoring"] == YES_NO_UNKNOWN[1][1]  # "No"
+
+
+@pytest.mark.django_db
+def test_cgm_2026_later_visit_null_cgm_falls_back_to_earlier_cgm(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2026 dataset: patient's earlier visit has cgm_use=1 (Yes) but a later visit
+    has cgm_use=None (not recorded). The annotation must fall back to the most
+    recent visit that does have a value — the earlier Yes visit.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get(slug="2026-2027")
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="7777777776",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit: CGM recorded as Yes
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=YES_NO_UNKNOWN[0][0],  # 1 = Yes
+    )
+    # Later visit: cgm_use not recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=None,
+        closed_loop_system=None,
+        glucose_monitoring=None,
+        cgm_use=None,
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    # Falls back to the earlier non-null visit — still Yes
+    assert patients[0]["glucose_monitoring"] == YES_NO_UNKNOWN[0][1]  # "Yes"

--- a/project/npda/tests/view_tests/test_patient_report.py
+++ b/project/npda/tests/view_tests/test_patient_report.py
@@ -2376,52 +2376,8 @@ def test_glucose_monitoring_missing_penultimate_visit_counted(
     )  # "Flash glucose monitor"
 
 
-@pytest.mark.django_db
-def test_hcl_missing_penultimate_visit_counted(
-    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
-):
-    """
-    When the most recent visit has no closed_loop_system value, the hcl
-    annotation should fall back to the most recent visit that does have a value.
-    """
-    user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
-        role=test_user_audit_centre_editor_data.role,
-    ).first()
-
-    client = login_and_verify_user(client, user)
-
-    audit_period = AuditPeriod.objects.get_default_audit_period()
-    audit_period.is_open = True
-    audit_period.save()
-
-    date_of_birth = audit_period.start_date - relativedelta(years=10)
-
-    patient = PatientFactory(
-        nhs_number="5555555557",
-        diabetes_type=DIABETES_TYPES[0][0],  # T1DM
-        date_of_birth=date_of_birth,
-        diagnosis_date=audit_period.start_date - relativedelta(years=2),
-    )
-
-    visit_date = audit_period.start_date + relativedelta(days=10)
-
-    # Earlier visit WITH HCL data (value 2 = licenced closed loop → hcl = "Yes")
-    VisitFactory(
-        patient=patient,
-        visit_date=visit_date,
-        closed_loop_system=CLOSED_LOOP_TYPES[1][
-            0
-        ],  # 2 = "Closed loop system (licenced)"
-    )
-
-    # Most recent visit WITHOUT HCL data — the earlier value should still be used
-    VisitFactory(
-        patient=patient,
-        visit_date=visit_date + relativedelta(days=30),
-        closed_loop_system=None,
-    )
-
+def _make_submission(user, audit_period, patient):
+    """Helper: create an active submission and add patient to it."""
     submission = Submission.objects.create(
         paediatric_diabetes_unit=user.organisation_employers.first(),
         audit_year=audit_period.start_date.year,
@@ -2431,7 +2387,11 @@ def test_hcl_missing_penultimate_visit_counted(
         submission_active=True,
     )
     submission.patients.add(patient)
+    return submission
 
+
+def _get_treatment_patients(client, audit_period):
+    """Helper: GET the treatment tab and return the patients list from context."""
     url = reverse(
         "pdu-patient-report",
         kwargs={
@@ -2439,20 +2399,260 @@ def test_hcl_missing_penultimate_visit_counted(
             "pz_code": ALDER_HEY_PZ_CODE,
         },
     )
-
     response = client.get(
         url + f"?category={TableCategories.TREATMENT.value}",
         HTTP_HX_REQUEST="true",
     )
     assert response.status_code == HTTPStatus.OK
+    return response.context["patients"]
 
-    patients = response.context["patients"]
+
+# ── 2021 dataset HCL tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_hcl_pump_and_closed_loop_on_same_visit_is_yes(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: a single visit with treatment=3 (pump) and closed_loop_system=2
+    (licenced) should produce hcl='Yes'.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555557",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        treatment=TREATMENT_TYPES[2][0],  # 3 = Insulin pump
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = Closed loop (licenced)
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
     assert len(patients) == 1
+    assert patients[0]["hcl"] == "Yes"
 
-    patient_data = patients[0]
-    assert patient_data["patient_identifier"] == "5555555557"
-    # Should use the earlier visit's closed loop value, not the default "No"
-    assert patient_data["hcl"] == "Yes"
+
+@pytest.mark.django_db
+def test_hcl_pump_without_closed_loop_is_no(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: treatment=3 (pump) with closed_loop_system=1 (No) should
+    produce hcl='No'.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555558",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        treatment=TREATMENT_TYPES[2][0],  # 3 = Insulin pump
+        closed_loop_system=CLOSED_LOOP_TYPES[0][0],  # 1 = No
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["hcl"] == "No"
+
+
+@pytest.mark.django_db
+def test_hcl_closed_loop_without_pump_treatment_is_no(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: closed_loop_system=2 (licenced) but treatment=2 (injections,
+    not a pump) should produce hcl='No'. A closed loop device requires a pump.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555559",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        treatment=TREATMENT_TYPES[1][0],  # 2 = Four or more injections/day
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = Closed loop (licenced)
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["hcl"] == "No"
+
+
+@pytest.mark.django_db
+def test_hcl_reverted_from_hcl_to_injections_is_no(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: patient was previously on HCL (earlier visit: pump + closed loop)
+    but their most recent treatment visit shows injections. hcl should be 'No'.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555560",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Earlier visit: on HCL
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=TREATMENT_TYPES[2][0],  # 3 = Insulin pump
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = Closed loop (licenced)
+    )
+    # Most recent visit: back on injections, no closed loop
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=TREATMENT_TYPES[1][0],  # 2 = Four or more injections/day
+        closed_loop_system=CLOSED_LOOP_TYPES[0][0],  # 1 = No
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["hcl"] == "No"
+
+
+@pytest.mark.django_db
+def test_hcl_pump_plus_other_with_closed_loop_is_yes(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: treatment=6 (pump + other medication) with closed_loop_system=3
+    (DIY unlicenced) should produce hcl='Yes'. Treatment value 6 is also a pump.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555561",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        treatment=TREATMENT_TYPES[5][0],  # 6 = Insulin pump + other medication
+        closed_loop_system=CLOSED_LOOP_TYPES[2][0],  # 3 = Closed loop (DIY)
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    assert patients[0]["hcl"] == "Yes"
+
+
+@pytest.mark.django_db
+def test_hcl_latest_treatment_visit_with_null_closed_loop_is_no(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture, client
+):
+    """
+    2021 dataset: most recent treatment visit has treatment=3 (pump) but
+    closed_loop_system=None (not recorded). An older visit had closed_loop_system=2.
+    hcl should be 'No' — the closed_loop value must come from the same visit as
+    the latest treatment, not a historical one.
+    """
+    user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_editor_data.role,
+    ).first()
+    client = login_and_verify_user(client, user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    audit_period.is_open = True
+    audit_period.save()
+
+    patient = PatientFactory(
+        nhs_number="5555555562",
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=10),
+        diagnosis_date=audit_period.start_date - relativedelta(years=2),
+    )
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Older visit: pump + closed loop recorded
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        treatment=TREATMENT_TYPES[2][0],  # 3 = Insulin pump
+        closed_loop_system=CLOSED_LOOP_TYPES[1][0],  # 2 = Closed loop (licenced)
+    )
+    # Most recent visit: still on pump, but closed_loop_system not recorded this time
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date + relativedelta(days=90),
+        treatment=TREATMENT_TYPES[2][0],  # 3 = Insulin pump
+        closed_loop_system=None,
+    )
+    _make_submission(user, audit_period, patient)
+
+    patients = _get_treatment_patients(client, audit_period)
+    assert len(patients) == 1
+    # closed_loop_system is null on the latest treatment visit → hcl='No'
+    assert patients[0]["hcl"] == "No"
 
 
 # ── 2026 dataset treatment fallback tests ─────────────────────────────────────


### PR DESCRIPTION
## Fix: HCL detection reads `closed_loop_system` from the wrong visit (2021 dataset)

### Problem

`annotate_treatment()` in `queries.py` builds three independent subqueries for the 2021 dataset:

- `latest_treatment` — most recent visit with a non-null `treatment` value
- `latest_glucose_monitoring` — most recent visit with a non-null `glucose_monitoring` value
- `latest_closed_loop` — most recent visit with a non-null `closed_loop_system` value

Because each subquery scans independently, they can resolve to **different visits**. This caused two bugs in the `hcl` annotation (and therefore in `count_hcl_use()` on the dashboard):

1. **False positive — reversion not detected.** A patient who was previously on HCL (pump + closed loop) but reverted to injections would still be flagged `hcl="Yes"` if any older visit recorded `closed_loop_system in [2, 3, 4]`, because `latest_closed_loop` returned the older closed-loop visit rather than the current treatment visit.

2. **False positive — no pump required.** The original `hcl_case` only checked `latest_closed_loop__in=[2, 3, 4]`; it did not require a pump treatment. A patient on injections who had any historical visit with a closed-loop value set could be incorrectly counted as HCL.

### Fix

`latest_closed_loop` is now anchored to the same visit as `latest_treatment` by filtering on `treatment__isnull=False` (instead of `closed_loop_system__isnull=False`). This means `closed_loop_system` is always read from the visit that determines the patient's current treatment regimen.

`hcl_case` is updated to require **both** conditions on that same visit:

```python
# Before
When(Q(latest_closed_loop__in=[2, 3, 4]), then=Value("Yes"))

# After
When(
    Q(latest_treatment__in=[3, 6]) & Q(latest_closed_loop__in=[2, 3, 4]),
    then=Value("Yes"),
)
```

The 2026 dataset branch is unaffected — HCL is encoded atomically as `insulin_regimen=5` with no separate closed-loop field.

And for PZ122
**Before:**
Pump: 173/257
Closed Loop: 169/257
CGM: 252/257

**After:**
Pump: 173/257
Closed Loop: 169/257
CGM: 248/257

---

### Tests added

| Test | File | Dataset | Scenario | Expected |
|---|---|---|---|---|
| `test_hcl_pump_and_closed_loop_on_same_visit_is_yes` | test_patient_report.py | 2021 | `treatment=3`, `closed_loop=2` same visit | `hcl="Yes"` |
| `test_hcl_pump_without_closed_loop_is_no` | test_patient_report.py | 2021 | `treatment=3`, `closed_loop=1` (No) | `hcl="No"` |
| `test_hcl_closed_loop_without_pump_treatment_is_no` | test_patient_report.py | 2021 | `treatment=2` (injections), `closed_loop=2` | `hcl="No"` |
| `test_hcl_reverted_from_hcl_to_injections_is_no` | test_patient_report.py | 2021 | Earlier: pump + HCL; latest: injections | `hcl="No"` |
| `test_hcl_pump_plus_other_with_closed_loop_is_yes` | test_patient_report.py | 2021 | `treatment=6`, `closed_loop=3` (DIY) | `hcl="Yes"` |
| `test_hcl_latest_treatment_visit_with_null_closed_loop_is_no` | test_patient_report.py | 2021 | Latest pump visit has `closed_loop=None`; older had `closed_loop=2` | `hcl="No"` |
| `test_count_hcl_use_2021_reverted_patient_excluded_from_total` | test_dashboard_kpi_calculations.py | 2021 | 3 patients: currently HCL / reverted to injections / never HCL | `passed=1, eligible=3` |
| `test_count_hcl_use_2021_closed_loop_on_older_visit_not_counted` | test_dashboard_kpi_calculations.py | 2021 | Latest pump visit has `closed_loop=None`; older visit had `closed_loop=2` | `passed=0, eligible=1` |
| `test_count_hcl_use_2026_reverted_patient_excluded_from_total` | test_dashboard_kpi_calculations.py | 2026 | One still on `insulin_regimen=5`; one reverted to `insulin_regimen=4` | `passed=1, eligible=2` |
| `test_cgm_2021_on_cgm_is_annotated_correctly` | test_patient_report.py | 2021 | Single visit, `glucose_monitoring=4` | `"Real time continuous glucose monitor with alarms"` |
| `test_cgm_2021_reverted_from_cgm_shows_latest_value` | test_patient_report.py | 2021 | Earlier: `glucose_monitoring=4`; latest: `glucose_monitoring=2` | `"Flash glucose monitor"` |
| `test_cgm_2021_later_visit_null_cgm_falls_back_to_earlier_cgm` | test_patient_report.py | 2021 | Earlier: `glucose_monitoring=4`; later: `glucose_monitoring=None` | falls back to `"Real time..."` |
| `test_cgm_2026_on_cgm_is_annotated_correctly` | test_patient_report.py | 2026 | Single visit, `cgm_use=1` | `"Yes"` |
| `test_cgm_2026_reverted_from_cgm_shows_latest_value` | test_patient_report.py | 2026 | Earlier: `cgm_use=1`; latest: `cgm_use=2` | `"No"` |
| `test_cgm_2026_later_visit_null_cgm_falls_back_to_earlier_cgm` | test_patient_report.py | 2026 | Earlier: `cgm_use=1`; later: `cgm_use=None` | falls back to `"Yes"` |
| `test_count_cgm_use_2021_reverted_patient_excluded_from_total` | test_dashboard_kpi_calculations.py | 2021 | Still on CGM + reverted to flash | `passed=1, eligible=2` |
| `test_count_cgm_use_2021_later_visit_null_falls_back_to_earlier_cgm` | test_dashboard_kpi_calculations.py | 2021 | Later visit `glucose_monitoring=None`; earlier had CGM | `passed=1, eligible=1` |
| `test_count_cgm_use_2026_reverted_patient_excluded_from_total` | test_dashboard_kpi_calculations.py | 2026 | Still on CGM + reverted to `cgm_use=2` | `passed=1, eligible=2` |
| `test_count_cgm_use_2026_later_visit_null_falls_back_to_earlier_cgm` | test_dashboard_kpi_calculations.py | 2026 | Later visit `cgm_use=None`; earlier had `cgm_use=1` | `passed=1, eligible=1` |

closes #1403