### PR TITLE
Fix enabling and disabling hospital admission fields

### DIFF
--- a/project/npda/templates/partials/visit_form_tab.html
+++ b/project/npda/templates/partials/visit_form_tab.html
@@ -205,11 +205,21 @@
       }
     ]);
 
-    // Hospital admission reason dependencies
+    // Hospital admission reason dependencies (2021 uses hospital_admission_reason, 2026 uses hospital_admission_reason_2026)
     handleFieldDependency('id_hospital_admission_reason', [
       {
         targetId: 'id_dka_additional_therapies',
         condition: value => value === '2'
+      },
+      {
+        targetId: 'id_hospital_admission_other',
+        condition: value => value === '6'
+      }
+    ]);
+    handleFieldDependency('id_hospital_admission_reason_2026', [
+      {
+        targetId: 'id_dka_additional_therapies',
+        condition: value => value === '1'
       },
       {
         targetId: 'id_hospital_admission_other',


### PR DESCRIPTION
With the addition of the separate hospital_admission_reasons_2026 field (#1418) the fields that should have been conditionally enabled for certain reasons weren't wired up.

This meant they were always set. For the "other" textarea this led to "None" appearing in the textarea so every visit ended up with that data, even if it wasn't a hospital admission.

Claude (thank you!) realised that by making these fields dependent on the correct values it also fixes that bug because the handleFieldDependency code clears the "None" to empty string,.