### PR TITLE
Quote value to defend against reflective XSS

### DIFF
--- a/project/npda/templates/npda/patient_form.html
+++ b/project/npda/templates/npda/patient_form.html
@@ -92,7 +92,7 @@
               class="select rcpch-select w-full mb-2 {% if not perms.npda.change_patient or not can_use_questionnaire %}opacity-40 pointer-events-none{% endif %}">
             <option value="">Select a reason</option>
             {% for choice in form.reason_leaving_service.field.choices %}
-              <option value={{ choice.0 }} {% if form.reason_leaving_service.value == choice.0 %} selected="true" {% endif %}>
+              <option value="{{ choice.0 }}" {% if form.reason_leaving_service.value == choice.0 %} selected="true" {% endif %}>
                 {{ choice.1 }}
               </option>
             {% endfor %}

--- a/project/npda/templates/npda/visit_form.html
+++ b/project/npda/templates/npda/visit_form.html
@@ -39,7 +39,7 @@
                   <div class="indicator">
                     <span class="indicator-item badge badge-lg bg-rcpch_pink text-white ">Required</span>
                   </div>
-                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} opacity-40 pointer-events-none {% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
+                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %} opacity-40 pointer-events-none {% endif %}" {% if field.value %}value="{{ field.value|stringformat:'s' }}"{% endif %}>
                   <button type='button'
                           _="on click set #{{ field.id_for_label }}'s value to '{% today_date %}'"
                           class="btn rcpch-btn bg-rcpch_light_blue border border-rcpch_light_blue hover:bg-rcpch_strong_blue hover:border-rcpch_strong_blue {% if not perms.npda.change_visit or not can_use_questionnaire  or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}">

--- a/project/npda/templates/partials/visit_form_tab.html
+++ b/project/npda/templates/partials/visit_form_tab.html
@@ -78,7 +78,7 @@
                     {% endfor %}
                   </select>
                 {% elif field.field.widget|is_dateinput %}
-                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text flex-grow basis-2/3 {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}" {% if field.value %}value={{ field.value|stringformat:'s' }}{% endif %}>
+                  <input type="date" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text flex-grow basis-2/3 {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year %}opacity-40 pointer-events-none{% endif %}" {% if field.value %}value="{{ field.value|stringformat:'s' }}"{% endif %}>
                   <div class="basis-1/3 flex">
                     <button type='button'
                             _="on click set #{{ field.id_for_label }}'s value to '{% today_date %}'"
@@ -106,14 +106,14 @@
                       name="{{ field.html_name }}"
                       class="grow bg-transparent"
                       {% if field.field.required %}placeholder="Required"{% endif %}
-                      {% if field.value %}value={{ field.value }}{% endif %}>
+                      {% if field.value %}value="{{ field.value }}"{% endif %}>
                       <span id="hba1c-conversion-label" class="text-xs text-gray-600 whitespace-nowrap"></span>
                       <span id="hba1c-unit-badge" class="badge badge-lg bg-rcpch_light_blue text-white">mmol/mol</span>
                     </label>
 
                   {% elif field.id_for_label != 'id_bmi' or field.id_for_label == 'id_bmi' and field.value is not None %}
                     <!-- Hide BMI label if no value -->
-                    <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year or field.id_for_label == 'id_bmi' %}opacity-40 pointer-events-none{% endif %}" {% if field.field.required %}placeholder="Required"{% endif %} {% if field.value %} value={{ field.value }} {% elif field.value == 0 %} value="0.0" {% endif %}>
+                    <input type="text" id="{{ field.id_for_label }}" name="{{ field.html_name }}" class="input rcpch-input-text rounded-none {% if not perms.npda.change_visit or not can_use_questionnaire or form.patient.is_in_transfer_in_the_last_year or field.id_for_label == 'id_bmi' %}opacity-40 pointer-events-none{% endif %}" {% if field.field.required %}placeholder="Required"{% endif %} {% if field.value %} value="{{ field.value }}" {% elif field.value == 0 %} value="0.0" {% endif %}>
                     {% if field.value is not None %}
                       {% with field|centile_for_field:'centile' as centile %}
                         {% if centile %}


### PR DESCRIPTION
Our pen test discovered that we were not enclosing `value=` on our `input` elements in quotes. This opened us up to reflective XSS attacks. However you needed to manually construct a request to inject it and also have a valid CSRF token and session. So we weren't open to a "drive by" attack where a malicious actor constructs an invisible form posting to us but it's still good hygiene to include quotes anyway.