### PR TITLE
Update IMD map to 0.4.0 and map Jersey/Isle of Man to channel_islands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,11 @@ All dashboard functions use `build_base_queryset()` as their base and respect `a
 
 The dashboard IMD map in `project/npda/templates/dashboard/map_chart_partial.html` uses the browser bundle from `@rcpch/imd-map`.
 
-- Current bundle version: `0.3.1`
+- Current bundle version: `0.4.0`
 - Script URL:
-    `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js`
+    `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.4.0/dist/umd/rcpch-imd-map.min.js`
 - Current SRI:
-    `sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig==`
+    `sha512-4icz8A609i4Dy78X8a2NYqhMNO6wyS+vpJ9ffcf6oLuyhpjLPGhnwmkZHZIpS1ZC7c5S2GpxqlK6oP+8Rawjag==`
 
 Tile auth is now configured via map options (query-string auth), not request headers.
 

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.3.1/dist/umd/rcpch-imd-map.min.js"
-          integrity="sha512-nE5gt833x02gAJE9hWc8jmeYawgdHqwnHw34riKVSPm7z/gBSsGoJV4CedzC/zZ4sSeoNdr5vWDmQgoDFQkeig=="
+    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.4.0/dist/umd/rcpch-imd-map.min.js"
+      integrity="sha512-4icz8A609i4Dy78X8a2NYqhMNO6wyS+vpJ9ffcf6oLuyhpjLPGhnwmkZHZIpS1ZC7c5S2GpxqlK6oP+8Rawjag=="
           crossorigin="anonymous"></script>
   <script>
     window.npdaInitOrganisationCasesMap = function () {

--- a/project/npda/tests/view_tests/dashboard/test_partials.py
+++ b/project/npda/tests/view_tests/dashboard/test_partials.py
@@ -21,6 +21,7 @@ from project.npda.tests.factories import test_user_audit_centre_editor_data
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
 from project.npda.tests.utils import login_and_verify_user
+from project.npda.views.dashboard.partials import _map_initial_nation_for_organisation
 
 
 def setup(audit_period, patient_args):
@@ -220,3 +221,40 @@ def test_partials_before_submission(
 
     assert response.status_code == HTTPStatus.OK
     assert response.context["number"] == 0
+
+
+@pytest.mark.parametrize(
+    ("organisation", "expected_nation"),
+    [
+        pytest.param({"country": "England"}, "england", id="england-country"),
+        pytest.param(
+            {"country": "Northern Ireland"},
+            "northern_ireland",
+            id="northern-ireland-country",
+        ),
+        pytest.param(
+            {"country": "Jersey"},
+            "channel_islands",
+            id="jersey-country",
+        ),
+        pytest.param(
+            {"country": "Isle of Man"},
+            "channel_islands",
+            id="isle-of-man-country",
+        ),
+        pytest.param(
+            {"country": "isle_of_man"},
+            "channel_islands",
+            id="isle-of-man-underscore",
+        ),
+        pytest.param(
+            {"country_name": "Channel Islands"},
+            "channel_islands",
+            id="channel-islands-country-name",
+        ),
+        pytest.param({"nation": "Wales"}, "wales", id="wales-nation-fallback"),
+        pytest.param({}, "all", id="missing-country-default-all"),
+    ],
+)
+def test_map_initial_nation_for_organisation(organisation, expected_nation):
+    assert _map_initial_nation_for_organisation(organisation) == expected_nation

--- a/project/npda/views/dashboard/partials.py
+++ b/project/npda/views/dashboard/partials.py
@@ -70,6 +70,14 @@ def _map_initial_nation_for_organisation(organisation: dict) -> str:
         return "scotland"
     if country in {"northern ireland", "northern_ireland"}:
         return "northern_ireland"
+    if country in {
+        "jersey",
+        "isle of man",
+        "isle_of_man",
+        "channel islands",
+        "channel_islands",
+    }:
+        return "channel_islands"
 
     return "all"
 


### PR DESCRIPTION
## Summary
- bump dashboard IMD map browser bundle from `@rcpch/imd-map@0.3.1` to `@rcpch/imd-map@0.4.0`
- update the script SRI to match the 0.4.0 CDN asset
- coerce organisation country values for Jersey and Isle of Man to `channel_islands` for map `initialNation`
- add unit tests for `_map_initial_nation_for_organisation` covering Jersey/Isle of Man and fallback behavior
- update AGENTS documentation for the map bundle version and SRI

## Why
The map package now supports `channel_islands`; NPDA now includes Jersey and Isle of Man and both should render using that nation mode.

## Validation
- `s/lint --check`
- `s/test project/npda/tests/view_tests/dashboard/test_partials.py`
