### PR TITLE
feat: national lead-centre bubble map on submissions page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,11 @@ All dashboard functions use `build_base_queryset()` as their base and respect `a
 
 The dashboard IMD map in `project/npda/templates/dashboard/map_chart_partial.html` uses the browser bundle from `@rcpch/imd-map`.
 
-- Current bundle version: `0.5.0`
+- Current bundle version: `0.5.1`
 - Script URL:
-  `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js`
+  `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js`
 - Current SRI:
-  `sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg==`
+  `sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw==`
 
 Tile auth is now configured via map options (query-string auth), not request headers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,12 @@ The script wraps: `docker compose run --rm django pytest -v $*`
 
 The patient report is driven by its own dedicated query layer — **do not reach for the KPI class** when working on it.
 
-| Path | Purpose |
-|------|---------|
+| Path                                                       | Purpose                                                                                                                                                                                                  |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `project/npda/general_functions/patient_report/queries.py` | All ORM queries that power the patient report **and the dashboard** (health checks, additional care processes, care at diagnosis, admissions, treatment, outcomes, plus all dashboard summary functions) |
-| `project/npda/views/patient_report/patient_report.py` | View logic, context assembly, sorting, pagination, XLSX export |
-| `project/npda/views/patient_report/patient_report.md` | Design intent, column definitions, edge cases, known shortcomings, and **the authoritative 2021/2026 field mapping per category — read this before touching any patient report query** |
-| `project/npda/templates/patient_report/` | Jinja/Django templates per category (e.g. `treatment_table_partial.html`) |
+| `project/npda/views/patient_report/patient_report.py`      | View logic, context assembly, sorting, pagination, XLSX export                                                                                                                                           |
+| `project/npda/views/patient_report/patient_report.md`      | Design intent, column definitions, edge cases, known shortcomings, and **the authoritative 2021/2026 field mapping per category — read this before touching any patient report query**                   |
+| `project/npda/templates/patient_report/`                   | Jinja/Django templates per category (e.g. `treatment_table_partial.html`)                                                                                                                                |
 
 When working on patient report queries, always check `patient_report.md` for the correct field to use for the active dataset year. Several fields changed or were added in 2026 (e.g. `treatment` → `insulin_regimen`, `glucose_monitoring` → `cgm_use`, `smoking_status` → `smoking_vaping_status`). The `audit_period.get_dataset_year()` method is the single source of truth — never hardcode a year.
 
@@ -43,27 +43,27 @@ When working on patient report queries, always check `patient_report.md` for the
 
 The dashboard views also use `queries.py` directly — **do not reach for the KPI class** when working on dashboard code.
 
-| Path | Purpose |
-|------|---------|
-| `project/npda/views/dashboard/dashboard.py` | Main dashboard view — eligible patient count and new-diagnoses quarter chart |
-| `project/npda/views/dashboard/partials.py` | HTMX partials — HCL, pump, CGM, admissions, service transitions, map |
+| Path                                                   | Purpose                                                                             |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `project/npda/views/dashboard/dashboard.py`            | Main dashboard view — eligible patient count and new-diagnoses quarter chart        |
+| `project/npda/views/dashboard/partials.py`             | HTMX partials — HCL, pump, CGM, admissions, service transitions, map                |
 | `project/npda/views/dashboard/patient_measurements.py` | Measurements card — HbA1c stats by diabetes type, health-check pass/eligible counts |
-| `project/npda/templates/dashboard/` | Dashboard templates |
+| `project/npda/templates/dashboard/`                    | Dashboard templates                                                                 |
 
 **Dashboard query functions in `queries.py`** (all accept `pdu, audit_period`):
 
-| Function | Returns | Notes |
-|----------|---------|-------|
-| `count_eligible_patients` | `int` | All diabetes types, complete-year filter |
-| `count_new_diagnoses_by_quarter` | `dict[int, dict]` | `{q: {total_passed, total_eligible, pct}}` |
-| `count_hcl_use` | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware |
-| `count_pump_use` | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware |
-| `count_cgm_use` | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware |
-| `count_admissions` | `int` | Total admissions count |
-| `count_admissions_by_quarter` | `dict[int, dict]` | Quarter-stratified admissions |
-| `count_service_transitions_by_quarter` | `dict[int, dict]` | Quarter-stratified adult-service transitions |
-| `hba1c_stats_by_diabetes_type` | `dict` | `{all, t1dm, t2dm, other}` each with `mean_mmol_mol`, `median_mmol_mol`, `mean_percent`, `median_percent`; 2021/2026 aware |
-| `dashboard_health_check_totals` | `dict` | `total_passed_*` / `total_eligible_*` for BMI, thyroid, BP, urinary albumin, foot exam; single aggregation query |
+| Function                               | Returns           | Notes                                                                                                                      |
+| -------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `count_eligible_patients`              | `int`             | All diabetes types, complete-year filter                                                                                   |
+| `count_new_diagnoses_by_quarter`       | `dict[int, dict]` | `{q: {total_passed, total_eligible, pct}}`                                                                                 |
+| `count_hcl_use`                        | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware                                                                                     |
+| `count_pump_use`                       | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware                                                                                     |
+| `count_cgm_use`                        | `tuple[int, int]` | `(passed, eligible)` — 2021/2026 aware                                                                                     |
+| `count_admissions`                     | `int`             | Total admissions count                                                                                                     |
+| `count_admissions_by_quarter`          | `dict[int, dict]` | Quarter-stratified admissions                                                                                              |
+| `count_service_transitions_by_quarter` | `dict[int, dict]` | Quarter-stratified adult-service transitions                                                                               |
+| `hba1c_stats_by_diabetes_type`         | `dict`            | `{all, t1dm, t2dm, other}` each with `mean_mmol_mol`, `median_mmol_mol`, `mean_percent`, `median_percent`; 2021/2026 aware |
+| `dashboard_health_check_totals`        | `dict`            | `total_passed_*` / `total_eligible_*` for BMI, thyroid, BP, urinary albumin, foot exam; single aggregation query           |
 
 All dashboard functions use `build_base_queryset()` as their base and respect `audit_period.get_dataset_year()`. They return plain Python values — no `KPIResult` objects.
 
@@ -71,11 +71,11 @@ All dashboard functions use `build_base_queryset()` as their base and respect `a
 
 The dashboard IMD map in `project/npda/templates/dashboard/map_chart_partial.html` uses the browser bundle from `@rcpch/imd-map`.
 
-- Current bundle version: `0.4.0`
+- Current bundle version: `0.5.0`
 - Script URL:
-    `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.4.0/dist/umd/rcpch-imd-map.min.js`
+  `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js`
 - Current SRI:
-    `sha512-4icz8A609i4Dy78X8a2NYqhMNO6wyS+vpJ9ffcf6oLuyhpjLPGhnwmkZHZIpS1ZC7c5S2GpxqlK6oP+8Rawjag==`
+  `sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg==`
 
 Tile auth is now configured via map options (query-string auth), not request headers.
 
@@ -85,10 +85,10 @@ Tile auth is now configured via map options (query-string auth), not request hea
 
 ```javascript
 RcpchImdMap.createImdMap({
-    container: container,
-    tilesBaseUrl: tilesBaseUrl,
-    tilesApiKey: window.RCPCH_CENSUS_PLATFORM_TOKEN || undefined,
-    tilesApiKeyParam: 'Subscription-Key',
+  container: container,
+  tilesBaseUrl: tilesBaseUrl,
+  tilesApiKey: window.RCPCH_CENSUS_PLATFORM_TOKEN || undefined,
+  tilesApiKeyParam: "Subscription-Key",
 });
 ```
 
@@ -100,27 +100,27 @@ Keep the API key plumbing aligned with `project/npda/general_functions/index_mul
 
 ### Core models
 
-| Model | Path | Notes |
-|-------|------|-------|
-| `Patient` | `project/npda/models/patient.py` | `nhs_number` and `unique_reference_number` are both `unique=False` at the DB level — uniqueness within a PDU's submission is enforced by `Submission.add_patient()`, not a DB constraint |
-| `Submission` | `project/npda/models/submission.py` | One active submission per PDU per audit period. Use `Submission.objects.get_submission_for_request(pdu, audit_period)` to fetch it. **Always use `submission.add_patient(patient)` in production code** (see Submission wiring below) |
-| `PatientSubmission` | `project/npda/models/patientsubmission.py` | Through-table for the `Submission ↔ Patient` M2M. No custom validation — uniqueness lives on `Submission.add_patient()` |
-| `Transfer` | `project/npda/models/transfer.py` | One `Transfer` per `Patient`, recording their current PDU. Created alongside the `Patient` in `PatientCreateView.form_valid()` |
-| `Visit` | `project/npda/models/visit.py` | FK to `Patient`. Many visits per patient per audit period |
-| `AuditPeriod` | `project/npda/models/audit_period.py` | Use `AuditPeriod.objects.get_default_audit_period()` in tests. `audit_period.get_dataset_year()` is the single source of truth for 2021 vs 2026 |
+| Model               | Path                                       | Notes                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Patient`           | `project/npda/models/patient.py`           | `nhs_number` and `unique_reference_number` are both `unique=False` at the DB level — uniqueness within a PDU's submission is enforced by `Submission.add_patient()`, not a DB constraint                                              |
+| `Submission`        | `project/npda/models/submission.py`        | One active submission per PDU per audit period. Use `Submission.objects.get_submission_for_request(pdu, audit_period)` to fetch it. **Always use `submission.add_patient(patient)` in production code** (see Submission wiring below) |
+| `PatientSubmission` | `project/npda/models/patientsubmission.py` | Through-table for the `Submission ↔ Patient` M2M. No custom validation — uniqueness lives on `Submission.add_patient()`                                                                                                               |
+| `Transfer`          | `project/npda/models/transfer.py`          | One `Transfer` per `Patient`, recording their current PDU. Created alongside the `Patient` in `PatientCreateView.form_valid()`                                                                                                        |
+| `Visit`             | `project/npda/models/visit.py`             | FK to `Patient`. Many visits per patient per audit period                                                                                                                                                                             |
+| `AuditPeriod`       | `project/npda/models/audit_period.py`      | Use `AuditPeriod.objects.get_default_audit_period()` in tests. `audit_period.get_dataset_year()` is the single source of truth for 2021 vs 2026                                                                                       |
 
 ### Constants
 
 `project/constants/` — canonical choice lists used across models, queries and templates.
 
-| File | Contains |
-|------|---------|
-| `diabetes_treatment.py` | `TREATMENT_TYPES` |
+| File                          | Contains                   |
+| ----------------------------- | -------------------------- |
+| `diabetes_treatment.py`       | `TREATMENT_TYPES`          |
 | `glucose_monitoring_types.py` | `GLUCOSE_MONITORING_TYPES` |
-| `closed_loop_types.py` | `CLOSED_LOOP_TYPES` |
-| `diabetes_types.py` | `DIABETES_TYPES` |
-| `smoking_status.py` | `SMOKING_STATUS` |
-| `hba1c_format.py` | `HBA1C_FORMATS` |
+| `closed_loop_types.py`        | `CLOSED_LOOP_TYPES`        |
+| `diabetes_types.py`           | `DIABETES_TYPES`           |
+| `smoking_status.py`           | `SMOKING_STATUS`           |
+| `hba1c_format.py`             | `HBA1C_FORMATS`            |
 
 ---
 
@@ -142,10 +142,10 @@ Use `ALDER_HEY_PZ_CODE` (imported from `project.npda.tests.constants_for_tests`)
 
 ### Factories
 
-| Factory | Import path |
-|---------|-------------|
+| Factory          | Import path                                    |
+| ---------------- | ---------------------------------------------- |
 | `PatientFactory` | `project.npda.tests.factories.patient_factory` |
-| `VisitFactory` | `project.npda.tests.factories.visit_factory` |
+| `VisitFactory`   | `project.npda.tests.factories.visit_factory`   |
 
 **`VisitFactory` has opinionated non-null defaults** for `treatment`, `closed_loop_system` and `glucose_monitoring`. Pass `None` explicitly when testing missing-data behaviour:
 
@@ -183,7 +183,7 @@ submission = Submission.objects.create(
 submission.patients.add(patient)
 ```
 
-**In production code** (views, management commands, etc.) always use `submission.add_patient(patient)` instead of the bare `patients.add()`. This method enforces a PDU-scoped uniqueness rule: a patient with the same NHS number (or Unique Reference Number for Jersey patients) cannot appear more than once across any active submissions for the *same PDU* in the same audit period. The same identifier is allowed in a different PDU's submission (e.g. after a cross-PDU transfer). A `ValidationError` is raised on violation.
+**In production code** (views, management commands, etc.) always use `submission.add_patient(patient)` instead of the bare `patients.add()`. This method enforces a PDU-scoped uniqueness rule: a patient with the same NHS number (or Unique Reference Number for Jersey patients) cannot appear more than once across any active submissions for the _same PDU_ in the same audit period. The same identifier is allowed in a different PDU's submission (e.g. after a cross-PDU transfer). A `ValidationError` is raised on violation.
 
 ```python
 # Raises ValidationError if NHS/URN already in an active submission for this PDU
@@ -201,21 +201,21 @@ Keys match the annotation names in `queries.py` (e.g. `"treatment_regimen"`, `"g
 
 All convenience scripts live in `s/`. They must be run from the repo root.
 
-| Script | What it does |
-|--------|-------------|
-| `s/up` | Start all Docker Compose services |
-| `s/down` | Stop all services |
-| `s/rebuild` | Remove containers/images then bring up fresh |
-| `s/local-clean-reset` | Nuclear reset: removes volumes and images, then `s/up` |
-| `s/start-dev` | Run migrations, seed data, start Django dev server on port 8008 |
-| `s/watch-tailwind` | Compile Tailwind CSS in watch mode |
-| `s/django-shell` | Open Django shell inside the running container |
-| `s/test` | Run pytest in a one-shot container (passes all args to pytest) |
-| `s/lint` | Run ruff formatter + linter in fix mode |
-| `s/lint --check` | Lint check only (used in CI, exits non-zero if unclean) |
-| `s/psql` | Connect to Postgres (local or Azure, see script for options) |
-| `s/create-superuser` | Create a Django superuser inside the container |
-| `s/start-celery-dev` | Start Celery worker for local development |
+| Script                | What it does                                                    |
+| --------------------- | --------------------------------------------------------------- |
+| `s/up`                | Start all Docker Compose services                               |
+| `s/down`              | Stop all services                                               |
+| `s/rebuild`           | Remove containers/images then bring up fresh                    |
+| `s/local-clean-reset` | Nuclear reset: removes volumes and images, then `s/up`          |
+| `s/start-dev`         | Run migrations, seed data, start Django dev server on port 8008 |
+| `s/watch-tailwind`    | Compile Tailwind CSS in watch mode                              |
+| `s/django-shell`      | Open Django shell inside the running container                  |
+| `s/test`              | Run pytest in a one-shot container (passes all args to pytest)  |
+| `s/lint`              | Run ruff formatter + linter in fix mode                         |
+| `s/lint --check`      | Lint check only (used in CI, exits non-zero if unclean)         |
+| `s/psql`              | Connect to Postgres (local or Azure, see script for options)    |
+| `s/create-superuser`  | Create a Django superuser inside the container                  |
+| `s/start-celery-dev`  | Start Celery worker for local development                       |
 
 ### IMD recalculation command (basic use)
 
@@ -255,14 +255,14 @@ There are two datasets: **2021** and **2026**. The dataset year is derived from 
 
 ### Where the dataset year is used
 
-| Location | Purpose |
-|----------|---------|
-| `project/npda/general_functions/headings.py` | `get_field_heading(field_name, dataset_year)` — returns the year-appropriate CSV column heading for a given model field |
-| `project/constants/csv_headings.py` | `ALL_HEADINGS` — master list of every field with a `dataset_years` list indicating which datasets include it |
-| `project/npda/general_functions/csv/csv_upload.py` | Infers `dataset_year` from the submission's audit period (or from column sniffing) before parsing |
-| `project/npda/models/patient.py` | `Patient.get_field_label()`, `get_sex_label()` etc. delegate to `get_field_heading` |
-| `project/npda/models/visit.py` | `Visit.get_field_label()` delegates to `get_field_heading` |
-| `project/npda/forms/patient_form.py` / `visit_form.py` | Form field labels are resolved via `get_field_heading` at form instantiation |
+| Location                                               | Purpose                                                                                                                 |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `project/npda/general_functions/headings.py`           | `get_field_heading(field_name, dataset_year)` — returns the year-appropriate CSV column heading for a given model field |
+| `project/constants/csv_headings.py`                    | `ALL_HEADINGS` — master list of every field with a `dataset_years` list indicating which datasets include it            |
+| `project/npda/general_functions/csv/csv_upload.py`     | Infers `dataset_year` from the submission's audit period (or from column sniffing) before parsing                       |
+| `project/npda/models/patient.py`                       | `Patient.get_field_label()`, `get_sex_label()` etc. delegate to `get_field_heading`                                     |
+| `project/npda/models/visit.py`                         | `Visit.get_field_label()` delegates to `get_field_heading`                                                              |
+| `project/npda/forms/patient_form.py` / `visit_form.py` | Form field labels are resolved via `get_field_heading` at form instantiation                                            |
 
 ### Key differences between datasets
 
@@ -312,11 +312,11 @@ Patients at the Jersey PDU (`pz_code == "PZ248"`) use `unique_reference_number` 
 
 ### Key files
 
-| File | Purpose |
-|------|---------|
-| `project/constants/csv_headings.py` | `ALL_HEADINGS` master list + helper functions |
+| File                                              | Purpose                                                                                                                |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `project/constants/csv_headings.py`               | `ALL_HEADINGS` master list + helper functions                                                                          |
 | `project/npda/general_functions/csv/csv_parse.py` | Reads a CSV file into a pandas DataFrame, normalises headings, detects the unique identifier, and records parse errors |
-| `project/npda/general_functions/csv/csv_clean.py` | Converts date strings to `pd.Timestamp`, cleans sex/ethnicity/measurement columns |
+| `project/npda/general_functions/csv/csv_clean.py` | Converts date strings to `pd.Timestamp`, cleans sex/ethnicity/measurement columns                                      |
 
 ### `ALL_HEADINGS` structure
 
@@ -333,16 +333,16 @@ Each entry in `ALL_HEADINGS` is a dict with:
 }
 ```
 
-Fields shared between both years have `dataset_years: [2021, 2026]`. Year-specific fields have only their year in the list. When a heading *name* changes between years, two separate entries share the same `model_field` (the deduplication in `get_csv_heading_objects` ensures each year's canonical heading is returned once).
+Fields shared between both years have `dataset_years: [2021, 2026]`. Year-specific fields have only their year in the list. When a heading _name_ changes between years, two separate entries share the same `model_field` (the deduplication in `get_csv_heading_objects` ensures each year's canonical heading is returned once).
 
 ### Helper functions in `csv_headings.py`
 
-| Function | Returns |
-|----------|---------|
-| `get_csv_heading_objects(dataset_year)` | Tuple of heading dicts for the given year (deduped by `model_field`) |
+| Function                                                                                  | Returns                                                                                                       |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `get_csv_heading_objects(dataset_year)`                                                   | Tuple of heading dicts for the given year (deduped by `model_field`)                                          |
 | `get_csv_heading_objects_for_year_and_unique_identifier(dataset_year, unique_identifier)` | Like above but also prepends the correct patient identifier heading (England NHS number, Jersey URN, or both) |
-| `get_all_dates(dataset_year)` | List of CSV column *headings* whose `data_type == "date"` for the given year |
-| `csv_definition_for(model_field_or_column, dataset_year)` | Single heading dict for a model field name or column heading |
+| `get_all_dates(dataset_year)`                                                             | List of CSV column _headings_ whose `data_type == "date"` for the given year                                  |
+| `csv_definition_for(model_field_or_column, dataset_year)`                                 | Single heading dict for a model field name or column heading                                                  |
 
 ### `csv_parse` flow
 
@@ -357,6 +357,7 @@ Fields shared between both years have `dataset_years: [2021, 2026]`. Year-specif
 ### `csv_clean` flow
 
 Called inside `csv_upload` after `csv_parse`. Applies:
+
 - `pd.to_datetime` (day-first, mixed format) to all date columns returned by `get_all_dates(dataset_year)`.
 - Custom cleaners for `sex`, `ethnicity`, `height`, `weight`.
 - Whitespace stripping across all string/object columns.
@@ -419,6 +420,7 @@ csv_upload(dataframe, errors_to_return, csv_file_name, submission)
 ### `row_to_dict(row, model)`
 
 Iterates `CSV_HEADINGS` filtering by `model`. For each matching entry it:
+
 1. Looks up the model field definition via `model._meta.get_field(model_field_name)`.
 2. Reads `row[entry["heading"]]`.
 3. Converts the value via `csv_value_to_model_value()` — handles NaN → None, `pd.Timestamp` → `datetime.date`, numpy scalars → Python scalars, integer-valued floats → int.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,11 @@ All dashboard functions use `build_base_queryset()` as their base and respect `a
 
 The dashboard IMD map in `project/npda/templates/dashboard/map_chart_partial.html` uses the browser bundle from `@rcpch/imd-map`.
 
-- Current bundle version: `0.5.1`
+- Current bundle version: `0.5.2`
 - Script URL:
-  `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js`
+  `https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.2/dist/umd/rcpch-imd-map.min.js`
 - Current SRI:
-  `sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw==`
+  `sha512-a766qxZJXhOAclDsv1qP89xJMden52mrMRWvodABs3zs34TLx/roXRik7grS4skx2mTUvKyO22RAokkpJMCLqg==`
 
 Tile auth is now configured via map options (query-string auth), not request headers.
 

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -38,7 +38,7 @@ from project.constants.leave_pdu_reasons import LEAVE_PDU_REASONS
 from project.constants.yes_no_unknown import YES_NO_UNKNOWN
 from project.npda.general_functions.audit_period import get_quarters_for_audit_period
 from project.npda.general_functions.quarter_for_date import retrieve_quarter_for_date
-from project.npda.models import Patient, Transfer, Visit
+from project.npda.models import PaediatricDiabetesUnit, Patient, Transfer, Visit
 from project.npda.models.db_functions import Round
 
 
@@ -1468,3 +1468,142 @@ def calculate_hba1c_values(qs, audit_period):
             patient["median_hba1c_pct"] = None
 
     return qs
+
+
+def all_pdus_t1dm_bubble_map_data(audit_period) -> list[dict]:
+    """Bubble map data for the national submissions overview (audit team only).
+
+    Returns one entry per PDU that has an active submission with T1DM patients and
+    a geocoordinate on record.  Each entry is a plain dict ready to be passed
+    directly to the map library's ``setLeadCentres()`` call:
+
+        {
+            "lat": float,
+            "lon": float,
+            "label": str,            # lead_organisation_name or pz_code
+            "pz_code": str,
+            "patient_count": int,    # eligible T1DM patients in the audit period
+            "median_hba1c": int | None,  # median HbA1c in mmol/mol
+        }
+
+    Uses the same eligibility filters as ``count_eligible_patients()`` and the
+    same HbA1c normalisation logic as ``hba1c_stats_by_diabetes_type()``.
+    Runs in ~4 DB round-trips regardless of the number of PDUs.
+    """
+    audit_range = (audit_period.start_date, audit_period.end_date)
+    dataset_year = audit_period.get_dataset_year()
+
+    # All active PDUs with a submission in this period and a geocoordinate
+    pdus = {
+        pdu.pz_code: pdu
+        for pdu in PaediatricDiabetesUnit.objects.filter(
+            active=True,
+            pdu_submissions__submission_active=True,
+            pdu_submissions__audit_period=audit_period,
+            lead_organisation_geocoordinates__isnull=False,
+        ).distinct()
+    }
+    if not pdus:
+        return []
+
+    # Eligible T1DM patients annotated with their PDU pz_code.
+    # distinct() on (pk, pz_code) gives one row per patient per PDU.
+    t1dm_rows = (
+        Patient.objects.filter(
+            submissions__submission_active=True,
+            submissions__audit_period=audit_period,
+            submissions__paediatric_diabetes_unit__pz_code__in=pdus.keys(),
+            diabetes_type=DIABETES_TYPES[0][0],
+            visit__visit_date__range=audit_range,
+            date_of_birth__gt=audit_period.start_date - relativedelta(years=25),
+        )
+        .distinct()
+        .values("pk", "submissions__paediatric_diabetes_unit__pz_code")
+    )
+
+    # Build patient→PDU map and per-PDU patient counts in one pass
+    patient_pdu_map: dict[int, str] = {}
+    patient_counts: dict[str, int] = defaultdict(int)
+    for row in t1dm_rows:
+        pk = row["pk"]
+        pz = row["submissions__paediatric_diabetes_unit__pz_code"]
+        if pk not in patient_pdu_map:
+            patient_pdu_map[pk] = pz
+            patient_counts[pz] += 1
+
+    if not patient_pdu_map:
+        return []
+
+    # Fetch HbA1c values for all T1DM patients in one query
+    if dataset_year == 2026:
+        hba1c_rows = Visit.objects.filter(
+            patient__pk__in=patient_pdu_map.keys(),
+            visit_date__range=audit_range,
+            hba1c__isnull=False,
+            hba1c_date__gt=F("patient__diagnosis_date") + timedelta(days=90),
+        ).values("patient__pk", "hba1c")
+        hba1c_key = "hba1c"
+    else:
+        hba1c_rows = (
+            Visit.objects.filter(
+                patient__pk__in=patient_pdu_map.keys(),
+                visit_date__range=audit_range,
+                hba1c__isnull=False,
+                hba1c_date__gt=F("patient__diagnosis_date") + timedelta(days=90),
+            )
+            .annotate(
+                hba1c_mmol_mol=Case(
+                    When(Q(hba1c_format=HBA1C_FORMATS[0][0]), then=F("hba1c")),
+                    When(
+                        Q(hba1c_format=HBA1C_FORMATS[1][0]),
+                        then=(F("hba1c") - Round(Decimal("2.152")))
+                        / Decimal("0.09148"),
+                    ),
+                    default=None,
+                    output_field=DecimalField(max_digits=5, decimal_places=2),
+                )
+            )
+            .filter(hba1c_mmol_mol__isnull=False)
+            .values("patient__pk", "hba1c_mmol_mol")
+        )
+        hba1c_key = "hba1c_mmol_mol"
+
+    # Group HbA1c values by PDU
+    hba1c_by_pdu: dict[str, list] = defaultdict(list)
+    for row in hba1c_rows:
+        pz = patient_pdu_map.get(row["patient__pk"])
+        if pz:
+            hba1c_by_pdu[pz].append(row[hba1c_key])
+
+    result = []
+    for pz_code, pdu in pdus.items():
+        count = patient_counts.get(pz_code, 0)
+        if count == 0:
+            continue
+
+        hba1c_vals = hba1c_by_pdu.get(pz_code, [])
+        if hba1c_vals:
+            sorted_vals = sorted(float(v) for v in hba1c_vals)
+            mid = len(sorted_vals) // 2
+            median_hba1c = (
+                (sorted_vals[mid - 1] + sorted_vals[mid]) / 2
+                if len(sorted_vals) % 2 == 0
+                else sorted_vals[mid]
+            )
+            median_hba1c = round(median_hba1c)
+        else:
+            median_hba1c = None
+
+        coords = pdu.lead_organisation_geocoordinates
+        result.append(
+            {
+                "lat": coords.y,
+                "lon": coords.x,
+                "label": pdu.lead_organisation_name or pdu.pz_code,
+                "pz_code": pz_code,
+                "patient_count": count,
+                "median_hba1c": median_hba1c,
+            }
+        )
+
+    return result

--- a/project/npda/general_functions/patient_report/queries.py
+++ b/project/npda/general_functions/patient_report/queries.py
@@ -1607,3 +1607,292 @@ def all_pdus_t1dm_bubble_map_data(audit_period) -> list[dict]:
         )
 
     return result
+
+
+def all_pdus_care_processes_map_data(audit_period) -> list[dict]:
+    """% complete care processes per PDU for the national bubble map (T1DM only).
+
+    Each entry:
+        {
+            "lat": float, "lon": float, "label": str, "pz_code": str,
+            "eligible_count": int,   # T1DM patients with complete year of care
+            "pct_complete": int,     # % who passed all required care processes (0-100)
+        }
+
+    Uses the same eligibility and care-process definitions as
+    ``dashboard_health_check_totals`` (HbA1c, BMI, thyroid for all;
+    + BP, albumin, foot exam for patients aged ≥12).
+    """
+    audit_range = (audit_period.start_date, audit_period.end_date)
+
+    pdus = {
+        pdu.pz_code: pdu
+        for pdu in PaediatricDiabetesUnit.objects.filter(
+            active=True,
+            pdu_submissions__submission_active=True,
+            pdu_submissions__audit_period=audit_period,
+            lead_organisation_geocoordinates__isnull=False,
+        ).distinct()
+    }
+    if not pdus:
+        return []
+
+    # Build patient → PDU mapping for T1DM patients with visits in this period
+    t1dm_rows = (
+        Patient.objects.filter(
+            submissions__submission_active=True,
+            submissions__audit_period=audit_period,
+            submissions__paediatric_diabetes_unit__pz_code__in=pdus.keys(),
+            diabetes_type=DIABETES_TYPES[0][0],
+            visit__visit_date__range=audit_range,
+            date_of_birth__gt=audit_period.start_date - relativedelta(years=25),
+        )
+        .distinct()
+        .values("pk", "submissions__paediatric_diabetes_unit__pz_code")
+    )
+    patient_pdu_map: dict[int, str] = {}
+    for row in t1dm_rows:
+        pk = row["pk"]
+        if pk not in patient_pdu_map:
+            patient_pdu_map[pk] = row["submissions__paediatric_diabetes_unit__pz_code"]
+
+    if not patient_pdu_map:
+        return []
+
+    # Annotate each patient with care-process pass/fail
+    care_qs = (
+        Patient.objects.filter(pk__in=patient_pdu_map.keys())
+        .annotate(
+            is_gte_12yo=Q(
+                date_of_birth__lte=audit_period.start_date - relativedelta(years=12)
+            ),
+            is_incomplete_year_of_care=Case(
+                When(Q(diagnosis_date__range=audit_range), then=True),
+                When(
+                    Exists(
+                        Transfer.objects.filter(
+                            patient=OuterRef("pk"),
+                            date_leaving_service__range=audit_range,
+                        )
+                    ),
+                    then=True,
+                ),
+                default=False,
+                output_field=BooleanField(),
+            ),
+        )
+        .annotate(
+            is_complete_year_of_care=Case(
+                When(is_incomplete_year_of_care=True, then=False),
+                default=True,
+                output_field=BooleanField(),
+            )
+        )
+    )
+    care_qs = annotate_health_checks(care_qs, audit_period)
+
+    eligible: dict[str, int] = defaultdict(int)
+    passed_all: dict[str, int] = defaultdict(int)
+    for row in care_qs.values(
+        "pk", "is_complete_year_of_care", "is_gte_12yo", "num_passed"
+    ):
+        pz = patient_pdu_map.get(row["pk"])
+        if pz is None or not row["is_complete_year_of_care"]:
+            continue
+        eligible[pz] += 1
+        threshold = 6 if row["is_gte_12yo"] else 3
+        if row["num_passed"] == threshold:
+            passed_all[pz] += 1
+
+    result = []
+    for pz_code, pdu in pdus.items():
+        eligible_count = eligible.get(pz_code, 0)
+        if eligible_count == 0:
+            continue
+        passed_count = passed_all.get(pz_code, 0)
+        coords = pdu.lead_organisation_geocoordinates
+        result.append(
+            {
+                "lat": coords.y,
+                "lon": coords.x,
+                "label": pdu.lead_organisation_name or pdu.pz_code,
+                "pz_code": pz_code,
+                "eligible_count": eligible_count,
+                "pct_complete": round(passed_count / eligible_count * 100),
+            }
+        )
+
+    return result
+
+
+def all_pdus_diabetes_type_map_data(audit_period) -> list[dict]:
+    """Diabetes type breakdown per PDU for the national bubble map.
+
+    Each entry:
+        {
+            "lat": float, "lon": float, "label": str, "pz_code": str,
+            "total_patients": int,    # all eligible patients (all types)
+            "dominant_type": str,     # 'type1' | 'type2' | 'other'
+            "pct_type1": int,         # percentage type 1 (0-100)
+            "pct_type2": int,         # percentage type 2 (0-100)
+            "pct_other": int,         # percentage other (0-100)
+        }
+
+    Suitable for ``colorMode: 'categorical'`` in setLeadCentres().
+    """
+    audit_range = (audit_period.start_date, audit_period.end_date)
+
+    pdus = {
+        pdu.pz_code: pdu
+        for pdu in PaediatricDiabetesUnit.objects.filter(
+            active=True,
+            pdu_submissions__submission_active=True,
+            pdu_submissions__audit_period=audit_period,
+            lead_organisation_geocoordinates__isnull=False,
+        ).distinct()
+    }
+    if not pdus:
+        return []
+
+    rows = (
+        Patient.objects.filter(
+            submissions__submission_active=True,
+            submissions__audit_period=audit_period,
+            submissions__paediatric_diabetes_unit__pz_code__in=pdus.keys(),
+            visit__visit_date__range=audit_range,
+            date_of_birth__gt=audit_period.start_date - relativedelta(years=25),
+        )
+        .distinct()
+        .values("pk", "diabetes_type", "submissions__paediatric_diabetes_unit__pz_code")
+    )
+
+    type_counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    seen: set[int] = set()
+    for row in rows:
+        pk = row["pk"]
+        if pk in seen:
+            continue
+        seen.add(pk)
+        pz = row["submissions__paediatric_diabetes_unit__pz_code"]
+        dtype = row["diabetes_type"]
+        if dtype == DIABETES_TYPES[0][0]:
+            cat = "type1"
+        elif dtype == DIABETES_TYPES[1][0]:
+            cat = "type2"
+        else:
+            cat = "other"
+        type_counts[pz][cat] += 1
+
+    result = []
+    for pz_code, pdu in pdus.items():
+        counts = type_counts.get(pz_code, {})
+        total = sum(counts.values())
+        if total == 0:
+            continue
+        t1 = counts.get("type1", 0)
+        t2 = counts.get("type2", 0)
+        other = total - t1 - t2
+        if t1 >= t2 and t1 >= other:
+            dominant = "type1"
+        elif t2 >= other:
+            dominant = "type2"
+        else:
+            dominant = "other"
+        coords = pdu.lead_organisation_geocoordinates
+        result.append(
+            {
+                "lat": coords.y,
+                "lon": coords.x,
+                "label": pdu.lead_organisation_name or pdu.pz_code,
+                "pz_code": pz_code,
+                "total_patients": total,
+                "dominant_type": dominant,
+                "pct_type1": round(t1 / total * 100),
+                "pct_type2": round(t2 / total * 100),
+                "pct_other": round(other / total * 100),
+            }
+        )
+
+    return result
+
+
+def all_pdus_age_map_data(audit_period) -> list[dict]:
+    """Age-group breakdown per PDU for the national bubble map (T1DM only).
+
+    Patients are split at their 16th birthday (at audit start date):
+        - 'under_16': age < 16
+        - 'over_16':  age >= 16
+
+    Each entry:
+        {
+            "lat": float, "lon": float, "label": str, "pz_code": str,
+            "total_patients": int,
+            "dominant_age_group": "under_16" | "over_16",
+            "pct_under_16": int,   # 0-100
+            "pct_over_16": int,    # 0-100
+        }
+    """
+    audit_range = (audit_period.start_date, audit_period.end_date)
+
+    pdus = {
+        pdu.pz_code: pdu
+        for pdu in PaediatricDiabetesUnit.objects.filter(
+            active=True,
+            pdu_submissions__submission_active=True,
+            pdu_submissions__audit_period=audit_period,
+            lead_organisation_geocoordinates__isnull=False,
+        ).distinct()
+    }
+    if not pdus:
+        return []
+
+    rows = (
+        Patient.objects.filter(
+            submissions__submission_active=True,
+            submissions__audit_period=audit_period,
+            submissions__paediatric_diabetes_unit__pz_code__in=pdus.keys(),
+            diabetes_type=DIABETES_TYPES[0][0],
+            visit__visit_date__range=audit_range,
+            date_of_birth__gt=audit_period.start_date - relativedelta(years=25),
+        )
+        .distinct()
+        .values("pk", "date_of_birth", "submissions__paediatric_diabetes_unit__pz_code")
+    )
+
+    cutoff_16 = audit_period.start_date - relativedelta(years=16)
+    age_counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    seen: set[int] = set()
+    for row in rows:
+        pk = row["pk"]
+        if pk in seen:
+            continue
+        seen.add(pk)
+        pz = row["submissions__paediatric_diabetes_unit__pz_code"]
+        dob = row["date_of_birth"]
+        group = "under_16" if (dob is None or dob > cutoff_16) else "over_16"
+        age_counts[pz][group] += 1
+
+    result = []
+    for pz_code, pdu in pdus.items():
+        counts = age_counts.get(pz_code, {})
+        total = sum(counts.values())
+        if total == 0:
+            continue
+        under = counts.get("under_16", 0)
+        over = total - under
+        dominant = "under_16" if under >= over else "over_16"
+        coords = pdu.lead_organisation_geocoordinates
+        result.append(
+            {
+                "lat": coords.y,
+                "lon": coords.x,
+                "label": pdu.lead_organisation_name or pdu.pz_code,
+                "pz_code": pz_code,
+                "total_patients": total,
+                "dominant_age_group": dominant,
+                "pct_under_16": round(under / total * 100),
+                "pct_over_16": round(over / total * 100),
+            }
+        )
+
+    return result

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.4.0/dist/umd/rcpch-imd-map.min.js"
-      integrity="sha512-4icz8A609i4Dy78X8a2NYqhMNO6wyS+vpJ9ffcf6oLuyhpjLPGhnwmkZHZIpS1ZC7c5S2GpxqlK6oP+8Rawjag=="
+    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
+      integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
           crossorigin="anonymous"></script>
   <script>
     window.npdaInitOrganisationCasesMap = function () {

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
-      integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
+    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js"
+      integrity="sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw=="
           crossorigin="anonymous"></script>
   <script>
     window.npdaInitOrganisationCasesMap = function () {

--- a/project/npda/templates/dashboard/components/cards/imd_map_card.html
+++ b/project/npda/templates/dashboard/components/cards/imd_map_card.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet"
         href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js"
-      integrity="sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw=="
+    <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.2/dist/umd/rcpch-imd-map.min.js"
+      integrity="sha512-a766qxZJXhOAclDsv1qP89xJMden52mrMRWvodABs3zs34TLx/roXRik7grS4skx2mTUvKyO22RAokkpJMCLqg=="
           crossorigin="anonymous"></script>
   <script>
     window.npdaInitOrganisationCasesMap = function () {

--- a/project/npda/templates/partials/submission_stats.html
+++ b/project/npda/templates/partials/submission_stats.html
@@ -1,5 +1,5 @@
 {% load npda_tags %}
-<div class="stats stats-vertical shadow text-rcpch_pink">
+<div class="stats shadow text-rcpch_pink flex-wrap">
   <div class="stat">
     <div class="stat-figure text secondary">
       <i class="fa-solid fa-trophy fa-2xl"></i>

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -148,15 +148,11 @@
             <link rel="stylesheet"
                   href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
             <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-            <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js"
-                    integrity="sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw=="
+            <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.2/dist/umd/rcpch-imd-map.min.js"
+                    integrity="sha512-a766qxZJXhOAclDsv1qP89xJMden52mrMRWvodABs3zs34TLx/roXRik7grS4skx2mTUvKyO22RAokkpJMCLqg=="
                     crossorigin="anonymous"></script>
             <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
             <style>
-              #submissions-bubble-map .maplibregl-ctrl {
-                max-height: calc(38rem - 2rem);
-                overflow-y: auto;
-              }
               .sbm-map-tab.is-active {
                 background-color: #e00087;
                 border-color: #e00087;

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -2,287 +2,356 @@
 {% load static %}
 {% block content %}
   {% if request.user.is_rcpch_audit_team_member %}
-    <!-- Leaderboard tiles -->
-    <div class="px-4 mb-4 mt-4">
-      {% include 'partials/submission_stats.html' with submission_statistics=submission_statistics %}
-    </div>
+    <style>
+      .sbm-nav-btn.is-active {
+        background-color: oklch(var(--p) / 0.12);
+        color: oklch(var(--p));
+        font-weight: 600;
+      }
+    </style>
 
-    <!-- Searchable PDU submission table -->
-    {% if pdu_submission_data %}
-      {{ pdu_submission_data|json_script:"pdu-submission-data" }}
-      <div class="px-4 mb-6">
-        <h2 class="text-base font-semibold text-rcpch_dark_blue mb-3">PDU submissions by quarter — {{ audit_period }}</h2>
-        <!-- Controls -->
-        <div class="flex flex-wrap items-center gap-3 mb-3">
-          <input id="pdu-search"
-                 type="search"
-                 placeholder="Search by PZ code or lead centre…"
-                 class="input input-bordered input-sm w-64" />
-          <div class="flex gap-1" id="quarter-filters">
-            <button data-quarter="all" class="btn btn-sm btn-active pdu-qbtn">All</button>
-            <button data-quarter="1" class="btn btn-sm pdu-qbtn">Q1</button>
-            <button data-quarter="2" class="btn btn-sm pdu-qbtn">Q2</button>
-            <button data-quarter="3" class="btn btn-sm pdu-qbtn">Q3</button>
-            <button data-quarter="4" class="btn btn-sm pdu-qbtn">Q4</button>
-            <button data-quarter="0" class="btn btn-sm btn-error btn-outline pdu-qbtn">Not submitted</button>
-          </div>
-          <span id="pdu-visible-count" class="text-sm text-gray-500"></span>
-        </div>
-        <!-- Table -->
-        <div class="overflow-y-auto rounded-lg border border-base-300" style="max-height: 28rem;">
-          <table class="table table-xs table-zebra w-full">
-            <thead class="sticky top-0 z-10 bg-base-100">
-              <tr>
-                <th class="w-28">PZ Code</th>
-                <th>Lead Centre</th>
-                <th class="w-36 text-center">Latest Quarter</th>
-              </tr>
-            </thead>
-            <tbody id="pdu-table-body">
-              {% for row in pdu_submission_data %}
-                <tr data-quarter="{{ row.latest_visit_quarter }}"
-                    data-pz="{{ row.pz_code|lower }}"
-                    data-name="{{ row.lead_organisation_name|lower }}">
-                  <td class="font-mono">{{ row.pz_code }}</td>
-                  <td>{{ row.lead_organisation_name }}</td>
-                  <td class="text-center">
-                    {% if row.latest_visit_quarter == 0 %}
-                      <span class="badge badge-error badge-outline badge-sm">Not submitted</span>
-                    {% elif row.latest_visit_quarter == 1 %}
-                      <span class="badge badge-success badge-sm">Q1</span>
-                    {% elif row.latest_visit_quarter == 2 %}
-                      <span class="badge badge-success badge-sm">Q2</span>
-                    {% elif row.latest_visit_quarter == 3 %}
-                      <span class="badge badge-success badge-sm">Q3</span>
-                    {% elif row.latest_visit_quarter == 4 %}
-                      <span class="badge badge-success badge-sm">Q4</span>
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <script>
-        (function () {
-          var searchInput = document.getElementById('pdu-search');
-          var qButtons = document.querySelectorAll('.pdu-qbtn');
-          var rows = document.querySelectorAll('#pdu-table-body tr');
-          var countEl = document.getElementById('pdu-visible-count');
-          var activeQuarter = 'all';
+    <div class="flex min-h-screen">
 
-          function updateCount() {
-            var visible = document.querySelectorAll('#pdu-table-body tr:not([hidden])').length;
-            countEl.textContent = visible + ' of ' + rows.length + ' PDUs';
-          }
+      <!-- ── Sticky sidebar ──────────────────────────────── -->
+      <aside class="hidden lg:flex flex-col w-52 shrink-0 sticky top-0 self-start h-screen pt-6 pb-4 px-3 border-r border-base-300 bg-base-100 z-20">
+        <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3 px-2">Submissions</p>
+        <nav class="flex flex-col gap-1 text-sm">
+          <button class="sbm-nav-btn is-active flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-base-200 transition-colors text-left w-full"
+                  data-sbm-section="section-leaderboard">
+            <i class="fa-solid fa-trophy w-4 text-center"></i> Leaderboard
+          </button>
+          <button class="sbm-nav-btn flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-base-200 transition-colors text-left w-full"
+                  data-sbm-section="section-pdu-table">
+            <i class="fa-solid fa-table-list w-4 text-center"></i> PDU Submissions
+          </button>
+          <button class="sbm-nav-btn flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-base-200 transition-colors text-left w-full"
+                  data-sbm-section="section-national-map">
+            <i class="fa-solid fa-map w-4 text-center"></i> National Summary
+          </button>
+          <button class="sbm-nav-btn flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-base-200 transition-colors text-left w-full"
+                  data-sbm-section="section-submissions-list">
+            <i class="fa-solid fa-file-lines w-4 text-center"></i> Submissions List
+          </button>
+        </nav>
+      </aside>
 
-          function applyFilters() {
-            var term = searchInput.value.trim().toLowerCase();
-            rows.forEach(function (row) {
-              var qMatch = activeQuarter === 'all' || row.dataset.quarter === activeQuarter;
-              var textMatch = !term || row.dataset.pz.includes(term) || row.dataset.name.includes(term);
-              row.hidden = !(qMatch && textMatch);
-            });
-            updateCount();
-          }
+      <!-- ── Main content ────────────────────────────────── -->
+      <div class="flex-1 min-w-0 px-4 py-6">
 
-          searchInput.addEventListener('input', applyFilters);
+        <!-- Section 1: Leaderboard -->
+        <section id="section-leaderboard">
+          <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-4">Leaderboard</h2>
+          {% include 'partials/submission_stats.html' with submission_statistics=submission_statistics %}
+        </section>
 
-          qButtons.forEach(function (btn) {
-            btn.addEventListener('click', function () {
-              activeQuarter = btn.dataset.quarter;
-              qButtons.forEach(function (b) { b.classList.remove('btn-active'); });
-              btn.classList.add('btn-active');
-              applyFilters();
-            });
-          });
-
-          updateCount();
-        })();
-      </script>
-    {% endif %}
-    {% if bubble_map_centres %}
-      <div class="px-4 mb-8">
-        <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">Lead centre overview — {{ audit_period }}</h2>
-        <link rel="stylesheet"
-              href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
-        <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
-                integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
-                crossorigin="anonymous"></script>
-        <style>
-          #submissions-bubble-map .maplibregl-ctrl {
-            max-height: calc(38rem - 2rem);
-            overflow-y: auto;
-          }
-        </style>
-
-        {{ bubble_map_centres|json_script:"sbm-data-hba1c" }}
-        {{ bubble_map_care_processes|json_script:"sbm-data-care" }}
-        {{ bubble_map_diabetes_type|json_script:"sbm-data-type" }}
-        {{ bubble_map_age|json_script:"sbm-data-age" }}
-
-        <!-- Tabs -->
-        <div class="flex gap-2 mb-3 flex-wrap" id="sbm-tabs">
-          <button class="btn btn-sm btn-primary" data-sbm-tab="hba1c">By HbA1c</button>
-          <button class="btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
-          <button class="btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
-          <button class="btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
-        </div>
-        <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3">
-          Bubble size = T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) → red (higher).
-        </p>
-
-        <div id="submissions-bubble-map"
-             data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
-             data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
-             style="width:100%;height:38rem;border-radius:4px;"></div>
-
-        <script>
-          (function () {
-            var container = document.getElementById('submissions-bubble-map');
-            if (!container || typeof RcpchImdMap === 'undefined') return;
-
-            function parseData(id) {
-              var el = document.getElementById(id);
-              return el ? JSON.parse(el.textContent) : [];
-            }
-
-            var tilesBaseUrl = (container.dataset.tilesBaseUrl || '').replace(/\/$/, '') || undefined;
-            var tilesApiKey = container.dataset.tilesApiKey || undefined;
-
-            var TABS = {
-              hba1c: {
-                data: parseData('sbm-data-hba1c'),
-                desc: 'Bubble size = number of eligible T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) \u2192 red (higher).',
-                leadCentres: {
-                  sizeField: 'patient_count', sizeLabel: 'T1DM patients',
-                  colorField: 'median_hba1c', colorLabel: 'Median HbA1c',
-                  colorUnit: 'mmol/mol', colorMode: 'continuous',
-                  colorScale: ['#2166ac', '#ffffbf', '#d7191c'],
-                  minRadius: 8, maxRadius: 40,
-                },
-              },
-              care: {
-                data: parseData('sbm-data-care'),
-                desc: 'Bubble size = T1DM patients with complete year of care. Colour = % who completed all required care processes (green = higher).',
-                leadCentres: {
-                  sizeField: 'eligible_count', sizeLabel: 'Eligible T1DM patients',
-                  colorField: 'pct_complete', colorLabel: '% Complete care',
-                  colorUnit: '%', colorMode: 'continuous',
-                  colorScale: ['#d7191c', '#ffffbf', '#1a9641'],
-                  minRadius: 8, maxRadius: 40,
-                },
-              },
-              type: {
-                data: parseData('sbm-data-type'),
-                desc: 'Bubble size = all patients. Colour = dominant diabetes type at the lead centre.',
-                leadCentres: {
-                  sizeField: 'total_patients', sizeLabel: 'Total patients',
-                  colorField: 'dominant_type', colorLabel: 'Dominant diabetes type',
-                  colorMode: 'categorical',
-                  colorByCategory: { type1: '#4e79a7', type2: '#f28e2b', other: '#59a14f' },
-                  breakdownFields: [
-                    { field: 'pct_type1', label: 'Type 1', color: '#4e79a7' },
-                    { field: 'pct_type2', label: 'Type 2', color: '#f28e2b' },
-                    { field: 'pct_other', label: 'Other',  color: '#59a14f' },
-                  ],
-                  minRadius: 8, maxRadius: 40,
-                },
-              },
-              age: {
-                data: parseData('sbm-data-age'),
-                desc: 'Bubble size = T1DM patients. Colour = dominant age group at the lead centre.',
-                leadCentres: {
-                  sizeField: 'total_patients', sizeLabel: 'T1DM patients',
-                  colorField: 'dominant_age_group', colorLabel: 'Age group',
-                  colorMode: 'categorical',
-                  colorByCategory: { under_16: '#2166ac', over_16: '#d7191c' },
-                  breakdownFields: [
-                    { field: 'pct_under_16', label: 'Under 16',   color: '#2166ac' },
-                    { field: 'pct_over_16',  label: '16 and over', color: '#d7191c' },
-                  ],
-                  minRadius: 8, maxRadius: 40,
-                },
-              },
-            };
-
-            var descEl = document.getElementById('sbm-tab-desc');
-            var activeTabId = 'hba1c';
-
-            function buildMap(tabId) {
-              /* Destroy any existing instance before recreating — this is the only
-                 reliable way to switch between continuous and categorical colour
-                 modes, because setStyle() deep-merges and leaves stale keys. */
-              if (window.__npdaSubmissionsMap) {
-                window.__npdaSubmissionsMap.destroy();
-                window.__npdaSubmissionsMap = null;
-              }
-              var tab = TABS[tabId];
-              if (!tab) return;
-
-              var map = RcpchImdMap.createImdMap({
-                container: container,
-                tilesBaseUrl: tilesBaseUrl,
-                tilesApiKey: tilesApiKey,
-                tilesApiKeyParam: 'Subscription-Key',
-                initialNation: 'all',
-                initialEra: '2021',
-                zoom: 5,
-                legendCollapsed: true,
-                style: {
-                  legend: { width: 200 },
-                  leadCentres: tab.leadCentres,
-                  tooltip: { backgroundColor: '#0d0d58', textColor: '#ffffff' },
-                },
-                onWarning: function (w) {
-                  console.warn('[rcpch-imd-map]', w.code, w.message);
-                },
-              });
-
-              map.setLeadCentres(tab.data);
-              window.__npdaSubmissionsMap = map;
-            }
-
-            function switchTab(tabId) {
-              activeTabId = tabId;
-              document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
-                var isActive = btn.dataset.sbmTab === tabId;
-                btn.classList.toggle('btn-primary', isActive);
-                btn.classList.toggle('btn-outline', !isActive);
-              });
-              var tab = TABS[tabId];
-              if (descEl && tab) descEl.textContent = tab.desc;
-              buildMap(tabId);
-            }
-
-            document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
-              btn.addEventListener('click', function () { switchTab(btn.dataset.sbmTab); });
-            });
-
-            buildMap('hba1c');
-          })();
-        </script>
-      </div>
-    {% endif %}
-  {% endif %}
-  <section class="mb-5 container-mx-auto flex items-center justify-center">
-    <div class="w-full"
-         hx-get="/submissions"
-         hx-trigger="submissions from:body"
-         hx-target="#submissions_table">
-      <div class="flex flex-col justify-center px-10">
-        <div>
-          <div>
-            <div class="relative">
-              <div id="submissions_table" class="w-full mt-5 mx-2">
-                {% include 'partials/submission_history.html' with submissions=object_list data=data submission_errors=submission_errors patients=patients done=done %}
+        <!-- Section 2: PDU Submissions -->
+        {% if pdu_submission_data %}
+          {{ pdu_submission_data|json_script:"pdu-submission-data" }}
+          <section id="section-pdu-table" class="hidden">
+            <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-4">PDU submissions by quarter — {{ audit_period }}</h2>
+            <div class="flex flex-wrap items-center gap-3 mb-3">
+              <input id="pdu-search"
+                     type="search"
+                     placeholder="Search by PZ code or lead centre…"
+                     class="input input-bordered input-sm w-64" />
+              <div class="flex gap-1 flex-wrap" id="quarter-filters">
+                <button data-quarter="all" class="btn btn-sm btn-active pdu-qbtn">All</button>
+                <button data-quarter="1" class="btn btn-sm pdu-qbtn">Q1</button>
+                <button data-quarter="2" class="btn btn-sm pdu-qbtn">Q2</button>
+                <button data-quarter="3" class="btn btn-sm pdu-qbtn">Q3</button>
+                <button data-quarter="4" class="btn btn-sm pdu-qbtn">Q4</button>
+                <button data-quarter="0" class="btn btn-sm btn-error btn-outline pdu-qbtn">Not submitted</button>
               </div>
+              <span id="pdu-visible-count" class="text-sm text-gray-500"></span>
+            </div>
+            <div class="overflow-y-auto rounded-lg border border-base-300" style="max-height: 28rem;">
+              <table class="table table-xs table-zebra w-full">
+                <thead class="sticky top-0 z-10 bg-base-100">
+                  <tr>
+                    <th class="w-28">PZ Code</th>
+                    <th>Lead Centre</th>
+                    <th class="w-36 text-center">Latest Quarter</th>
+                  </tr>
+                </thead>
+                <tbody id="pdu-table-body">
+                  {% for row in pdu_submission_data %}
+                    <tr data-quarter="{{ row.latest_visit_quarter }}"
+                        data-pz="{{ row.pz_code|lower }}"
+                        data-name="{{ row.lead_organisation_name|lower }}">
+                      <td class="font-mono">{{ row.pz_code }}</td>
+                      <td>{{ row.lead_organisation_name }}</td>
+                      <td class="text-center">
+                        {% if row.latest_visit_quarter == 0 %}
+                          <span class="badge badge-error badge-outline badge-sm">Not submitted</span>
+                        {% elif row.latest_visit_quarter == 1 %}
+                          <span class="badge badge-success badge-sm">Q1</span>
+                        {% elif row.latest_visit_quarter == 2 %}
+                          <span class="badge badge-success badge-sm">Q2</span>
+                        {% elif row.latest_visit_quarter == 3 %}
+                          <span class="badge badge-success badge-sm">Q3</span>
+                        {% elif row.latest_visit_quarter == 4 %}
+                          <span class="badge badge-success badge-sm">Q4</span>
+                        {% endif %}
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <script>
+            (function () {
+              var searchInput = document.getElementById('pdu-search');
+              var qButtons = document.querySelectorAll('.pdu-qbtn');
+              var rows = document.querySelectorAll('#pdu-table-body tr');
+              var countEl = document.getElementById('pdu-visible-count');
+              var activeQuarter = 'all';
+
+              function updateCount() {
+                var visible = document.querySelectorAll('#pdu-table-body tr:not([hidden])').length;
+                countEl.textContent = visible + ' of ' + rows.length + ' PDUs';
+              }
+
+              function applyFilters() {
+                var term = searchInput.value.trim().toLowerCase();
+                rows.forEach(function (row) {
+                  var qMatch = activeQuarter === 'all' || row.dataset.quarter === activeQuarter;
+                  var textMatch = !term || row.dataset.pz.includes(term) || row.dataset.name.includes(term);
+                  row.hidden = !(qMatch && textMatch);
+                });
+                updateCount();
+              }
+
+              searchInput.addEventListener('input', applyFilters);
+              qButtons.forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                  activeQuarter = btn.dataset.quarter;
+                  qButtons.forEach(function (b) { b.classList.remove('btn-active'); });
+                  btn.classList.add('btn-active');
+                  applyFilters();
+                });
+              });
+              updateCount();
+            })();
+          </script>
+        {% endif %}
+
+        <!-- Section 3: National Summary Map -->
+        {% if bubble_map_centres %}
+          <section id="section-national-map" class="hidden">
+            <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">National summary — {{ audit_period }}</h2>
+            <link rel="stylesheet"
+                  href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
+            <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+            <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
+                    integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
+                    crossorigin="anonymous"></script>
+            <style>
+              #submissions-bubble-map .maplibregl-ctrl {
+                max-height: calc(38rem - 2rem);
+                overflow-y: auto;
+              }
+            </style>
+
+            {{ bubble_map_centres|json_script:"sbm-data-hba1c" }}
+            {{ bubble_map_care_processes|json_script:"sbm-data-care" }}
+            {{ bubble_map_diabetes_type|json_script:"sbm-data-type" }}
+            {{ bubble_map_age|json_script:"sbm-data-age" }}
+
+            <div class="flex gap-2 mb-3 flex-wrap" id="sbm-tabs">
+              <button class="btn btn-sm btn-primary" data-sbm-tab="hba1c">By HbA1c</button>
+              <button class="btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
+              <button class="btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
+              <button class="btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
+            </div>
+            <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3">
+              Bubble size = T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) → red (higher).
+            </p>
+
+            <div id="submissions-bubble-map"
+                 data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
+                 data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
+                 style="width:100%;height:38rem;border-radius:4px;"></div>
+
+            <script>
+              (function () {
+                var container = document.getElementById('submissions-bubble-map');
+                if (!container || typeof RcpchImdMap === 'undefined') return;
+
+                function parseData(id) {
+                  var el = document.getElementById(id);
+                  return el ? JSON.parse(el.textContent) : [];
+                }
+
+                var tilesBaseUrl = (container.dataset.tilesBaseUrl || '').replace(/\/$/, '') || undefined;
+                var tilesApiKey = container.dataset.tilesApiKey || undefined;
+
+                var TABS = {
+                  hba1c: {
+                    data: parseData('sbm-data-hba1c'),
+                    desc: 'Bubble size = number of eligible T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) \u2192 red (higher).',
+                    leadCentres: {
+                      sizeField: 'patient_count', sizeLabel: 'T1DM patients',
+                      colorField: 'median_hba1c', colorLabel: 'Median HbA1c',
+                      colorUnit: 'mmol/mol', colorMode: 'continuous',
+                      colorScale: ['#2166ac', '#ffffbf', '#d7191c'],
+                      minRadius: 8, maxRadius: 40,
+                    },
+                  },
+                  care: {
+                    data: parseData('sbm-data-care'),
+                    desc: 'Bubble size = T1DM patients with complete year of care. Colour = % who completed all required care processes (green = higher).',
+                    leadCentres: {
+                      sizeField: 'eligible_count', sizeLabel: 'Eligible T1DM patients',
+                      colorField: 'pct_complete', colorLabel: '% Complete care',
+                      colorUnit: '%', colorMode: 'continuous',
+                      colorScale: ['#d7191c', '#ffffbf', '#1a9641'],
+                      minRadius: 8, maxRadius: 40,
+                    },
+                  },
+                  type: {
+                    data: parseData('sbm-data-type'),
+                    desc: 'Bubble size = all patients. Colour = dominant diabetes type at the lead centre.',
+                    leadCentres: {
+                      sizeField: 'total_patients', sizeLabel: 'Total patients',
+                      colorField: 'dominant_type', colorLabel: 'Dominant diabetes type',
+                      colorMode: 'categorical',
+                      colorByCategory: { type1: '#4e79a7', type2: '#f28e2b', other: '#59a14f' },
+                      breakdownFields: [
+                        { field: 'pct_type1', label: 'Type 1', color: '#4e79a7' },
+                        { field: 'pct_type2', label: 'Type 2', color: '#f28e2b' },
+                        { field: 'pct_other', label: 'Other',  color: '#59a14f' },
+                      ],
+                      minRadius: 8, maxRadius: 40,
+                    },
+                  },
+                  age: {
+                    data: parseData('sbm-data-age'),
+                    desc: 'Bubble size = T1DM patients. Colour = dominant age group at the lead centre.',
+                    leadCentres: {
+                      sizeField: 'total_patients', sizeLabel: 'T1DM patients',
+                      colorField: 'dominant_age_group', colorLabel: 'Age group',
+                      colorMode: 'categorical',
+                      colorByCategory: { under_16: '#2166ac', over_16: '#d7191c' },
+                      breakdownFields: [
+                        { field: 'pct_under_16', label: 'Under 16',    color: '#2166ac' },
+                        { field: 'pct_over_16',  label: '16 and over', color: '#d7191c' },
+                      ],
+                      minRadius: 8, maxRadius: 40,
+                    },
+                  },
+                };
+
+                var descEl = document.getElementById('sbm-tab-desc');
+
+                function buildMap(tabId) {
+                  if (window.__npdaSubmissionsMap) {
+                    window.__npdaSubmissionsMap.destroy();
+                    window.__npdaSubmissionsMap = null;
+                  }
+                  var tab = TABS[tabId];
+                  if (!tab) return;
+                  var map = RcpchImdMap.createImdMap({
+                    container: container,
+                    tilesBaseUrl: tilesBaseUrl,
+                    tilesApiKey: tilesApiKey,
+                    tilesApiKeyParam: 'Subscription-Key',
+                    initialNation: 'all',
+                    initialEra: '2021',
+                    zoom: 5,
+                    legendCollapsed: true,
+                    style: {
+                      legend: { width: 200 },
+                      leadCentres: tab.leadCentres,
+                      tooltip: { backgroundColor: '#0d0d58', textColor: '#ffffff' },
+                    },
+                    onWarning: function (w) {
+                      console.warn('[rcpch-imd-map]', w.code, w.message);
+                    },
+                  });
+                  map.setLeadCentres(tab.data);
+                  window.__npdaSubmissionsMap = map;
+                }
+
+                function switchTab(tabId) {
+                  document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
+                    var isActive = btn.dataset.sbmTab === tabId;
+                    btn.classList.toggle('btn-primary', isActive);
+                    btn.classList.toggle('btn-outline', !isActive);
+                  });
+                  var tab = TABS[tabId];
+                  if (descEl && tab) descEl.textContent = tab.desc;
+                  buildMap(tabId);
+                }
+
+                document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
+                  btn.addEventListener('click', function () { switchTab(btn.dataset.sbmTab); });
+                });
+
+                window.__npdaActiveMapTab = 'hba1c';
+                window.__npdaBuildMap = buildMap;
+              })();
+            </script>
+          </section>
+        {% endif %}
+
+        <!-- Section 4: Submissions List -->
+        <section id="section-submissions-list" class="hidden">
+          <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-4">Submissions list</h2>
+          <div hx-get="/submissions"
+               hx-trigger="submissions from:body"
+               hx-target="#submissions_table">
+            <div id="submissions_table">
+              {% include 'partials/submission_history.html' with submissions=object_list data=data submission_errors=submission_errors patients=patients done=done %}
             </div>
           </div>
+        </section>
+
+      </div>{# end main content #}
+    </div>{# end flex wrapper #}
+
+    <!-- Sidebar show/hide navigation -->
+    <script>
+      (function () {
+        var navBtns = document.querySelectorAll('.sbm-nav-btn');
+        var allSections = document.querySelectorAll('section[id^="section-"]');
+        var mapInitialised = false;
+
+        function showSection(sectionId) {
+          allSections.forEach(function (s) {
+            s.classList.toggle('hidden', s.id !== sectionId);
+          });
+          navBtns.forEach(function (btn) {
+            btn.classList.toggle('is-active', btn.dataset.sbmSection === sectionId);
+          });
+          // Lazy-init the map the first time the map section is shown
+          if (sectionId === 'section-national-map' && !mapInitialised && typeof window.__npdaBuildMap === 'function') {
+            mapInitialised = true;
+            window.__npdaBuildMap(window.__npdaActiveMapTab || 'hba1c');
+          }
+        }
+
+        navBtns.forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            showSection(btn.dataset.sbmSection);
+          });
+        });
+      })();
+    </script>
+
+  {% else %}
+    <!-- Non-admin: just the submissions list -->
+    <section class="mb-5 container-mx-auto flex items-center justify-center">
+      <div class="w-full"
+           hx-get="/submissions"
+           hx-trigger="submissions from:body"
+           hx-target="#submissions_table">
+        <div class="flex flex-col justify-center px-10">
+          <div id="submissions_table" class="w-full mt-5 mx-2">
+            {% include 'partials/submission_history.html' with submissions=object_list data=data submission_errors=submission_errors patients=patients done=done %}
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  {% endif %}
 {% endblock %}

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -4,9 +4,12 @@
   {% if request.user.is_rcpch_audit_team_member %}
     <style>
       .sbm-nav-btn.is-active {
-        background-color: oklch(var(--p) / 0.12);
-        color: oklch(var(--p));
+        background-color: #e00087;
+        color: #ffffff;
         font-weight: 600;
+      }
+      .sbm-nav-btn.is-active:hover {
+        background-color: #ab1368;
       }
     </style>
 
@@ -137,19 +140,32 @@
         {% endif %}
 
         <!-- Section 3: National Summary Map -->
-        {% if bubble_map_centres %}
-          <section id="section-national-map" class="hidden">
-            <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">National summary — {{ audit_period }}</h2>
+         {% if bubble_map_centres %}
+          <section id="section-national-map" class="hidden -mx-4">
+            <div class="px-4">
+              <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">National summary — {{ audit_period }}</h2>
+            </div>
             <link rel="stylesheet"
                   href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
             <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
                     integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
                     crossorigin="anonymous"></script>
+            <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
             <style>
               #submissions-bubble-map .maplibregl-ctrl {
                 max-height: calc(38rem - 2rem);
                 overflow-y: auto;
+              }
+              .sbm-map-tab.is-active {
+                background-color: #e00087;
+                border-color: #e00087;
+                color: #ffffff;
+                font-weight: 600;
+              }
+              .sbm-map-tab.is-active:hover {
+                background-color: #ab1368;
+                border-color: #ab1368;
               }
             </style>
 
@@ -158,20 +174,27 @@
             {{ bubble_map_diabetes_type|json_script:"sbm-data-type" }}
             {{ bubble_map_age|json_script:"sbm-data-age" }}
 
-            <div class="flex gap-2 mb-3 flex-wrap" id="sbm-tabs">
-              <button class="btn btn-sm btn-primary" data-sbm-tab="hba1c">By HbA1c</button>
-              <button class="btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
-              <button class="btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
-              <button class="btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
+            <div class="flex gap-2 mb-3 flex-wrap px-4" id="sbm-tabs">
+              <button class="sbm-map-tab btn btn-sm is-active" data-sbm-tab="hba1c">By HbA1c</button>
+              <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
+              <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
+              <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
             </div>
-            <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3">
+            <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3 px-4">
               Bubble size = T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) → red (higher).
             </p>
 
+            <!-- Map view — full bleed -->
             <div id="submissions-bubble-map"
                  data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
                  data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
-                 style="width:100%;height:38rem;border-radius:4px;"></div>
+                 style="width:100%;height:38rem;"></div>
+
+            <!-- League chart — auto-shown for continuous tabs (hba1c, care) -->
+            <div id="sbm-league-panel" class="hidden mt-2 px-2">
+              <p id="sbm-league-title" class="text-sm font-semibold text-rcpch_dark_blue mb-1 px-2"></p>
+              <div id="sbm-league-chart" style="width:100%;height:18rem;"></div>
+            </div>
 
             <script>
               (function () {
@@ -274,14 +297,95 @@
                 }
 
                 function switchTab(tabId) {
-                  document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
+                  document.querySelectorAll('.sbm-map-tab').forEach(function (btn) {
                     var isActive = btn.dataset.sbmTab === tabId;
-                    btn.classList.toggle('btn-primary', isActive);
+                    btn.classList.toggle('is-active', isActive);
                     btn.classList.toggle('btn-outline', !isActive);
                   });
+                  var leaguePanel = document.getElementById('sbm-league-panel');
                   var tab = TABS[tabId];
                   if (descEl && tab) descEl.textContent = tab.desc;
                   buildMap(tabId);
+                  // Show league chart only for continuous (linear) tabs
+                  var leagueView = LEAGUE_VIEWS[tabId];
+                  if (leagueView) {
+                    leaguePanel.classList.remove('hidden');
+                    buildLeagueChart(tabId);
+                  } else {
+                    leaguePanel.classList.add('hidden');
+                    if (typeof Plotly !== 'undefined') Plotly.purge('sbm-league-chart');
+                  }
+                }
+
+                // ── League chart (continuous tabs only: hba1c, care) ───────
+                var allPdus = (function () {
+                  var el = document.getElementById('pdu-submission-data');
+                  return el ? JSON.parse(el.textContent) : [];
+                })();
+
+                function mergeLeagueData(mapData, valueField) {
+                  var lookup = {};
+                  mapData.forEach(function (d) { lookup[d.pz_code] = d; });
+                  return allPdus.map(function (pdu) {
+                    var match = lookup[pdu.pz_code] || {};
+                    return {
+                      pz_code: pdu.pz_code,
+                      name: pdu.lead_organisation_name,
+                      value: match[valueField] != null ? match[valueField] : null,
+                    };
+                  });
+                }
+
+                var LEAGUE_VIEWS = {
+                  hba1c: {
+                    rows: mergeLeagueData(parseData('sbm-data-hba1c'), 'median_hba1c'),
+                    label: 'Median HbA1c (mmol/mol)',
+                    title: 'PDUs ranked by median HbA1c — all PDUs (grey = no data)',
+                    color: '#0d0d58',
+                  },
+                  care: {
+                    rows: mergeLeagueData(parseData('sbm-data-care'), 'pct_complete'),
+                    label: '% Complete care processes',
+                    title: 'PDUs ranked by % complete care processes — all PDUs (grey = no data)',
+                    color: '#1a9641',
+                  },
+                };
+
+                function buildLeagueChart(tabId) {
+                  var view = LEAGUE_VIEWS[tabId];
+                  if (!view || typeof Plotly === 'undefined') return;
+                  var titleEl = document.getElementById('sbm-league-title');
+                  if (titleEl) titleEl.textContent = view.title;
+                  var sorted = view.rows.slice().sort(function (a, b) {
+                    if (a.value == null && b.value == null) return 0;
+                    if (a.value == null) return 1;
+                    if (b.value == null) return -1;
+                    return a.value - b.value;
+                  });
+                  Plotly.react('sbm-league-chart', [{
+                    type: 'bar',
+                    x: sorted.map(function (_, i) { return i; }),
+                    y: sorted.map(function (d) { return d.value != null ? d.value : 0; }),
+                    text: sorted.map(function (d) {
+                      return '<b>' + (d.name || d.pz_code) + '</b><br>' + d.pz_code +
+                             '<br>' + view.label + ': ' + (d.value != null ? d.value : 'No data');
+                    }),
+                    hovertemplate: '%{text}<extra></extra>',
+                    marker: {
+                      color: sorted.map(function (d) { return d.value != null ? view.color : '#d1d5db'; }),
+                    },
+                  }], {
+                    margin: { t: 5, b: 35, l: 60, r: 10 },
+                    xaxis: {
+                      showticklabels: false,
+                      title: { text: 'PDUs (ranked lowest → highest)', font: { size: 11 } },
+                      zeroline: false,
+                    },
+                    yaxis: { title: view.label },
+                    paper_bgcolor: 'rgba(0,0,0,0)',
+                    plot_bgcolor: 'rgba(0,0,0,0)',
+                    font: { family: 'sans-serif', size: 12 },
+                  }, { responsive: true, displayModeBar: false });
                 }
 
                 document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
@@ -289,7 +393,7 @@
                 });
 
                 window.__npdaActiveMapTab = 'hba1c';
-                window.__npdaBuildMap = buildMap;
+                window.__npdaSwitchTab = switchTab;
               })();
             </script>
           </section>
@@ -325,9 +429,9 @@
             btn.classList.toggle('is-active', btn.dataset.sbmSection === sectionId);
           });
           // Lazy-init the map the first time the map section is shown
-          if (sectionId === 'section-national-map' && !mapInitialised && typeof window.__npdaBuildMap === 'function') {
+          if (sectionId === 'section-national-map' && !mapInitialised && typeof window.__npdaSwitchTab === 'function') {
             mapInitialised = true;
-            window.__npdaBuildMap(window.__npdaActiveMapTab || 'hba1c');
+            window.__npdaSwitchTab(window.__npdaActiveMapTab || 'hba1c');
           }
         }
 

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -55,6 +55,87 @@
         </div>
       </div>
     </div>
+    {% if bubble_map_centres %}
+      <div class="px-4 mb-8">
+        <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">
+          Lead centres — T1DM patients &amp; median HbA1c ({{ audit_period }})
+        </h2>
+        <p class="text-sm text-gray-600 mb-3">
+          Bubble size = number of eligible T1DM patients. Colour = median HbA1c (mmol/mol):
+          blue (lower) → red (higher).
+        </p>
+        <link rel="stylesheet"
+              href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
+        <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
+                integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
+                crossorigin="anonymous"></script>
+        <style>
+          /* Make the bubble-map legend scrollable when it is taller than the map */
+          #submissions-bubble-map .maplibregl-ctrl {
+            max-height: calc(38rem - 2rem);
+            overflow-y: auto;
+          }
+        </style>
+        {{ bubble_map_centres|json_script:"submissions-bubble-map-data" }}
+        <div id="submissions-bubble-map"
+             data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
+             data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
+             style="width:100%;height:38rem;border-radius:4px;"></div>
+        <script>
+          (function () {
+            var container = document.getElementById('submissions-bubble-map');
+            if (!container || typeof RcpchImdMap === 'undefined') return;
+
+            if (window.__npdaSubmissionsMap) {
+              window.__npdaSubmissionsMap.destroy();
+              window.__npdaSubmissionsMap = null;
+            }
+
+            var centres = JSON.parse(
+              document.getElementById('submissions-bubble-map-data').textContent
+            );
+
+            var map = RcpchImdMap.createImdMap({
+              container: container,
+              tilesBaseUrl: (container.dataset.tilesBaseUrl || '').replace(/\/$/, '') || undefined,
+              tilesApiKey: container.dataset.tilesApiKey || undefined,
+              tilesApiKeyParam: 'Subscription-Key',
+              initialNation: 'all',
+              initialEra: '2021',
+              zoom: 5,
+              legendCollapsed: true,
+              style: {
+                legend: {
+                  width: 200,
+                },
+                leadCentres: {
+                  sizeField: 'patient_count',
+                  sizeLabel: 'T1DM patients',
+                  colorField: 'median_hba1c',
+                  colorLabel: 'Median HbA1c',
+                  colorUnit: 'mmol/mol',
+                  colorMode: 'continuous',
+                  colorScale: ['#2166ac', '#ffffbf', '#d7191c'],
+                  minRadius: 8,
+                  maxRadius: 40,
+                },
+                tooltip: {
+                  backgroundColor: '#0d0d58',
+                  textColor: '#ffffff',
+                },
+              },
+              onWarning: function (w) {
+                console.warn('[rcpch-imd-map]', w.code, w.message);
+              },
+            });
+
+            map.setLeadCentres(centres);
+            window.__npdaSubmissionsMap = map;
+          })();
+        </script>
+      </div>
+    {% endif %}
   {% endif %}
   <section class="mb-5 container-mx-auto flex items-center justify-center">
     <div class="w-full"

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -148,8 +148,8 @@
             <link rel="stylesheet"
                   href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
             <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
-            <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.0/dist/umd/rcpch-imd-map.min.js"
-                    integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
+            <script src="https://cdn.jsdelivr.net/npm/@rcpch/imd-map@0.5.1/dist/umd/rcpch-imd-map.min.js"
+                    integrity="sha512-eL1iCgZ8KVnELAEum+mIwBG58FdZPUYJ/8B1eUHOGc0AQAdVIQoZSc6myiygjgLKZrB0I5XbU+ZDQpYb66EJkw=="
                     crossorigin="anonymous"></script>
             <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
             <style>

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -2,59 +2,125 @@
 {% load static %}
 {% block content %}
   {% if request.user.is_rcpch_audit_team_member %}
-    <div class="grid grid-cols-2 gap-6 mb-6">
-      <!-- Chart Column - 50% width -->
-      <div class="col-span-1">
-        <div class="flex flex-col justify-center px-4">
-          <div class="relative">
-            <div id="column_chart" class="w-full mt-5 mx-2">{{ column_chart|safe }}</div>
+    <!-- Stats bar -->
+    <div class="flex flex-wrap items-start gap-4 px-4 mb-4 mt-4">
+      <div class="stats shadow">
+        <div class="stat">
+          <div class="stat-figure text-secondary">
+            <svg width="48px"
+                 height="48px"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 xmlns="http://www.w3.org/2000/svg">
+              <line x1="12" y1="2" x2="12" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
+              <line x1="7.5" y1="2" x2="9" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
+              <line x1="16.5" y1="2" x2="15" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M23 17C23 19.2091 21.2091 21 19 21H5C2.79086 21 1 19.2091 1 17V12.5183C1 12.1784 1.08662 11.8441 1.25169 11.547L5.42849 4.02871C5.78123 3.39378 6.45047 3 7.17681 3H16.8232C17.5495 3 18.2188 3.39378 18.5715 4.02871L22.7483 11.547C22.9134 11.8441 23 12.1784 23 12.5183V17ZM19.5845 11H16C15.6656 11 15.3534 11.1671 15.1679 11.4453L13.4648 14H10.5352L8.83205 11.4453C8.64658 11.1671 8.33435 11 8 11H4.41545L7.47101 5.5H16.529L19.5845 11Z" fill="#e00087" />
+            </svg>
           </div>
+          <div class="stat-title">PDUs without Submission</div>
+          <div class="stat-value">{{ non_submission_pdus|length }}</div>
+          <div class="stat-desc">{{ audit_period }}</div>
         </div>
       </div>
-      <!-- PDUs Info Column - 50% width -->
-      <div class="col-span-1 mt-10">
-        <div class="flex flex-col px-4 h-full">
-          <div>
-            <div class="stats shadow">
-              <div class="stat">
-                <div class="stat-figure text-secondary">
-                  <svg width="48px"
-                       height="48px"
-                       viewBox="0 0 24 24"
-                       fill="none"
-                       xmlns="http://www.w3.org/2000/svg">
-                    <!-- Rays (higher and swapped) -->
-                    <line x1="12" y1="2" x2="12" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-                    <line x1="7.5" y1="2" x2="9" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-                    <line x1="16.5" y1="2" x2="15" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-                    <!-- Tray -->
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M23 17C23 19.2091 21.2091 21 19 21H5C2.79086 21 1 19.2091 1 17V12.5183C1 12.1784 1.08662 11.8441 1.25169 11.547L5.42849 4.02871C5.78123 3.39378 6.45047 3 7.17681 3H16.8232C17.5495 3 18.2188 3.39378 18.5715 4.02871L22.7483 11.547C22.9134 11.8441 23 12.1784 23 12.5183V17ZM19.5845 11H16C15.6656 11 15.3534 11.1671 15.1679 11.4453L13.4648 14H10.5352L8.83205 11.4453C8.64658 11.1671 8.33435 11 8 11H4.41545L7.47101 5.5H16.529L19.5845 11Z" fill="#e00087" />
-                  </svg>
-                </div>
-                <div class="stat-title">Paediatric Diabetes Units without Submission</div>
-                <div class="stat-value">{{ non_submission_pdus|length }}</div>
-                <div class="stat-desc">{{ audit_period }}</div>
-              </div>
-            </div>
-            {% include 'partials/submission_stats.html' with submission_statistics=submission_statistics %}
-            {% if non_submission_pdus %}
-              <div class="mt-4">
-                <details class="cursor-pointer">
-                  <summary class="text-sm text-gray-600 hover:text-gray-800">
-                    View PDUs without submissions
-                  </summary>
-                  <ul class="mt-2 text-sm text-gray-600 overflow-y-auto">
-                    {% for pz_code, name in non_submission_pdus %}
-                      <li class="py-1">{{ pz_code }} - {{ name }}</li>
-                    {% endfor %}
-                  </ul>
-                </details>
-              </div>
-            {% endif %}
-          </div>
-        </div>
-      </div>
+      {% include 'partials/submission_stats.html' with submission_statistics=submission_statistics %}
     </div>
+
+    <!-- Searchable PDU submission table -->
+    {% if pdu_submission_data %}
+      {{ pdu_submission_data|json_script:"pdu-submission-data" }}
+      <div class="px-4 mb-6">
+        <h2 class="text-base font-semibold text-rcpch_dark_blue mb-3">PDU submissions by quarter — {{ audit_period }}</h2>
+        <!-- Controls -->
+        <div class="flex flex-wrap items-center gap-3 mb-3">
+          <input id="pdu-search"
+                 type="search"
+                 placeholder="Search by PZ code or lead centre…"
+                 class="input input-bordered input-sm w-64" />
+          <div class="flex gap-1" id="quarter-filters">
+            <button data-quarter="all" class="btn btn-sm btn-active pdu-qbtn">All</button>
+            <button data-quarter="1" class="btn btn-sm pdu-qbtn">Q1</button>
+            <button data-quarter="2" class="btn btn-sm pdu-qbtn">Q2</button>
+            <button data-quarter="3" class="btn btn-sm pdu-qbtn">Q3</button>
+            <button data-quarter="4" class="btn btn-sm pdu-qbtn">Q4</button>
+            <button data-quarter="0" class="btn btn-sm btn-error btn-outline pdu-qbtn">Not submitted</button>
+          </div>
+          <span id="pdu-visible-count" class="text-sm text-gray-500"></span>
+        </div>
+        <!-- Table -->
+        <div class="overflow-y-auto rounded-lg border border-base-300" style="max-height: 28rem;">
+          <table class="table table-xs table-zebra w-full">
+            <thead class="sticky top-0 z-10 bg-base-100">
+              <tr>
+                <th class="w-28">PZ Code</th>
+                <th>Lead Centre</th>
+                <th class="w-36 text-center">Latest Quarter</th>
+              </tr>
+            </thead>
+            <tbody id="pdu-table-body">
+              {% for row in pdu_submission_data %}
+                <tr data-quarter="{{ row.latest_visit_quarter }}"
+                    data-pz="{{ row.pz_code|lower }}"
+                    data-name="{{ row.lead_organisation_name|lower }}">
+                  <td class="font-mono">{{ row.pz_code }}</td>
+                  <td>{{ row.lead_organisation_name }}</td>
+                  <td class="text-center">
+                    {% if row.latest_visit_quarter == 0 %}
+                      <span class="badge badge-error badge-outline badge-sm">Not submitted</span>
+                    {% elif row.latest_visit_quarter == 1 %}
+                      <span class="badge badge-success badge-sm">Q1</span>
+                    {% elif row.latest_visit_quarter == 2 %}
+                      <span class="badge badge-success badge-sm">Q2</span>
+                    {% elif row.latest_visit_quarter == 3 %}
+                      <span class="badge badge-success badge-sm">Q3</span>
+                    {% elif row.latest_visit_quarter == 4 %}
+                      <span class="badge badge-success badge-sm">Q4</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <script>
+        (function () {
+          var searchInput = document.getElementById('pdu-search');
+          var qButtons = document.querySelectorAll('.pdu-qbtn');
+          var rows = document.querySelectorAll('#pdu-table-body tr');
+          var countEl = document.getElementById('pdu-visible-count');
+          var activeQuarter = 'all';
+
+          function updateCount() {
+            var visible = document.querySelectorAll('#pdu-table-body tr:not([hidden])').length;
+            countEl.textContent = visible + ' of ' + rows.length + ' PDUs';
+          }
+
+          function applyFilters() {
+            var term = searchInput.value.trim().toLowerCase();
+            rows.forEach(function (row) {
+              var qMatch = activeQuarter === 'all' || row.dataset.quarter === activeQuarter;
+              var textMatch = !term || row.dataset.pz.includes(term) || row.dataset.name.includes(term);
+              row.hidden = !(qMatch && textMatch);
+            });
+            updateCount();
+          }
+
+          searchInput.addEventListener('input', applyFilters);
+
+          qButtons.forEach(function (btn) {
+            btn.addEventListener('click', function () {
+              activeQuarter = btn.dataset.quarter;
+              qButtons.forEach(function (b) { b.classList.remove('btn-active'); });
+              btn.classList.add('btn-active');
+              applyFilters();
+            });
+          });
+
+          updateCount();
+        })();
+      </script>
+    {% endif %}
     {% if bubble_map_centres %}
       <div class="px-4 mb-8">
         <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -104,13 +104,7 @@
     {% endif %}
     {% if bubble_map_centres %}
       <div class="px-4 mb-8">
-        <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">
-          Lead centres — T1DM patients &amp; median HbA1c ({{ audit_period }})
-        </h2>
-        <p class="text-sm text-gray-600 mb-3">
-          Bubble size = number of eligible T1DM patients. Colour = median HbA1c (mmol/mol):
-          blue (lower) → red (higher).
-        </p>
+        <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">Lead centre overview — {{ audit_period }}</h2>
         <link rel="stylesheet"
               href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
         <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
@@ -118,67 +112,156 @@
                 integrity="sha512-Udl5igLQTnxSJGcneRNBfS+zFpzYUcNZW2kA+dkVf/9mNpmS9numEnCaFdtWLqndBqGUJisvJ4QSYudGOK5oYg=="
                 crossorigin="anonymous"></script>
         <style>
-          /* Make the bubble-map legend scrollable when it is taller than the map */
           #submissions-bubble-map .maplibregl-ctrl {
             max-height: calc(38rem - 2rem);
             overflow-y: auto;
           }
         </style>
-        {{ bubble_map_centres|json_script:"submissions-bubble-map-data" }}
+
+        {{ bubble_map_centres|json_script:"sbm-data-hba1c" }}
+        {{ bubble_map_care_processes|json_script:"sbm-data-care" }}
+        {{ bubble_map_diabetes_type|json_script:"sbm-data-type" }}
+        {{ bubble_map_age|json_script:"sbm-data-age" }}
+
+        <!-- Tabs -->
+        <div class="flex gap-2 mb-3 flex-wrap" id="sbm-tabs">
+          <button class="btn btn-sm btn-primary" data-sbm-tab="hba1c">By HbA1c</button>
+          <button class="btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
+          <button class="btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
+          <button class="btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
+        </div>
+        <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3">
+          Bubble size = T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) → red (higher).
+        </p>
+
         <div id="submissions-bubble-map"
              data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
              data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
              style="width:100%;height:38rem;border-radius:4px;"></div>
+
         <script>
           (function () {
             var container = document.getElementById('submissions-bubble-map');
             if (!container || typeof RcpchImdMap === 'undefined') return;
 
-            if (window.__npdaSubmissionsMap) {
-              window.__npdaSubmissionsMap.destroy();
-              window.__npdaSubmissionsMap = null;
+            function parseData(id) {
+              var el = document.getElementById(id);
+              return el ? JSON.parse(el.textContent) : [];
             }
 
-            var centres = JSON.parse(
-              document.getElementById('submissions-bubble-map-data').textContent
-            );
+            var tilesBaseUrl = (container.dataset.tilesBaseUrl || '').replace(/\/$/, '') || undefined;
+            var tilesApiKey = container.dataset.tilesApiKey || undefined;
 
-            var map = RcpchImdMap.createImdMap({
-              container: container,
-              tilesBaseUrl: (container.dataset.tilesBaseUrl || '').replace(/\/$/, '') || undefined,
-              tilesApiKey: container.dataset.tilesApiKey || undefined,
-              tilesApiKeyParam: 'Subscription-Key',
-              initialNation: 'all',
-              initialEra: '2021',
-              zoom: 5,
-              legendCollapsed: true,
-              style: {
-                legend: {
-                  width: 200,
-                },
+            var TABS = {
+              hba1c: {
+                data: parseData('sbm-data-hba1c'),
+                desc: 'Bubble size = number of eligible T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) \u2192 red (higher).',
                 leadCentres: {
-                  sizeField: 'patient_count',
-                  sizeLabel: 'T1DM patients',
-                  colorField: 'median_hba1c',
-                  colorLabel: 'Median HbA1c',
-                  colorUnit: 'mmol/mol',
-                  colorMode: 'continuous',
+                  sizeField: 'patient_count', sizeLabel: 'T1DM patients',
+                  colorField: 'median_hba1c', colorLabel: 'Median HbA1c',
+                  colorUnit: 'mmol/mol', colorMode: 'continuous',
                   colorScale: ['#2166ac', '#ffffbf', '#d7191c'],
-                  minRadius: 8,
-                  maxRadius: 40,
-                },
-                tooltip: {
-                  backgroundColor: '#0d0d58',
-                  textColor: '#ffffff',
+                  minRadius: 8, maxRadius: 40,
                 },
               },
-              onWarning: function (w) {
-                console.warn('[rcpch-imd-map]', w.code, w.message);
+              care: {
+                data: parseData('sbm-data-care'),
+                desc: 'Bubble size = T1DM patients with complete year of care. Colour = % who completed all required care processes (green = higher).',
+                leadCentres: {
+                  sizeField: 'eligible_count', sizeLabel: 'Eligible T1DM patients',
+                  colorField: 'pct_complete', colorLabel: '% Complete care',
+                  colorUnit: '%', colorMode: 'continuous',
+                  colorScale: ['#d7191c', '#ffffbf', '#1a9641'],
+                  minRadius: 8, maxRadius: 40,
+                },
               },
+              type: {
+                data: parseData('sbm-data-type'),
+                desc: 'Bubble size = all patients. Colour = dominant diabetes type at the lead centre.',
+                leadCentres: {
+                  sizeField: 'total_patients', sizeLabel: 'Total patients',
+                  colorField: 'dominant_type', colorLabel: 'Dominant diabetes type',
+                  colorMode: 'categorical',
+                  colorByCategory: { type1: '#4e79a7', type2: '#f28e2b', other: '#59a14f' },
+                  breakdownFields: [
+                    { field: 'pct_type1', label: 'Type 1', color: '#4e79a7' },
+                    { field: 'pct_type2', label: 'Type 2', color: '#f28e2b' },
+                    { field: 'pct_other', label: 'Other',  color: '#59a14f' },
+                  ],
+                  minRadius: 8, maxRadius: 40,
+                },
+              },
+              age: {
+                data: parseData('sbm-data-age'),
+                desc: 'Bubble size = T1DM patients. Colour = dominant age group at the lead centre.',
+                leadCentres: {
+                  sizeField: 'total_patients', sizeLabel: 'T1DM patients',
+                  colorField: 'dominant_age_group', colorLabel: 'Age group',
+                  colorMode: 'categorical',
+                  colorByCategory: { under_16: '#2166ac', over_16: '#d7191c' },
+                  breakdownFields: [
+                    { field: 'pct_under_16', label: 'Under 16',   color: '#2166ac' },
+                    { field: 'pct_over_16',  label: '16 and over', color: '#d7191c' },
+                  ],
+                  minRadius: 8, maxRadius: 40,
+                },
+              },
+            };
+
+            var descEl = document.getElementById('sbm-tab-desc');
+            var activeTabId = 'hba1c';
+
+            function buildMap(tabId) {
+              /* Destroy any existing instance before recreating — this is the only
+                 reliable way to switch between continuous and categorical colour
+                 modes, because setStyle() deep-merges and leaves stale keys. */
+              if (window.__npdaSubmissionsMap) {
+                window.__npdaSubmissionsMap.destroy();
+                window.__npdaSubmissionsMap = null;
+              }
+              var tab = TABS[tabId];
+              if (!tab) return;
+
+              var map = RcpchImdMap.createImdMap({
+                container: container,
+                tilesBaseUrl: tilesBaseUrl,
+                tilesApiKey: tilesApiKey,
+                tilesApiKeyParam: 'Subscription-Key',
+                initialNation: 'all',
+                initialEra: '2021',
+                zoom: 5,
+                legendCollapsed: true,
+                style: {
+                  legend: { width: 200 },
+                  leadCentres: tab.leadCentres,
+                  tooltip: { backgroundColor: '#0d0d58', textColor: '#ffffff' },
+                },
+                onWarning: function (w) {
+                  console.warn('[rcpch-imd-map]', w.code, w.message);
+                },
+              });
+
+              map.setLeadCentres(tab.data);
+              window.__npdaSubmissionsMap = map;
+            }
+
+            function switchTab(tabId) {
+              activeTabId = tabId;
+              document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
+                var isActive = btn.dataset.sbmTab === tabId;
+                btn.classList.toggle('btn-primary', isActive);
+                btn.classList.toggle('btn-outline', !isActive);
+              });
+              var tab = TABS[tabId];
+              if (descEl && tab) descEl.textContent = tab.desc;
+              buildMap(tabId);
+            }
+
+            document.querySelectorAll('[data-sbm-tab]').forEach(function (btn) {
+              btn.addEventListener('click', function () { switchTab(btn.dataset.sbmTab); });
             });
 
-            map.setLeadCentres(centres);
-            window.__npdaSubmissionsMap = map;
+            buildMap('hba1c');
           })();
         </script>
       </div>

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -2,27 +2,8 @@
 {% load static %}
 {% block content %}
   {% if request.user.is_rcpch_audit_team_member %}
-    <!-- Stats bar -->
-    <div class="flex flex-wrap items-start gap-4 px-4 mb-4 mt-4">
-      <div class="stats shadow">
-        <div class="stat">
-          <div class="stat-figure text-secondary">
-            <svg width="48px"
-                 height="48px"
-                 viewBox="0 0 24 24"
-                 fill="none"
-                 xmlns="http://www.w3.org/2000/svg">
-              <line x1="12" y1="2" x2="12" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-              <line x1="7.5" y1="2" x2="9" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-              <line x1="16.5" y1="2" x2="15" y2="10.0" stroke="#e00087" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="4 2" />
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M23 17C23 19.2091 21.2091 21 19 21H5C2.79086 21 1 19.2091 1 17V12.5183C1 12.1784 1.08662 11.8441 1.25169 11.547L5.42849 4.02871C5.78123 3.39378 6.45047 3 7.17681 3H16.8232C17.5495 3 18.2188 3.39378 18.5715 4.02871L22.7483 11.547C22.9134 11.8441 23 12.1784 23 12.5183V17ZM19.5845 11H16C15.6656 11 15.3534 11.1671 15.1679 11.4453L13.4648 14H10.5352L8.83205 11.4453C8.64658 11.1671 8.33435 11 8 11H4.41545L7.47101 5.5H16.529L19.5845 11Z" fill="#e00087" />
-            </svg>
-          </div>
-          <div class="stat-title">PDUs without Submission</div>
-          <div class="stat-value">{{ non_submission_pdus|length }}</div>
-          <div class="stat-desc">{{ audit_period }}</div>
-        </div>
-      </div>
+    <!-- Leaderboard tiles -->
+    <div class="px-4 mb-4 mt-4">
       {% include 'partials/submission_stats.html' with submission_statistics=submission_statistics %}
     </div>
 

--- a/project/npda/templates/submissions_list.html
+++ b/project/npda/templates/submissions_list.html
@@ -141,10 +141,8 @@
 
         <!-- Section 3: National Summary Map -->
          {% if bubble_map_centres %}
-          <section id="section-national-map" class="hidden -mx-4">
-            <div class="px-4">
-              <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">National summary — {{ audit_period }}</h2>
-            </div>
+          <section id="section-national-map" class="hidden">
+            <h2 class="text-lg font-semibold text-rcpch_dark_blue mb-2">National summary — {{ audit_period }}</h2>
             <link rel="stylesheet"
                   href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
             <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
@@ -170,26 +168,26 @@
             {{ bubble_map_diabetes_type|json_script:"sbm-data-type" }}
             {{ bubble_map_age|json_script:"sbm-data-age" }}
 
-            <div class="flex gap-2 mb-3 flex-wrap px-4" id="sbm-tabs">
+            <div class="flex gap-2 mb-3 flex-wrap" id="sbm-tabs">
               <button class="sbm-map-tab btn btn-sm is-active" data-sbm-tab="hba1c">By HbA1c</button>
               <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="care">% Complete care processes</button>
               <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="type">By diabetes type</button>
               <button class="sbm-map-tab btn btn-sm btn-outline" data-sbm-tab="age">By age group</button>
             </div>
-            <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3 px-4">
+            <p id="sbm-tab-desc" class="text-sm text-gray-600 mb-3">
               Bubble size = T1DM patients. Colour = median HbA1c (mmol/mol): blue (lower) → red (higher).
             </p>
 
-            <!-- Map view — full bleed -->
+            <!-- Map — margin trick to fill edge-to-edge within the flex-1 column -->
             <div id="submissions-bubble-map"
                  data-tiles-base-url="{{ RCPCH_DEPRIVATION_TILES_URL|default:'' }}"
                  data-tiles-api-key="{{ RCPCH_CENSUS_PLATFORM_TOKEN|default:'' }}"
-                 style="width:100%;height:38rem;"></div>
+                 style="margin-left:-1rem;margin-right:-1rem;width:calc(100% + 2rem);height:38rem;"></div>
 
             <!-- League chart — auto-shown for continuous tabs (hba1c, care) -->
-            <div id="sbm-league-panel" class="hidden mt-2 px-2">
-              <p id="sbm-league-title" class="text-sm font-semibold text-rcpch_dark_blue mb-1 px-2"></p>
-              <div id="sbm-league-chart" style="width:100%;height:18rem;"></div>
+            <div id="sbm-league-panel" class="hidden mt-2">
+              <p id="sbm-league-title" class="text-sm font-semibold text-rcpch_dark_blue mb-1"></p>
+              <div id="sbm-league-chart" style="margin-left:-1rem;margin-right:-1rem;width:calc(100% + 2rem);height:18rem;"></div>
             </div>
 
             <script>

--- a/project/npda/tests/view_tests/test_bubble_map_query.py
+++ b/project/npda/tests/view_tests/test_bubble_map_query.py
@@ -1,0 +1,242 @@
+"""Tests for the all_pdus_t1dm_bubble_map_data query."""
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.contrib.gis.geos import Point
+
+from project.constants.diabetes_types import DIABETES_TYPES
+from project.npda.general_functions.patient_report.queries import (
+    all_pdus_t1dm_bubble_map_data,
+)
+from project.npda.models import AuditPeriod, NPDAUser, Submission
+from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
+from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
+from project.npda.tests.factories.patient_factory import PatientFactory
+from project.npda.tests.factories.visit_factory import VisitFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+T1DM = DIABETES_TYPES[0][0]
+T2DM = DIABETES_TYPES[1][0]
+
+# Alder Hey's approximate coordinates (lon, lat)
+ALDER_HEY_COORDS = Point(-2.9003, 53.4152)
+
+
+def _get_audit_team_user():
+    return NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_rcpch_audit_team_data.role,
+    ).first()
+
+
+def _create_submission(user, audit_period):
+    return Submission.objects.create(
+        paediatric_diabetes_unit=user.organisation_employers.first(),
+        audit_period=audit_period,
+        audit_year=audit_period.start_date.year,
+        submission_date=audit_period.start_date,
+        submission_by=user,
+        submission_active=True,
+    )
+
+
+def _add_t1dm_patient_with_visit(submission, audit_period, hba1c=60):
+    """Create a T1DM patient with a visit and add to the submission."""
+    patient = PatientFactory(
+        diabetes_type=T1DM,
+        date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+        diagnosis_date=audit_period.start_date - relativedelta(days=200),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        hba1c=hba1c,
+        hba1c_date=audit_period.start_date + relativedelta(days=10),
+        hba1c_format=1,  # mmol/mol — required for 2021 dataset HbA1c normalisation
+    )
+    submission.patients.add(patient)
+    return patient
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_returns_empty_list_when_no_submissions(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """No active submissions → empty list, no crash."""
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert result == []
+
+
+@pytest.mark.django_db
+def test_returns_empty_list_when_pdu_has_no_geocoordinates(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A submission exists but the PDU has no geocoordinate → excluded from results."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = None
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+    _add_t1dm_patient_with_visit(submission, audit_period)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert result == []
+
+
+@pytest.mark.django_db
+def test_returns_entry_for_pdu_with_geocoordinates(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """PDU with a geocoordinate, one T1DM patient → one entry returned."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = ALDER_HEY_COORDS
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+    _add_t1dm_patient_with_visit(submission, audit_period, hba1c=60)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["pz_code"] == ALDER_HEY_PZ_CODE
+    assert entry["patient_count"] == 1
+    assert entry["lat"] == pytest.approx(ALDER_HEY_COORDS.y, abs=0.001)
+    assert entry["lon"] == pytest.approx(ALDER_HEY_COORDS.x, abs=0.001)
+    assert isinstance(entry["label"], str)
+
+
+@pytest.mark.django_db
+def test_patient_count_reflects_t1dm_only(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """T2DM patients are excluded from patient_count."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = ALDER_HEY_COORDS
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+
+    # One T1DM patient
+    _add_t1dm_patient_with_visit(submission, audit_period, hba1c=60)
+
+    # One T2DM patient — should not be counted
+    t2_patient = PatientFactory(
+        diabetes_type=T2DM,
+        date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+        diagnosis_date=audit_period.start_date - relativedelta(days=200),
+    )
+    VisitFactory(
+        patient=t2_patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        hba1c=70,
+        hba1c_date=audit_period.start_date + relativedelta(days=10),
+    )
+    submission.patients.add(t2_patient)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert len(result) == 1
+    assert result[0]["patient_count"] == 1
+
+
+@pytest.mark.django_db
+def test_median_hba1c_calculated_correctly(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """median_hba1c is the median of all T1DM HbA1c values in the period."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = ALDER_HEY_COORDS
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+
+    # Three patients with HbA1c 50, 60, 70 → median = 60
+    for hba1c in (50, 60, 70):
+        _add_t1dm_patient_with_visit(submission, audit_period, hba1c=hba1c)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert len(result) == 1
+    assert result[0]["median_hba1c"] == 60
+
+
+@pytest.mark.django_db
+def test_median_hba1c_is_none_when_no_valid_hba1c(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """median_hba1c is None when the patient's only HbA1c is within 90 days of diagnosis."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = ALDER_HEY_COORDS
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+
+    # Patient diagnosed very recently — HbA1c within 90 days is excluded
+    patient = PatientFactory(
+        diabetes_type=T1DM,
+        date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+        diagnosis_date=audit_period.start_date + relativedelta(days=5),
+    )
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date + relativedelta(days=10),
+        hba1c=60,
+        hba1c_date=audit_period.start_date + relativedelta(days=10),
+        hba1c_format=1,
+    )
+    submission.patients.add(patient)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert len(result) == 1
+    assert result[0]["median_hba1c"] is None
+
+
+@pytest.mark.django_db
+def test_patient_without_visit_in_period_excluded(
+    seed_groups_fixture, seed_users_fixture, seed_audit_periods_fixture
+):
+    """A patient with no visit inside the audit period does not appear in results."""
+    user = _get_audit_team_user()
+    pdu = user.organisation_employers.first()
+    pdu.lead_organisation_geocoordinates = ALDER_HEY_COORDS
+    pdu.save()
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+    submission = _create_submission(user, audit_period)
+
+    patient = PatientFactory(
+        diabetes_type=T1DM,
+        date_of_birth=audit_period.start_date - relativedelta(years=11, days=2),
+        diagnosis_date=audit_period.start_date - relativedelta(days=200),
+    )
+    # Visit is outside the audit period
+    VisitFactory(
+        patient=patient,
+        visit_date=audit_period.start_date - relativedelta(days=5),
+        hba1c=60,
+        hba1c_date=audit_period.start_date - relativedelta(days=5),
+        hba1c_format=1,
+    )
+    submission.patients.add(patient)
+
+    result = all_pdus_t1dm_bubble_map_data(audit_period)
+    assert result == []

--- a/project/npda/tests/view_tests/test_bubble_map_query.py
+++ b/project/npda/tests/view_tests/test_bubble_map_query.py
@@ -9,11 +9,10 @@ from project.npda.general_functions.patient_report.queries import (
     all_pdus_t1dm_bubble_map_data,
 )
 from project.npda.models import AuditPeriod, NPDAUser, Submission
-from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
 from project.npda.tests.constants_for_tests import ALDER_HEY_PZ_CODE
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
-
+from project.npda.tests.UserDataClasses import test_user_rcpch_audit_team_data
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -183,8 +183,11 @@ class SubmissionsListView(
                 .values("pz_code", "lead_organisation_name", "latest_visit_quarter")
             )
 
-            column_chart = create_column_chart(chart_data, selected_audit_period)
-            context["column_chart"] = column_chart.to_html(full_html=False)
+            context["pdu_submission_data"] = list(
+                chart_data.order_by("latest_visit_quarter", "pz_code").values(
+                    "pz_code", "lead_organisation_name", "latest_visit_quarter"
+                )
+            )
             context["non_submission_pdus"] = chart_data.filter(
                 latest_visit_quarter=0
             ).values_list("pz_code", "lead_organisation_name")

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -37,6 +37,7 @@ from django.views.generic import ListView
 # RCPCH imports
 from project.constants.colors import RCPCH_LIGHT_BLUE
 from project.npda.views.decorators import check_data_permissions, login_and_otp_required
+from project.settings import RCPCH_CENSUS_PLATFORM_TOKEN, RCPCH_DEPRIVATION_TILES_URL
 
 from ..general_functions.breadcrumbs import data_breadcrumbs
 from ..general_functions.csv import (
@@ -46,6 +47,7 @@ from ..general_functions.csv import (
     download_xlsx,
     export_as_csv,
 )
+from ..general_functions.patient_report.queries import all_pdus_t1dm_bubble_map_data
 from ..general_functions.session import save_csv_uploading_user_to_visitactivity
 from ..models import (
     PaediatricDiabetesUnit,
@@ -188,6 +190,11 @@ class SubmissionsListView(
             ).values_list("pz_code", "lead_organisation_name")
             context["audit_period"] = selected_audit_period
             context["submission_statistics"] = submission_stats(selected_audit_period)
+            context["bubble_map_centres"] = all_pdus_t1dm_bubble_map_data(
+                selected_audit_period
+            )
+            context["RCPCH_DEPRIVATION_TILES_URL"] = RCPCH_DEPRIVATION_TILES_URL
+            context["RCPCH_CENSUS_PLATFORM_TOKEN"] = RCPCH_CENSUS_PLATFORM_TOKEN
 
         context["breadcrumbs"] = data_breadcrumbs(
             self.pdu,

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -47,7 +47,12 @@ from ..general_functions.csv import (
     download_xlsx,
     export_as_csv,
 )
-from ..general_functions.patient_report.queries import all_pdus_t1dm_bubble_map_data
+from ..general_functions.patient_report.queries import (
+    all_pdus_age_map_data,
+    all_pdus_care_processes_map_data,
+    all_pdus_diabetes_type_map_data,
+    all_pdus_t1dm_bubble_map_data,
+)
 from ..general_functions.session import save_csv_uploading_user_to_visitactivity
 from ..models import (
     PaediatricDiabetesUnit,
@@ -196,6 +201,13 @@ class SubmissionsListView(
             context["bubble_map_centres"] = all_pdus_t1dm_bubble_map_data(
                 selected_audit_period
             )
+            context["bubble_map_care_processes"] = all_pdus_care_processes_map_data(
+                selected_audit_period
+            )
+            context["bubble_map_diabetes_type"] = all_pdus_diabetes_type_map_data(
+                selected_audit_period
+            )
+            context["bubble_map_age"] = all_pdus_age_map_data(selected_audit_period)
             context["RCPCH_DEPRIVATION_TILES_URL"] = RCPCH_DEPRIVATION_TILES_URL
             context["RCPCH_CENSUS_PLATFORM_TOKEN"] = RCPCH_CENSUS_PLATFORM_TOKEN
 


### PR DESCRIPTION
## Summary

Adds a proportional symbol (bubble) map to the submissions page, visible to audit team admins only. Upgrades the `@rcpch/imd-map` library to v0.5.0 which introduced the `setLeadCentres()` API used here.

## Changes

### Library upgrade
- `@rcpch/imd-map` 0.4.0 → 0.5.0 (CDN + SRI updated in `imd_map_card.html` and `AGENTS.md`)

### New query — `all_pdus_t1dm_bubble_map_data(audit_period)`
- Added to `queries.py` alongside the existing dashboard functions
- Returns one entry per active PDU that has geocoordinates and T1DM patients in the audit period
- Each entry carries `lat`, `lon`, `label`, `pz_code`, `patient_count` (eligible T1DM), `median_hba1c` (mmol/mol)
- ~4 DB queries regardless of PDU count; reuses same eligibility filters and HbA1c normalisation as `hba1c_stats_by_diabetes_type()`

### Submissions view
- `bubble_map_centres`, `RCPCH_DEPRIVATION_TILES_URL`, `RCPCH_CENSUS_PLATFORM_TOKEN` added to context for audit team members

### Submissions template
- Bubble map rendered below the column chart / stats block (audit team only)
- Bubble **size** = T1DM patient count; bubble **colour** = median HbA1c on a blue→yellow→red gradient
- Legend starts collapsed; scoped CSS makes it scrollable if taller than the map container

## Testing
- All 69 existing patient-report tests pass
- Linter clean

<img width="1270" height="542" alt="image" src="https://github.com/user-attachments/assets/38ef94d5-3d5a-494b-92bf-86ea7e3c44bf" />
