### PR TITLE
Fix accessing user data by guessing PK

### DIFF
--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -140,6 +140,29 @@ def test_npda_user_list_view_users_can_only_see_users_from_their_pdu(
 
 
 @pytest.mark.django_db
+def test_npda_user_update_view_users_can_only_see_users_from_their_pdu(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+):
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
+    ).first()
+
+    non_ah_user = NPDAUser.objects.exclude(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
+    ).first()
+
+    client = login_and_verify_user(client, ah_user)
+
+    url = reverse("npdauser-update", kwargs={"pk": non_ah_user.pk})
+    response = client.get(url)
+
+    assert response.status_code != HTTPStatus.OK
+
+
+@pytest.mark.django_db
 def test_npda_user_list_view_rcpch_audit_team_can_view_all_users(
     seed_groups_fixture,
     seed_users_fixture,

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -9,7 +9,6 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 
 from project.npda.models.audit_period import AuditPeriod
-from project.npda.models.npda_user import NPDAUser
 from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
 from project.npda.models.patient import Patient
 from project.npda.models.submission import Submission

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -108,16 +108,6 @@ class PDUPermissionMixin(AccessMixin):
                         pdu, audit_period, request.user, self.kwargs["patient_id"]
                     )
 
-                # PDU level permission checked in the request helpers above. This is to prevent access to models by guessing their pk.
-                case "NPDAUser" if "pk" in self.kwargs:
-                    requested_user = get_object_or_404(NPDAUser, pk=self.kwargs["pk"])
-                    if not requested_user.organisation_employers.filter(
-                        pz_code=pdu.pz_code
-                    ).exists():
-                        raise PermissionDenied(
-                            f"User {request.user} does not have permission to view {model} for PDU {pdu.pz_code} in audit period {audit_period.slug}"
-                        )
-
         self.audit_period = audit_period
         self.pdu = pdu
 

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -536,11 +536,15 @@ class NPDAUserUpdateView(
 
         else:
             return super().post(request, *args, **kwargs)
-    
+
     def dispatch(self, request, *args, **kwargs):
         requested_user = self.get_object()
 
-        if request.user.is_superuser or request.user.is_rcpch_audit_team_member or self.user_shares_at_least_one_pdu_with_requesting_user():
+        if (
+            request.user.is_superuser
+            or request.user.is_rcpch_audit_team_member
+            or self.user_shares_at_least_one_pdu_with_requesting_user()
+        ):
             return super().dispatch(request, *args, **kwargs)
 
         raise PermissionDenied(

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -291,6 +291,16 @@ class NPDAUserUpdateView(
     success_message = "NPDA User record updated successfully"
     success_url = reverse_lazy("npda_users")
 
+    def user_shares_at_least_one_pdu_with_requesting_user(self):
+        my_pz_codes = set(
+            self.request.user.organisation_employers.values_list("pz_code", flat=True)
+        )
+        their_pz_codes = set(
+            self.get_object().organisation_employers.values_list("pz_code", flat=True)
+        )
+
+        return len(my_pz_codes & their_pz_codes) > 0
+
     def user_in_exactly_the_same_pdus_as_requesting_user(self):
         my_pz_codes = set(
             self.request.user.organisation_employers.values_list("pz_code", flat=True)
@@ -526,6 +536,16 @@ class NPDAUserUpdateView(
 
         else:
             return super().post(request, *args, **kwargs)
+    
+    def dispatch(self, request, *args, **kwargs):
+        requested_user = self.get_object()
+
+        if request.user.is_superuser or request.user.is_rcpch_audit_team_member or self.user_shares_at_least_one_pdu_with_requesting_user():
+            return super().dispatch(request, *args, **kwargs)
+
+        raise PermissionDenied(
+            f"User {request.user} does not have permission to view user {requested_user}"
+        )
 
 
 @login_and_otp_required()


### PR DESCRIPTION
Fixes #1451 and adds a regression test.

I broke this when we rolled out the data URL changes. `PDUPermissionMixin` had code to do this but was not used for the users view (as it's not PDU specific). I've removed the user case from that view as it's unused.