### PR TITLE
Handle missing user on logout signal

### DIFF
--- a/project/npda/signals.py
+++ b/project/npda/signals.py
@@ -122,13 +122,15 @@ def log_user_login_failed(sender, request, user=None, **kwargs):
 @receiver(user_logged_out)
 def log_user_logout(sender, request, user, **kwargs):
     # https://github.com/rcpch/national-paediatric-diabetes-audit/issues/679
-    # Sometimes this fires without an email on the user.
-    email_to_log = f"({user.email})" if user else ""
-    logger.info(f"{user} {email_to_log} logged out from {get_client_ip(request)}.")
+    # Sometimes this fires without an email on the user or missing the user entirely.
+    if user is None:
+        logger.info(f"Logout without a user from {get_client_ip(request)}.")
+    else:
+        logger.info(f"{user} {user.email} logged out from {get_client_ip(request)}.")
 
-    VisitActivity.objects.create(
-        activity=3, ip_address=get_client_ip(request), npdauser=user
-    )
+        VisitActivity.objects.create(
+            activity=3, ip_address=get_client_ip(request), npdauser=user
+        )
 
 
 # Two factor auth receiver


### PR DESCRIPTION
Follow on from #679, I'm also seeing crashes in live telemetry where the user is missing entirely from the logout signal