### PR TITLE
visit-categories-for-2026

### DIFF
--- a/project/constants/visit_categories.py
+++ b/project/constants/visit_categories.py
@@ -2,98 +2,177 @@ VISIT_CATEGORIES_BY_TAB = {
     "Routine Measurements": {
         "Measurements": {
             "colour": "rcpch_yellow",
-            "fields": ["height", "weight", "height_weight_observation_date"],
+            "fields": [
+                {"field": "height", "dataset_years": [2021, 2026]},
+                {"field": "weight", "dataset_years": [2021, 2026]},
+                {
+                    "field": "height_weight_observation_date",
+                    "dataset_years": [2021, 2026],
+                },
+            ],
         },
         "HBA1c": {
             "colour": "rcpch_dark_grey",
-            "fields": ["hba1c", "hba1c_format", "hba1c_date"],
+            "fields": [
+                {"field": "hba1c", "dataset_years": [2021, 2026]},
+                {"field": "hba1c_format", "dataset_years": [2021]},
+                {"field": "hba1c_date", "dataset_years": [2021, 2026]},
+            ],
         },
         "Treatment": {
             "colour": "rcpch_strong_green_light_tint1",
-            "fields": ["treatment", "closed_loop_system"],
+            "fields": [
+                {"field": "treatment", "dataset_years": [2021]},
+                {"field": "closed_loop_system", "dataset_years": [2021, 2026]},
+                {"field": "insulin_regimen", "dataset_years": [2026]},
+                {"field": "non_insulin_medication", "dataset_years": [2026]},
+                {"field": "dietary_lifestyle_modification", "dataset_years": [2026]},
+            ],
         },
         "CGM": {
             "colour": "rcpch_aqua_green_light_tint1",
-            "fields": ["glucose_monitoring"],
+            "fields": [
+                {"field": "glucose_monitoring", "dataset_years": [2021]},
+                {"field": "cgm_use", "dataset_years": [2026]},
+            ],
         },
         "BP": {
             "colour": "rcpch_orange_light_tint1",
             "fields": [
-                "systolic_blood_pressure",
-                "diastolic_blood_pressure",
-                "blood_pressure_observation_date",
+                {"field": "systolic_blood_pressure", "dataset_years": [2021, 2026]},
+                {"field": "diastolic_blood_pressure", "dataset_years": [2021, 2026]},
+                {
+                    "field": "blood_pressure_observation_date",
+                    "dataset_years": [2021, 2026],
+                },
             ],
         },
     },
     "Annual Review": {
         "Foot Care": {
             "colour": "rcpch_gold",
-            "fields": ["foot_examination_observation_date"],
+            "fields": [
+                {
+                    "field": "foot_examination_observation_date",
+                    "dataset_years": [2021, 2026],
+                },
+            ],
         },
         "DECS": {
             "colour": "rcpch_vivid_green",
             "fields": [
-                "retinal_screening_observation_date",
-                "retinal_screening_result",
+                {
+                    "field": "retinal_screening_observation_date",
+                    "dataset_years": [2021, 2026],
+                },
+                {"field": "retinal_screening_result", "dataset_years": [2021, 2026]},
             ],
         },
         "ACR": {
             "colour": "rcpch_red_light_tint2",
             "fields": [
-                "albumin_creatinine_ratio",
-                "albumin_creatinine_ratio_date",
-                "albuminuria_stage",
+                {"field": "albumin_creatinine_ratio", "dataset_years": [2021, 2026]},
+                {
+                    "field": "albumin_creatinine_ratio_date",
+                    "dataset_years": [2021, 2026],
+                },
+                {"field": "albuminuria_stage", "dataset_years": [2021, 2026]},
             ],
         },
         "Cholesterol": {
             "colour": "rcpch_orange_dark_tint",
-            "fields": ["total_cholesterol", "total_cholesterol_date"],
+            "fields": [
+                {"field": "total_cholesterol", "dataset_years": [2021, 2026]},
+                {"field": "total_cholesterol_date", "dataset_years": [2021, 2026]},
+            ],
         },
         "Thyroid": {
             "colour": "rcpch_red_dark_tint",
-            "fields": ["thyroid_function_date", "thyroid_treatment_status"],
+            "fields": [
+                {"field": "thyroid_function_date", "dataset_years": [2021, 2026]},
+                {"field": "thyroid_treatment_status", "dataset_years": [2021, 2026]},
+            ],
         },
         "Coeliac": {
             "colour": "rcpch_purple_light_tint2",
-            "fields": ["coeliac_screen_date", "gluten_free_diet"],
+            "fields": [
+                {"field": "coeliac_screen_date", "dataset_years": [2021, 2026]},
+                {"field": "gluten_free_diet", "dataset_years": [2021, 2026]},
+            ],
         },
         "Psychology": {
             "colour": "rcpch_yellow_dark_tint",
             "fields": [
-                "psychological_screening_assessment_date",
-                "psychological_additional_support_status",
+                {
+                    "field": "psychological_screening_assessment_date",
+                    "dataset_years": [2021, 2026],
+                },
+                {
+                    "field": "psychological_additional_support_status",
+                    "dataset_years": [2021, 2026],
+                },
+                {"field": "psychological_support_outcome", "dataset_years": [2026]},
             ],
         },
         "Smoking": {
             "colour": "rcpch_strong_green_dark_tint",
-            "fields": ["smoking_status", "smoking_cessation_referral_date"],
+            "fields": [
+                {"field": "smoking_status", "dataset_years": [2021]},
+                {"field": "smoking_vaping_status", "dataset_years": [2026]},
+                {
+                    "field": "smoking_cessation_referral_date",
+                    "dataset_years": [2021, 2026],
+                },
+            ],
         },
         "Dietician": {
             "colour": "rcpch_aqua_green_dark_tint",
             "fields": [
-                "carbohydrate_counting_level_three_education_date",
-                "dietician_additional_appointment_offered",
-                "dietician_additional_appointment_date",
+                {
+                    "field": "carbohydrate_counting_level_three_education_date",
+                    "dataset_years": [2021, 2026],
+                },
+                {
+                    "field": "dietician_additional_appointment_offered",
+                    "dataset_years": [2021, 2026],
+                },
+                {
+                    "field": "dietician_additional_appointment_date",
+                    "dataset_years": [2021, 2026],
+                },
             ],
         },
         "Sick Day Rules": {
             "colour": "rcpch_pink_light_tint2",
-            "fields": ["ketone_meter_training", "sick_day_rules_training_date"],
+            "fields": [
+                {"field": "ketone_meter_training", "dataset_years": [2021, 2026]},
+                {
+                    "field": "sick_day_rules_training_date",
+                    "dataset_years": [2021, 2026],
+                },
+            ],
         },
         "Immunisation (flu)": {
             "colour": "rcpch_orange",
-            "fields": ["flu_immunisation_recommended_date"],
+            "fields": [
+                {
+                    "field": "flu_immunisation_recommended_date",
+                    "dataset_years": [2021, 2026],
+                },
+            ],
         },
     },
     "Inpatient Entry": {
         "Hospital Admission": {
             "colour": "rcpch_strong_green_dark_tint",
             "fields": [
-                "hospital_admission_date",
-                "hospital_discharge_date",
-                "hospital_admission_reason",
-                "dka_additional_therapies",
-                "hospital_admission_other",
+                {"field": "hospital_admission_date", "dataset_years": [2021, 2026]},
+                {"field": "hospital_discharge_date", "dataset_years": [2021, 2026]},
+                {"field": "hospital_admission_reason", "dataset_years": [2021, 2026]},
+                {"field": "dka_additional_therapies", "dataset_years": [2021, 2026]},
+                {"field": "hospital_admission_other", "dataset_years": [2021, 2026]},
+                {"field": "blood_gas_ph", "dataset_years": [2026]},
+                {"field": "blood_gas_bicarbonate", "dataset_years": [2026]},
             ],
         }
     },

--- a/project/npda/general_functions/categories.py
+++ b/project/npda/general_functions/categories.py
@@ -3,15 +3,20 @@ import urllib.parse
 from ...constants.visit_categories import VISIT_CATEGORIES_BY_TAB
 
 
-def get_categories(instance, form):
+def get_categories(instance, form, dataset_year):
     """
-    Returns visit categories present in this visit instance, and tags them as to whether they contain errors
+    Returns visit categories present in this visit instance, and tags them as to whether they contain errors.
+    Only fields matching dataset_year are included.
     """
     categories = []
 
     for _, tab in VISIT_CATEGORIES_BY_TAB.items():
         for category_name, category in tab.items():
-            fields = category["fields"]
+            fields = [
+                entry["field"]
+                for entry in category["fields"]
+                if dataset_year in entry["dataset_years"]
+            ]
 
             present = False
             errors = {}
@@ -38,9 +43,6 @@ def get_categories(instance, form):
                             errors[field] = [
                                 error["message"] for error in instance.errors[field]
                             ]
-                            errors[field] = [
-                                error["message"] for error in instance.errors[field]
-                            ]
 
             categories.append(
                 {
@@ -55,11 +57,11 @@ def get_categories(instance, form):
     return categories
 
 
-def get_tabs(form):
+def get_tabs(form, dataset_year):
     tabs = []
     instance = form.instance if form else None
 
-    all_categories = get_categories(instance, form)
+    all_categories = get_categories(instance, form, dataset_year)
     assigned_active_tab = False
 
     for tab_name, categories in VISIT_CATEGORIES_BY_TAB.items():

--- a/project/npda/tests/general_functions_tests/test_visit_categories.py
+++ b/project/npda/tests/general_functions_tests/test_visit_categories.py
@@ -17,7 +17,7 @@ def all_fields_for_year(dataset_year):
     """Return a flat set of all field names visible for the given dataset year."""
     categories = get_categories(instance=None, form=None, dataset_year=dataset_year)
     fields = set()
-    for category in categories:
+    for _category in categories:
         # Categories don't expose their filtered field list directly, so we
         # re-derive it from VISIT_CATEGORIES_BY_TAB via a second import.
         pass

--- a/project/npda/tests/general_functions_tests/test_visit_categories.py
+++ b/project/npda/tests/general_functions_tests/test_visit_categories.py
@@ -1,0 +1,278 @@
+"""
+Tests for get_categories and get_tabs in categories.py.
+
+These are pure unit tests — no DB access required.
+They verify that the correct fields are included/excluded for each dataset year,
+and that the tab structure is built correctly.
+"""
+
+from project.npda.general_functions.categories import get_categories, get_tabs
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def all_fields_for_year(dataset_year):
+    """Return a flat set of all field names visible for the given dataset year."""
+    categories = get_categories(instance=None, form=None, dataset_year=dataset_year)
+    fields = set()
+    for category in categories:
+        # Categories don't expose their filtered field list directly, so we
+        # re-derive it from VISIT_CATEGORIES_BY_TAB via a second import.
+        pass
+    return fields
+
+
+def category_names_for_year(dataset_year):
+    """Return the list of category names returned by get_categories for a given year."""
+    return [
+        c["name"]
+        for c in get_categories(instance=None, form=None, dataset_year=dataset_year)
+    ]
+
+
+def fields_in_category(category_name, dataset_year):
+    """Return the field names in a named category for a given dataset year."""
+    from project.constants.visit_categories import VISIT_CATEGORIES_BY_TAB
+
+    for tab in VISIT_CATEGORIES_BY_TAB.values():
+        if category_name in tab:
+            return [
+                entry["field"]
+                for entry in tab[category_name]["fields"]
+                if dataset_year in entry["dataset_years"]
+            ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Structure tests — categories are always present regardless of year
+# ---------------------------------------------------------------------------
+
+
+def test_all_categories_present_for_2021():
+    names = category_names_for_year(2021)
+    assert "Measurements" in names
+    assert "HBA1c" in names
+    assert "Treatment" in names
+    assert "CGM" in names
+    assert "BP" in names
+    assert "Foot Care" in names
+    assert "DECS" in names
+    assert "ACR" in names
+    assert "Cholesterol" in names
+    assert "Thyroid" in names
+    assert "Coeliac" in names
+    assert "Psychology" in names
+    assert "Smoking" in names
+    assert "Dietician" in names
+    assert "Sick Day Rules" in names
+    assert "Immunisation (flu)" in names
+    assert "Hospital Admission" in names
+
+
+def test_all_categories_present_for_2026():
+    names = category_names_for_year(2026)
+    assert "Measurements" in names
+    assert "HBA1c" in names
+    assert "Treatment" in names
+    assert "CGM" in names
+    assert "BP" in names
+    assert "Foot Care" in names
+    assert "DECS" in names
+    assert "ACR" in names
+    assert "Cholesterol" in names
+    assert "Thyroid" in names
+    assert "Coeliac" in names
+    assert "Psychology" in names
+    assert "Smoking" in names
+    assert "Dietician" in names
+    assert "Sick Day Rules" in names
+    assert "Immunisation (flu)" in names
+    assert "Hospital Admission" in names
+
+
+# ---------------------------------------------------------------------------
+# HBA1c — hba1c_format is 2021 only
+# ---------------------------------------------------------------------------
+
+
+def test_hba1c_format_present_in_2021():
+    assert "hba1c_format" in fields_in_category("HBA1c", 2021)
+
+
+def test_hba1c_format_absent_in_2026():
+    assert "hba1c_format" not in fields_in_category("HBA1c", 2026)
+
+
+def test_hba1c_and_date_present_in_both_years():
+    for year in (2021, 2026):
+        fields = fields_in_category("HBA1c", year)
+        assert "hba1c" in fields
+        assert "hba1c_date" in fields
+
+
+# ---------------------------------------------------------------------------
+# Treatment — 2021 uses treatment; 2026 uses insulin_regimen etc.
+# ---------------------------------------------------------------------------
+
+
+def test_treatment_field_present_in_2021():
+    assert "treatment" in fields_in_category("Treatment", 2021)
+
+
+def test_treatment_field_absent_in_2026():
+    assert "treatment" not in fields_in_category("Treatment", 2026)
+
+
+def test_insulin_regimen_absent_in_2021():
+    assert "insulin_regimen" not in fields_in_category("Treatment", 2021)
+
+
+def test_insulin_regimen_present_in_2026():
+    assert "insulin_regimen" in fields_in_category("Treatment", 2026)
+
+
+def test_non_insulin_medication_absent_in_2021():
+    assert "non_insulin_medication" not in fields_in_category("Treatment", 2021)
+
+
+def test_non_insulin_medication_present_in_2026():
+    assert "non_insulin_medication" in fields_in_category("Treatment", 2026)
+
+
+def test_dietary_lifestyle_modification_absent_in_2021():
+    assert "dietary_lifestyle_modification" not in fields_in_category("Treatment", 2021)
+
+
+def test_dietary_lifestyle_modification_present_in_2026():
+    assert "dietary_lifestyle_modification" in fields_in_category("Treatment", 2026)
+
+
+def test_closed_loop_system_present_in_both_years():
+    for year in (2021, 2026):
+        assert "closed_loop_system" in fields_in_category("Treatment", year)
+
+
+# ---------------------------------------------------------------------------
+# CGM — glucose_monitoring (2021) vs cgm_use (2026)
+# ---------------------------------------------------------------------------
+
+
+def test_glucose_monitoring_present_in_2021():
+    assert "glucose_monitoring" in fields_in_category("CGM", 2021)
+
+
+def test_glucose_monitoring_absent_in_2026():
+    assert "glucose_monitoring" not in fields_in_category("CGM", 2026)
+
+
+def test_cgm_use_absent_in_2021():
+    assert "cgm_use" not in fields_in_category("CGM", 2021)
+
+
+def test_cgm_use_present_in_2026():
+    assert "cgm_use" in fields_in_category("CGM", 2026)
+
+
+# ---------------------------------------------------------------------------
+# Smoking — smoking_status (2021) vs smoking_vaping_status (2026)
+# ---------------------------------------------------------------------------
+
+
+def test_smoking_status_present_in_2021():
+    assert "smoking_status" in fields_in_category("Smoking", 2021)
+
+
+def test_smoking_status_absent_in_2026():
+    assert "smoking_status" not in fields_in_category("Smoking", 2026)
+
+
+def test_smoking_vaping_status_absent_in_2021():
+    assert "smoking_vaping_status" not in fields_in_category("Smoking", 2021)
+
+
+def test_smoking_vaping_status_present_in_2026():
+    assert "smoking_vaping_status" in fields_in_category("Smoking", 2026)
+
+
+def test_smoking_cessation_referral_date_present_in_both_years():
+    for year in (2021, 2026):
+        assert "smoking_cessation_referral_date" in fields_in_category("Smoking", year)
+
+
+# ---------------------------------------------------------------------------
+# Psychology — psychological_support_outcome is 2026 only
+# ---------------------------------------------------------------------------
+
+
+def test_psychological_support_outcome_absent_in_2021():
+    assert "psychological_support_outcome" not in fields_in_category("Psychology", 2021)
+
+
+def test_psychological_support_outcome_present_in_2026():
+    assert "psychological_support_outcome" in fields_in_category("Psychology", 2026)
+
+
+def test_psychology_core_fields_present_in_both_years():
+    for year in (2021, 2026):
+        fields = fields_in_category("Psychology", year)
+        assert "psychological_screening_assessment_date" in fields
+        assert "psychological_additional_support_status" in fields
+
+
+# ---------------------------------------------------------------------------
+# Hospital Admission — blood_gas fields are 2026 only
+# ---------------------------------------------------------------------------
+
+
+def test_blood_gas_ph_absent_in_2021():
+    assert "blood_gas_ph" not in fields_in_category("Hospital Admission", 2021)
+
+
+def test_blood_gas_ph_present_in_2026():
+    assert "blood_gas_ph" in fields_in_category("Hospital Admission", 2026)
+
+
+def test_blood_gas_bicarbonate_absent_in_2021():
+    assert "blood_gas_bicarbonate" not in fields_in_category("Hospital Admission", 2021)
+
+
+def test_blood_gas_bicarbonate_present_in_2026():
+    assert "blood_gas_bicarbonate" in fields_in_category("Hospital Admission", 2026)
+
+
+def test_hospital_admission_core_fields_present_in_both_years():
+    for year in (2021, 2026):
+        fields = fields_in_category("Hospital Admission", year)
+        assert "hospital_admission_date" in fields
+        assert "hospital_discharge_date" in fields
+        assert "hospital_admission_reason" in fields
+        assert "dka_additional_therapies" in fields
+        assert "hospital_admission_other" in fields
+
+
+# ---------------------------------------------------------------------------
+# get_tabs — tab structure and active-tab logic
+# ---------------------------------------------------------------------------
+
+
+def test_get_tabs_returns_three_tabs_for_2021():
+    tabs = get_tabs(form=None, dataset_year=2021)
+    tab_names = [t["name"] for t in tabs]
+    assert tab_names == ["Routine Measurements", "Annual Review", "Inpatient Entry"]
+
+
+def test_get_tabs_returns_three_tabs_for_2026():
+    tabs = get_tabs(form=None, dataset_year=2026)
+    tab_names = [t["name"] for t in tabs]
+    assert tab_names == ["Routine Measurements", "Annual Review", "Inpatient Entry"]
+
+
+def test_get_tabs_first_tab_is_active_when_no_errors():
+    for year in (2021, 2026):
+        tabs = get_tabs(form=None, dataset_year=year)
+        assert tabs[0].get("active") is True
+        assert not tabs[1].get("active")
+        assert not tabs[2].get("active")

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -86,8 +86,11 @@ class PatientVisitsListView(
             .order_by("is_valid", "id")
         )
         calculated_visits = []
+        dataset_year = self.audit_period.get_dataset_year()
         for visit in visits:
-            visit_categories = get_categories(instance=visit, form=None)
+            visit_categories = get_categories(
+                instance=visit, form=None, dataset_year=dataset_year
+            )
             calculated_visits.append({"visit": visit, "categories": visit_categories})
         context["visits"] = calculated_visits
         context["patient"] = patient
@@ -132,7 +135,9 @@ class VisitCreateView(
         context["title"] = "Add New Visit"
         context["form_method"] = "create"
         context["button_title"] = "Create New Visit"
-        context["visit_tabs"] = get_tabs(form=None)
+        context["visit_tabs"] = get_tabs(
+            form=None, dataset_year=self.audit_period.get_dataset_year()
+        )
         context["override_height_weight"] = False
         context["audit_period"] = self.audit_period
         context["pdu"] = self.pdu
@@ -244,7 +249,9 @@ class VisitUpdateView(
         context["title"] = "Edit/Update Visit Details"
         context["button_title"] = "Save Changes"
         context["form_method"] = "update"
-        context["visit_tabs"] = get_tabs(form=context["form"])
+        context["visit_tabs"] = get_tabs(
+            form=context["form"], dataset_year=self.audit_period.get_dataset_year()
+        )
         visit = Visit.objects.get(pk=self.kwargs["pk"])
         context["audit_period"] = self.audit_period
         patient = visit.patient


### PR DESCRIPTION
## Dataset-year-aware visit categories

### What changed

**`project/constants/visit_categories.py`**

`VISIT_CATEGORIES_BY_TAB` fields are now structured as `{"field": "...", "dataset_years": [...]}` dicts, mirroring the existing pattern in `ALL_HEADINGS` (`csv_headings.py`). Fields shared between both datasets carry `[2021, 2026]`; year-specific fields carry only their year.

| Category | 2021 fields | 2026 fields |
|---|---|---|
| HBA1c | `hba1c_format` | *(removed)* |
| Treatment | `treatment` | `insulin_regimen`, `non_insulin_medication`, `dietary_lifestyle_modification` |
| Treatment | `closed_loop_system` | `closed_loop_system` |
| CGM | `glucose_monitoring` | `cgm_use` |
| Smoking | `smoking_status` | `smoking_vaping_status` |
| Psychology | — | `psychological_support_outcome` *(added)* |
| Hospital Admission | — | `blood_gas_ph`, `blood_gas_bicarbonate` *(added)* |

**`project/npda/general_functions/categories.py`**

`get_categories(instance, form, dataset_year)` and `get_tabs(form, dataset_year)` now accept `dataset_year` and filter fields accordingly. Also removed a duplicate `errors[field] = ...` assignment from the original.

**`project/npda/views/visit.py`**

All three call sites (`PatientVisitsListView`, `VisitCreateView`, `VisitUpdateView`) pass `dataset_year=self.audit_period.get_dataset_year()`.

---

### Tests

`project/npda/tests/general_functions_tests/test_visit_categories.py` — 34 pure unit tests (no DB fixtures), covering:

- All category names are present for both 2021 and 2026
- Each year-specific field is present/absent in the correct year for: HBA1c, Treatment, CGM, Smoking, Psychology, Hospital Admission
- Shared fields are present in both years
- `get_tabs` returns the correct three tabs and sets the first tab active when there are no errors

All 34 tests pass in 0.33 s.

closes #1408