### PR TITLE
Update IMD map auth and HTMX loading behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,33 @@ The dashboard views also use `queries.py` directly — **do not reach for the KP
 
 All dashboard functions use `build_base_queryset()` as their base and respect `audit_period.get_dataset_year()`. They return plain Python values — no `KPIResult` objects.
 
+### Dashboard map component (IMD)
+
+The dashboard IMD map in `project/npda/templates/dashboard/map_chart_partial.html` uses the browser bundle from `@rcpch/imd-map`.
+
+- Current bundle version: `0.3.1`
+- Script URL:
+    `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js`
+- Current SRI:
+    `sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig==`
+
+Tile auth is now configured via map options (query-string auth), not request headers.
+
+- Token source: `settings.RCPCH_CENSUS_PLATFORM_TOKEN`
+- Passed from view context in `project/npda/views/dashboard/partials.py`
+- Consumed in JS as:
+
+```javascript
+RcpchImdMap.createImdMap({
+    container: container,
+    tilesBaseUrl: tilesBaseUrl,
+    tilesApiKey: window.RCPCH_CENSUS_PLATFORM_TOKEN || undefined,
+    tilesApiKeyParam: 'Subscription-Key',
+});
+```
+
+Keep the API key plumbing aligned with `project/npda/general_functions/index_multiple_deprivation.py`, which uses the same token setting for server-side deprivation requests.
+
 ### KPI class
 
 `project/npda/general_functions/calculate_kpis/` — for **national benchmarking aggregates only**. Not used directly in patient report or dashboard views.

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -4,19 +4,131 @@
   Distribution of patients - {{ pdu_object.lead_organisation_name }} ({{ pdu_object.pz_code }})
 {% endblock card_title %}
 {% block card_body %}
+  <link rel="stylesheet"
+        href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
+  <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js"
+          integrity="sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig=="
+          crossorigin="anonymous"></script>
+  <script>
+    window.npdaInitOrganisationCasesMap = function () {
+      function showMapLoadError() {
+        var errorElement = document.getElementById('organisation-cases-map-error');
+        if (!errorElement) return;
+        errorElement.classList.remove('hidden');
+      }
+
+      var container = document.getElementById('organisation-cases-map');
+      if (!container) {
+        showMapLoadError();
+        return;
+      }
+
+      var errorElement = document.getElementById('organisation-cases-map-error');
+      if (errorElement) {
+        errorElement.classList.add('hidden');
+      }
+
+      if (typeof RcpchImdMap === 'undefined') {
+        console.error('RcpchImdMap library is not loaded');
+        showMapLoadError();
+        return;
+      }
+
+      if (window.__npdaMap) {
+        window.__npdaMap.destroy();
+        window.__npdaMap = null;
+      }
+
+      var tilesBaseUrl = (container.dataset.tilesBaseUrl || '').replace(/\/$/, '');
+      if (!tilesBaseUrl) {
+        console.error('RCPCH_DEPRIVATION_TILES_URL not set for organisation cases map');
+        showMapLoadError();
+        return;
+      }
+
+      var payloadElement = document.getElementById('organisation-cases-map-payload');
+      if (!payloadElement) {
+        showMapLoadError();
+        return;
+      }
+
+      var payload = JSON.parse(payloadElement.textContent);
+      var hasLeadCentre =
+        payload &&
+        payload.leadCentre &&
+        typeof payload.leadCentre.lon === 'number' &&
+        typeof payload.leadCentre.lat === 'number';
+      var initialNation = payload && payload.initialNation ? payload.initialNation : 'all';
+      var initialEra = payload && payload.initialEra ? payload.initialEra : '2021';
+
+      var token = {
+        patientLabel: '{% templatetag openvariable %}patientLabel{% templatetag closevariable %}',
+        id: '{% templatetag openvariable %}id{% templatetag closevariable %}',
+        nhsNumber: '{% templatetag openvariable %}nhs_number{% templatetag closevariable %}',
+        uniqueReferenceNumber: '{% templatetag openvariable %}unique_reference_number{% templatetag closevariable %}',
+        distanceKm: '{% templatetag openvariable %}distance_km{% templatetag closevariable %}',
+        distanceMi: '{% templatetag openvariable %}distance_mi{% templatetag closevariable %}',
+        imdQuintile: '{% templatetag openvariable %}imd_quintile{% templatetag closevariable %}',
+        leadCentreLabel: '{% templatetag openvariable %}leadCentreLabel{% templatetag closevariable %}',
+        label: '{% templatetag openvariable %}label{% templatetag closevariable %}'
+      };
+
+      try {
+        window.__npdaMap = RcpchImdMap.createImdMap({
+          container: container,
+          tilesBaseUrl: tilesBaseUrl,
+          tilesApiKey: container.dataset.tilesApiKey || undefined,
+          tilesApiKeyParam: 'Subscription-Key',
+          initialNation: initialNation,
+          initialEra: initialEra,
+          center: hasLeadCentre ? [payload.leadCentre.lon, payload.leadCentre.lat] : undefined,
+          zoom: hasLeadCentre ? 11 : 5,
+          style: {
+            choropleth: {
+              baseColorByNation: {
+                england: '#d7191c',
+                wales: '#1a9641',
+                scotland: '#2b83ba',
+                northern_ireland: '#7f7f7f',
+              },
+            },
+            tooltip: {
+              areaLabel: 'Local area',
+              patientLabel: 'Child',
+              patientTooltipText: token.patientLabel + ': ' + token.id + ' - ' + (token.nhsNumber != 'N/A' ? 'NHS: ' + token.nhsNumber : 'Unique Reference: ' + token.uniqueReferenceNumber) + ' | Distance to Lead Centre: ' + token.distanceMi + ' mi (' + token.distanceKm + ' km)' + (token.imdQuintile && token.imdQuintile !== 'None' && token.imdQuintile !== 'null' ? ' | IMD Quintile: ' + token.imdQuintile : ''),
+              leadCentreTooltipText: token.leadCentreLabel + ': ' + token.label,
+              backgroundColor: '#0d0d58',
+              textColor: '#ffffff',
+            },
+          },
+        });
+
+        window.__npdaMap.setPatients(payload.patients);
+        window.__npdaMap.setLeadCentre(payload.leadCentre);
+      } catch (error) {
+        console.error('Error initializing map:', error);
+        showMapLoadError();
+      }
+    };
+  </script>
   <div hx-get="{% data_url 'pdu-get-map-chart-partial' %}"
        hx-trigger="load"
        hx-swap="innerHTML"
        hx-target="#organisation_cases_map"
-       hx-indicator="#loading-spinner-imd-map"
-       _="on htmx:afterSwap remove #loading-spinner-imd-map">
-    <figure>
-      <div id="organisation_cases_map" style="width: 100%">
-        {% include 'dashboard/map_chart_partial.html' with chart_html=chart_html aggregated_distances=aggregated_distances %}
-      </div>
-    </figure>
+      hx-indicator="#loading-spinner-imd-map">
   </div>
   <div id="loading-spinner-imd-map"
        class="loading loading-spinner text-rcpch_dark_blue flex flex-grow-1 justify-center items-center w-1/5 mx-auto bg-center">
   </div>
+  <figure>
+    <div id="organisation-cases-map-error"
+         class="alert alert-info hidden"
+         role="status">
+      The map has failed to load. Please check back later.
+    </div>
+    <div id="organisation_cases_map"
+         hx-on::after-swap="window.npdaInitOrganisationCasesMap(); document.getElementById('loading-spinner-imd-map')?.remove();"
+         style="width: 100%"></div>
+  </figure>
 {% endblock %}

--- a/project/npda/templates/dashboard/map_chart_partial.html
+++ b/project/npda/templates/dashboard/map_chart_partial.html
@@ -28,11 +28,12 @@
 
 
 <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.2.1/dist/umd/rcpch-imd-map.min.js" integrity="sha512-TKqNMyuHiEPc2WKKI3eNh6Vv98bu23MYDKXNVhvzIMgBG//ckkcYDTTq7BBH+LZvkHBnSGh6fH+PVEI8Sb4VSA==" crossorigin="anonymous"> </script>
+<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js" integrity="sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig==" crossorigin="anonymous"> </script>
 {% if RCPCH_DEPRIVATION_TILES_URL %}
 <script>
     // Map your setting name to the library's expected variable name
     window.RCPCH_DEPRIVATION_TILES_URL = "{{ RCPCH_DEPRIVATION_TILES_URL }}";
+  window.RCPCH_CENSUS_PLATFORM_TOKEN = "{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:''|escapejs }}";
 
 
   (function () {
@@ -84,6 +85,8 @@
       window.__npdaMap = RcpchImdMap.createImdMap({
         container: container,
         tilesBaseUrl: tilesBaseUrl,
+        tilesApiKey: window.RCPCH_CENSUS_PLATFORM_TOKEN || undefined,
+        tilesApiKeyParam: 'Subscription-Key',
         initialNation: initialNation,
         initialEra: initialEra,
         center: hasLeadCentre ? [payload.leadCentre.lon, payload.leadCentre.lat] : undefined,

--- a/project/npda/templates/dashboard/map_chart_partial.html
+++ b/project/npda/templates/dashboard/map_chart_partial.html
@@ -4,9 +4,9 @@
 {% elif info %}
   <div class="alert alert-info">{{ info }}</div>
 {% else %}
-  <link rel="stylesheet"
-        href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   <div id="organisation-cases-map"
+        data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
+        data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
         style="width:100%;height:32rem;border-radius:4px;"></div>
   {{ map_payload|json_script:"organisation-cases-map-payload" }}
   <div class="mt-2 flex items-center gap-3 text-xs text-gray-600">
@@ -24,99 +24,4 @@
       {% include 'common/icon_link_button.html' with link=docs_base_url|add:"user-guide/maps" fa_icon_class="fa-solid fa-circle-question" extra_classes="text-rcpch_pink" %}
     </div>
   </div>
-{% endif %}
-
-
-<script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js" integrity="sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig==" crossorigin="anonymous"> </script>
-{% if RCPCH_DEPRIVATION_TILES_URL %}
-<script>
-    // Map your setting name to the library's expected variable name
-    window.RCPCH_DEPRIVATION_TILES_URL = "{{ RCPCH_DEPRIVATION_TILES_URL }}";
-  window.RCPCH_CENSUS_PLATFORM_TOKEN = "{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:''|escapejs }}";
-
-
-  (function () {
-    var container = document.getElementById('organisation-cases-map');
-    if (!container) return;
-
-    // Check if RcpchImdMap library is loaded
-    if (typeof RcpchImdMap === 'undefined') {
-      console.error('RcpchImdMap library is not loaded');
-      console.error('Available globals:', Object.keys(window).filter(k => k.includes('Rcpch') || k.includes('map')));
-      return;
-    }
-
-    // Destroy any previous instance to prevent GL context leaks on HTMX swaps.
-    if (window.__npdaMap) {
-      window.__npdaMap.destroy();
-      window.__npdaMap = null;
-    }
-
-    // The tile URL pattern the library constructs is:
-    // {tilesBaseUrl}/public.uk_master_2011_z0_4/{z}/{x}/{y}.pbf
-    // Check the Network tab to confirm tile requests reach the right endpoint.
-    var tilesBaseUrl = window.RCPCH_DEPRIVATION_TILES_URL.replace(/\/$/, '');
-
-    const payload = JSON.parse(
-      document.getElementById('organisation-cases-map-payload').textContent
-    );
-    var hasLeadCentre =
-      payload &&
-      payload.leadCentre &&
-      typeof payload.leadCentre.lon === 'number' &&
-      typeof payload.leadCentre.lat === 'number';
-    var initialNation = payload && payload.initialNation ? payload.initialNation : 'all';
-    var initialEra = payload && payload.initialEra ? payload.initialEra : '2021';
-
-    var token = {
-      patientLabel: '{% templatetag openvariable %}patientLabel{% templatetag closevariable %}',
-      id: '{% templatetag openvariable %}id{% templatetag closevariable %}',
-      nhsNumber: '{% templatetag openvariable %}nhs_number{% templatetag closevariable %}',
-      uniqueReferenceNumber: '{% templatetag openvariable %}unique_reference_number{% templatetag closevariable %}',
-      distanceKm: '{% templatetag openvariable %}distance_km{% templatetag closevariable %}',
-      distanceMi: '{% templatetag openvariable %}distance_mi{% templatetag closevariable %}',
-      imdQuintile: '{% templatetag openvariable %}imd_quintile{% templatetag closevariable %}',
-      leadCentreLabel: '{% templatetag openvariable %}leadCentreLabel{% templatetag closevariable %}',
-      label: '{% templatetag openvariable %}label{% templatetag closevariable %}'
-    };
-
-    try {
-      window.__npdaMap = RcpchImdMap.createImdMap({
-        container: container,
-        tilesBaseUrl: tilesBaseUrl,
-        tilesApiKey: window.RCPCH_CENSUS_PLATFORM_TOKEN || undefined,
-        tilesApiKeyParam: 'Subscription-Key',
-        initialNation: initialNation,
-        initialEra: initialEra,
-        center: hasLeadCentre ? [payload.leadCentre.lon, payload.leadCentre.lat] : undefined,
-        zoom: hasLeadCentre ? 11 : 5,
-        style: {
-          choropleth: {
-            baseColorByNation: {
-              england: '#d7191c',
-              wales: '#1a9641',
-              scotland: '#2b83ba',
-              northern_ireland: '#7f7f7f',
-            },
-          },
-          tooltip: {
-            areaLabel: 'Local area',
-            patientLabel: 'Child',
-            patientTooltipText: token.patientLabel + ': ' + token.id + ' - ' + (token.nhsNumber !='N/A' ? 'NHS: ' + token.nhsNumber : 'Unique Reference: ' + token.uniqueReferenceNumber ) + ' | Distance to Lead Centre: ' + token.distanceMi + ' mi (' + token.distanceKm + ' km)' + (token.imdQuintile && token.imdQuintile !== 'None' && token.imdQuintile !== 'null' ? ' | IMD Quintile: ' + token.imdQuintile : ''),
-            leadCentreTooltipText: token.leadCentreLabel + ': ' + token.label,
-            backgroundColor: '#0d0d58',
-            textColor: '#ffffff',
-          },
-        },
-      });
-
-
-      window.__npdaMap.setPatients(payload.patients);
-      window.__npdaMap.setLeadCentre(payload.leadCentre);
-    } catch (error) {
-      console.error('Error initializing map:', error);
-    }
-  })();
-</script>
 {% endif %}

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -29,7 +29,7 @@ from project.npda.general_functions.rcpch_nhs_organisations import (
 )
 from project.npda.models.submission import Submission
 from project.npda.views.decorators import check_data_permissions, login_and_otp_required
-from project.settings import RCPCH_DEPRIVATION_TILES_URL
+from project.settings import RCPCH_CENSUS_PLATFORM_TOKEN, RCPCH_DEPRIVATION_TILES_URL
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,7 @@ def get_map_chart_partial(request, audit_period, pdu):
             template_name="dashboard/map_chart_partial.html",
             context={
                 "RCPCH_DEPRIVATION_TILES_URL": RCPCH_DEPRIVATION_TILES_URL,
+                "RCPCH_CENSUS_PLATFORM_TOKEN": RCPCH_CENSUS_PLATFORM_TOKEN,
                 "aggregated_distances": aggregated_distances,
                 "map_payload": {
                     "initialEra": _map_initial_era_for_audit_period(audit_period),


### PR DESCRIPTION
## Summary
Update the dashboard IMD map integration to use `@rcpch/imd-map` 0.3.1, pass the APIM subscription token through to browser tile requests, and fix the HTMX loading flow so the spinner, map rendering, and client-side failure handling behave consistently.

## Why
The census platform token is now being enabled for tile access through APIM, so the browser map needed to send the same token that the server-side deprivation lookup already uses. While wiring that in, the dashboard card also exposed a couple of UI issues: the loading spinner could remain visible after the partial loaded, and the map initialization path was unreliable when the map content arrived via HTMX.

## What changed
- Bumped the IMD map browser bundle to `@rcpch/imd-map@0.3.1` and updated the SRI hash.
- Passed `RCPCH_CENSUS_PLATFORM_TOKEN` from the dashboard view into the IMD map partial.
- Configured the map with:
  - `tilesApiKey`
  - `tilesApiKeyParam: 'Subscription-Key'`
- Kept the browser auth wiring aligned with the existing server-side token usage in `index_multiple_deprivation.py`.
- Refactored the IMD map HTMX flow so:
  - the spinner is shown first
  - the map partial swaps into the target container
  - map initialization runs after the swap on the target element
  - the spinner is removed once the swapped content has arrived
- Added a polite in-card fallback message for client-side map load failures: if the JS library is unavailable, the tile URL is missing, or map initialization throws, users now see a visible “The map has failed to load. Please check back later.” message instead of empty map space.
- Updated `AGENTS.md` to document the current IMD map version, SRI hash, and API key configuration pattern.

## Files touched
- `project/npda/views/dashboard/partials.py`
- `project/npda/templates/dashboard/map_chart_partial.html`
- `project/npda/templates/dashboard/components/cards/imd_map_card.html`
- `AGENTS.md`

## Notes for reviewers
- The map component now expects browser-side tile auth to be passed as a query parameter via the component API, not as a request header.
- The query parameter name is set to `Subscription-Key` to match the existing APIM token naming already used elsewhere in the project.
- Server-side error and “no data” states remain in the map partial; the new fallback only covers client-side initialization failures.

## Validation
- Verified the touched templates/files for editor-reported errors.
- Confirmed the branch is clean and pushed.
- Did not run the full test suite, since the changes are limited to the dashboard map view/templates and documentation.
