### PR TITLE
Speed up generating data quality report if you have LOADS of errors

### DIFF
--- a/project/npda/general_functions/write_errors_to_xlsx.py
+++ b/project/npda/general_functions/write_errors_to_xlsx.py
@@ -71,6 +71,8 @@ def write_errors_to_xlsx(
         "Uploaded data (comments)"  # You can set any name for the copied sheet
     )
 
+    column_indices = {}
+
     # Style the openpyxl worksheet to highlight in red erroneous/invalid cells.
     # Also add comments to annotate the actual error.
     for _, patient_errors in df_errors.iterrows():
@@ -79,7 +81,12 @@ def write_errors_to_xlsx(
         field_name = patient_errors["Column"]
         field_errors = patient_errors["Errors"]
 
-        column_index = find_column_index_by_name(field_name, styled_sheet)
+        if field_name not in column_indices:
+            column_indices[field_name] = find_column_index_by_name(
+                field_name, styled_sheet
+            )
+
+        column_index = column_indices.get(field_name)
         if column_index:
             styled_sheet.cell(row=row_index, column=column_index).fill = PatternFill(
                 patternType="solid", fgColor="FFC9C9"


### PR DESCRIPTION
@AmaniKrayemRCPCH reported that she couldn't download a data quality report for a unit that has a lot of errors. Profiling showed that it was the code to add the inline comments for each error that was slowing it down.

In particular I don't know what this function is doing that makes it so slow but memoizing the calls seems to help.

Generating a data quality report with 22,430 errors before took well over 10 minutes. Now it takes 33 seconds.