### PR TITLE
Dashboard: add 4+ HbA1c and all care processes tiles to measurements card

### DIFF
--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -1259,10 +1259,25 @@ def dashboard_health_check_totals(pdu, audit_period) -> dict:
         total_passed_thyroid_screen, total_eligible_thyroid_screen,
         total_passed_blood_pressure, total_eligible_blood_pressure,
         total_passed_urinary_albumin, total_eligible_urinary_albumin,
-        total_passed_foot_exam, total_eligible_foot_exam
+        total_passed_foot_exam, total_eligible_foot_exam,
+        total_passed_four_hba1cs, total_eligible_four_hba1cs,
+        total_passed_all_care_processes, total_eligible_all_care_processes
     """
+    audit_range = (audit_period.start_date, audit_period.end_date)
     qs = build_base_queryset(pdu, audit_period, type1_only=True)
     qs = annotate_health_checks(qs, audit_period)
+
+    # Annotate per-patient HbA1c count within the audit period (for 4+ HbA1c tile)
+    qs = qs.annotate(
+        hba1c_count=Count(
+            "visit",
+            filter=Q(
+                visit__hba1c__isnull=False,
+                visit__hba1c_date__range=audit_range,
+            ),
+            distinct=True,
+        )
+    )
 
     # Aggregate all counts in a single query
     agg = qs.aggregate(
@@ -1320,6 +1335,27 @@ def dashboard_health_check_totals(pdu, audit_period) -> dict:
         total_eligible_foot_exam=Count(
             "pk",
             filter=Q(is_complete_year_of_care=True, is_gte_12yo=True),
+        ),
+        # 4+ HbA1c measurements — all complete-year T1DM patients
+        total_passed_four_hba1cs=Count(
+            "pk",
+            filter=Q(hba1c_count__gte=4, is_complete_year_of_care=True),
+        ),
+        total_eligible_four_hba1cs=Count(
+            "pk",
+            filter=Q(is_complete_year_of_care=True),
+        ),
+        # All applicable care processes complete:
+        #   ≥12yo: all 6 (HbA1c, BMI, thyroid, BP, urinary albumin, foot exam)
+        #   <12yo: all 3 (HbA1c, BMI, thyroid)
+        total_passed_all_care_processes=Count(
+            "pk",
+            filter=Q(is_complete_year_of_care=True)
+            & (Q(is_gte_12yo=True, num_passed=6) | Q(is_gte_12yo=False, num_passed=3)),
+        ),
+        total_eligible_all_care_processes=Count(
+            "pk",
+            filter=Q(is_complete_year_of_care=True),
         ),
     )
     return agg

--- a/project/npda/templates/dashboard/components/cards/card_partials/patient_measurements_partial.html
+++ b/project/npda/templates/dashboard/components/cards/card_partials/patient_measurements_partial.html
@@ -175,4 +175,43 @@
       </div>
     </div>
   </a>
+  <!-- Care Quality Stats -->
+  <a href="{% data_url 'pdu-patient-report' %}"
+     class="tooltip block mt-4"
+     data-tip="Click here to view care quality totals for all patients with T1 diabetes in this submission">
+    <!-- Care Quality Title -->
+    <div class="text-center mb-2">
+      <h3 class="text-base font-semibold text-rcpch_light_blue">Care Quality</h3>
+    </div>
+    <div class="stats stats-vertical lg:stats-horizontal shadow text-rcpch_light_blue w-full overflow-hidden">
+      <!-- 4+ HbA1c Stat -->
+      <div class="stat place-items-center p-2">
+        <div class="stat-figure">
+          <i class="fa-solid fa-vial fa-lg text-rcpch_light_blue"></i>
+        </div>
+        <div class="stat-title text-xs">4+ HbA1c</div>
+        <div class="stat-value text-sm text-rcpch_light_blue">
+          {{ total_passed_four_hba1cs|percentage:total_eligible_four_hba1cs }}
+        </div>
+        <div class="stat-desc text-xs">
+          {{ total_passed_four_hba1cs }}/{{ total_eligible_four_hba1cs }}
+        </div>
+        <div class="stat-desc text-xs">T1 patients with ≥4 HbA1c</div>
+      </div>
+      <!-- All Care Processes Complete Stat -->
+      <div class="stat place-items-center p-2">
+        <div class="stat-figure">
+          <i class="fa-solid fa-circle-check fa-lg text-rcpch_light_blue"></i>
+        </div>
+        <div class="stat-title text-xs">All Care Processes</div>
+        <div class="stat-value text-sm text-rcpch_light_blue">
+          {{ total_passed_all_care_processes|percentage:total_eligible_all_care_processes }}
+        </div>
+        <div class="stat-desc text-xs">
+          {{ total_passed_all_care_processes }}/{{ total_eligible_all_care_processes }}
+        </div>
+        <div class="stat-desc text-xs">T1 patients with all checks complete</div>
+      </div>
+    </div>
+  </a>
 </div>

--- a/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
+++ b/project/npda/tests/kpi_calculations/test_dashboard_kpi_calculations.py
@@ -1140,3 +1140,307 @@ def test_dashboard_health_check_totals_2026_dataset(
 
     assert totals["total_eligible_blood_pressure"] == 1
     assert totals["total_passed_blood_pressure"] == 1
+
+
+# ---------------------------------------------------------------------------
+# dashboard_health_check_totals — 4+ HbA1c
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_four_hba1cs_patient_with_four_measurements_passes(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A T1DM patient with exactly 4 HbA1c values in the audit period passes the tile."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    for offset_months in [1, 3, 6, 9]:
+        visit_date = audit_period.start_date + relativedelta(months=offset_months)
+        VisitFactory(
+            patient=patient,
+            visit_date=visit_date,
+            hba1c=60,
+            hba1c_date=visit_date,
+        )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_four_hba1cs"] == 1
+    assert totals["total_passed_four_hba1cs"] == 1
+
+
+@pytest.mark.django_db
+def test_four_hba1cs_patient_with_three_measurements_fails(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A T1DM patient with only 3 HbA1c values in the audit period does not pass."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    for offset_months in [1, 3, 6]:
+        visit_date = audit_period.start_date + relativedelta(months=offset_months)
+        VisitFactory(
+            patient=patient,
+            visit_date=visit_date,
+            hba1c=60,
+            hba1c_date=visit_date,
+        )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_four_hba1cs"] == 1
+    assert totals["total_passed_four_hba1cs"] == 0
+
+
+@pytest.mark.django_db
+def test_four_hba1cs_visit_without_hba1c_value_not_counted(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """Visits where hba1c is None are not counted towards the 4+ HbA1c total."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    # 3 visits with a real HbA1c, 1 visit with hba1c=None
+    for offset_months in [1, 3, 6]:
+        visit_date = audit_period.start_date + relativedelta(months=offset_months)
+        VisitFactory(
+            patient=patient, visit_date=visit_date, hba1c=60, hba1c_date=visit_date
+        )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(months=9),
+        hba1c=None,
+        hba1c_date=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_four_hba1cs"] == 1
+    assert totals["total_passed_four_hba1cs"] == 0
+
+
+@pytest.mark.django_db
+def test_four_hba1cs_incomplete_year_patient_excluded(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A patient who joined mid-audit (incomplete year) is excluded from the eligible count."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+
+    # Diagnosed during the audit year → incomplete year of care
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date + relativedelta(months=2),
+    )
+    for offset_months in [3, 5, 7, 9]:
+        visit_date = audit_period.start_date + relativedelta(months=offset_months)
+        VisitFactory(
+            patient=patient, visit_date=visit_date, hba1c=60, hba1c_date=visit_date
+        )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_four_hba1cs"] == 0
+    assert totals["total_passed_four_hba1cs"] == 0
+
+
+# ---------------------------------------------------------------------------
+# dashboard_health_check_totals — all care processes complete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_all_care_processes_over_12_all_six_complete_passes(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A T1DM patient ≥12 with all 6 care processes recorded passes the tile."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        # HbA1c
+        hba1c=60,
+        hba1c_date=visit_date,
+        # BMI (bmi is a separate stored field, not auto-calculated from height/weight)
+        height=160,
+        weight=55,
+        bmi=21.5,
+        height_weight_observation_date=visit_date,
+        # Thyroid
+        thyroid_function_date=visit_date,
+        # Blood pressure
+        systolic_blood_pressure=110,
+        blood_pressure_observation_date=visit_date,
+        # Urinary albumin (ACR)
+        albumin_creatinine_ratio=1.2,
+        albumin_creatinine_ratio_date=visit_date,
+        # Foot exam
+        foot_examination_observation_date=visit_date,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_all_care_processes"] == 1
+    assert totals["total_passed_all_care_processes"] == 1
+
+
+@pytest.mark.django_db
+def test_all_care_processes_over_12_missing_one_fails(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A T1DM patient ≥12 missing one of the 6 care processes does not pass."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        hba1c=60,
+        hba1c_date=visit_date,
+        height=160,
+        weight=55,
+        height_weight_observation_date=visit_date,
+        thyroid_function_date=visit_date,
+        systolic_blood_pressure=110,
+        blood_pressure_observation_date=visit_date,
+        albumin_creatinine_ratio=1.2,
+        albumin_creatinine_ratio_date=visit_date,
+        # foot exam intentionally omitted
+        foot_examination_observation_date=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_all_care_processes"] == 1
+    assert totals["total_passed_all_care_processes"] == 0
+
+
+@pytest.mark.django_db
+def test_all_care_processes_under_12_three_complete_passes(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A T1DM patient <12 only needs HbA1c, BMI and thyroid to pass (not age-gated checks)."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    # Aged 11 at audit start
+    patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[0][0],
+        date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=visit_date,
+        hba1c=60,
+        hba1c_date=visit_date,
+        # bmi is a separate stored field, not auto-calculated from height/weight
+        height=140,
+        weight=38,
+        bmi=19.4,
+        height_weight_observation_date=visit_date,
+        thyroid_function_date=visit_date,
+        # Age-gated checks should not be required
+        systolic_blood_pressure=None,
+        blood_pressure_observation_date=None,
+        albumin_creatinine_ratio=None,
+        albumin_creatinine_ratio_date=None,
+        foot_examination_observation_date=None,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_all_care_processes"] == 1
+    assert totals["total_passed_all_care_processes"] == 1
+
+
+@pytest.mark.django_db
+def test_all_care_processes_t2dm_patient_excluded(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """T2DM patients are excluded from both the eligible and passed counts (T1 only metric)."""
+    user, pdu = _get_user_and_pdu()
+    audit_period = AuditPeriod.objects.get(slug="2024-2025")
+    visit_date = audit_period.start_date + relativedelta(days=10)
+
+    t2_patient = PatientFactory(
+        diabetes_type=DIABETES_TYPES[1][0],  # T2DM
+        date_of_birth=audit_period.start_date - relativedelta(years=14),
+        diagnosis_date=audit_period.start_date - relativedelta(days=2),
+    )
+    VisitFactory(
+        patient=t2_patient,
+        visit_date=visit_date,
+        hba1c=60,
+        hba1c_date=visit_date,
+        height=160,
+        weight=55,
+        height_weight_observation_date=visit_date,
+        thyroid_function_date=visit_date,
+        systolic_blood_pressure=110,
+        blood_pressure_observation_date=visit_date,
+        albumin_creatinine_ratio=1.2,
+        albumin_creatinine_ratio_date=visit_date,
+        foot_examination_observation_date=visit_date,
+    )
+
+    submission = _create_submission(user, pdu, audit_period)
+    submission.patients.add(t2_patient)
+
+    totals = dashboard_health_check_totals(pdu, audit_period)
+
+    assert totals["total_eligible_all_care_processes"] == 0
+    assert totals["total_passed_all_care_processes"] == 0


### PR DESCRIPTION
## Summary

Adds two new "Care Quality" stat tiles to the patient measurements dashboard card, both scoped to complete-year T1DM patients.

### New tiles

| Tile | Logic |
|------|-------|
| **4+ HbA1c** | Patients with ≥ 4 distinct HbA1c measurements recorded in the audit period |
| **All Care Processes** | Patients where every applicable care process is complete: all 6 for ≥12yo (HbA1c, BMI, BP, Urinary Albumin, Foot Exam, Thyroid), all 3 for <12yo (HbA1c, BMI, Thyroid) |

### Changes

**`queries.py`** — `dashboard_health_check_totals()`
- Annotates each patient with `hba1c_count` (distinct visits with a recorded HbA1c in the audit period)
- Returns two new aggregate pairs: `total_passed/eligible_four_hba1cs` and `total_passed/eligible_all_care_processes`
- No additional DB queries — computed in the same single aggregation pass

**`patient_measurements_partial.html`**
- New "Care Quality" section below the existing Health Checks section with two DaisyUI stat tiles
- No view changes needed — the existing `context.update(**returned_patient_health_check_totals)` already spreads the new keys into the template context

### Tests (8 new)

Added to `test_dashboard_kpi_calculations.py`:

- `test_four_hba1cs_patient_with_four_measurements_passes`
- `test_four_hba1cs_patient_with_three_measurements_fails`
- `test_four_hba1cs_visit_without_hba1c_value_not_counted`
- `test_four_hba1cs_incomplete_year_patient_excluded`
- `test_all_care_processes_over_12_all_six_complete_passes`
- `test_all_care_processes_over_12_missing_one_fails`
- `test_all_care_processes_under_12_three_complete_passes`
- `test_all_care_processes_t2dm_patient_excluded`

<img width="697" height="439" alt="image" src="https://github.com/user-attachments/assets/79f00fd4-c343-47bf-94f3-2f58b751e70a" />

closes #1405