### PR TITLE
Clearer error message for CSV file with no rows

### DIFF
--- a/project/npda/general_functions/csv/csv_parse.py
+++ b/project/npda/general_functions/csv/csv_parse.py
@@ -106,6 +106,11 @@ def csv_parse(csv_file, dataset_year=2021):
 
                 if lowercase_col in lowercase_alternative_headings:
                     df = df.rename(columns={column: heading["heading"]})
+    if df.empty:
+        raise ValueError(
+            "The CSV file contains no data rows. Please add patient data and upload again."
+        )
+
     # Pandas has strange behaviour for the first line in a CSV - additional cells become row labels
     # https://github.com/pandas-dev/pandas/issues/47490
     #

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1488,6 +1488,47 @@ def test_first_row_with_extra_cell_on_the_end(test_user, single_row_valid_df):
 
 
 @pytest.mark.django_db
+def test_empty_csv_raises_error(
+    single_row_valid_df,
+    tmp_path,
+    client,
+    test_rcpch_user,
+    dataset_year,
+    audit_period_for_dataset_year,
+):
+    """A CSV with headers but no data rows should return a user-facing error, not a 500."""
+    headers_only = single_row_valid_df.iloc[:0].to_csv(index=False)
+
+    Submission.objects.all().delete()
+
+    tmp_csv_path = tmp_path / "empty_sheet.csv"
+    tmp_csv_path.write_text(headers_only)
+
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse(
+        "pdu-upload-csv",
+        kwargs={
+            "pz_code": ALDER_HEY_PZ_CODE,
+            "audit_period": audit_period_for_dataset_year.slug,
+        },
+    )
+
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(url, {"csv_upload": csv_file}, format="multipart")
+
+    assert response.status_code == 302
+    assert response.url == url
+
+    error_messages = list(get_messages(response.wsgi_request))
+    assert len(error_messages) == 1
+    assert error_messages[0].tags == "error"
+    assert "no data rows" in error_messages[0].message
+
+    assert Submission.objects.count() == 0
+
+
+@pytest.mark.django_db
 def test_second_row_with_extra_cell_at_the_start(test_user, one_patient_two_visits):
     csv = one_patient_two_visits.to_csv(index=False, date_format="%d/%m/%Y")
 


### PR DESCRIPTION
Previous error:

```
Exception Type: IndexError at /period/2026-2027/pdu/PZ164/upload_csv
Exception Value: single positional indexer is out-of-bounds
```

which was not particularly instructive as the user got a blank generic 500 and I got an error email!

Now you get a reasonable error message in the frontend:

<img width="1272" height="543" alt="Screenshot 2026-06-29 132817" src="https://github.com/user-attachments/assets/ffb5f784-5231-408e-a4cb-bd10981e3f6c" />

I don't know why anyone would upload an empty CSV file but I've caught it in telemetry twice now in the last week.