### PR TITLE
Infer HbA1c unit for CSV uploads in 2026

### DIFF
--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -910,6 +910,8 @@ class VisitForm(forms.ModelForm):
         else:
             effective_hba1c_format = 1  # IFCC (mmol/mol)
 
+        cleaned_data["hba1c_format"] = effective_hba1c_format
+
         def hba1c_error(msg):
             return ValidationError({"hba1c": [msg]})
 

--- a/project/npda/forms/visit_form.py
+++ b/project/npda/forms/visit_form.py
@@ -898,51 +898,42 @@ class VisitForm(forms.ModelForm):
         hba1c_format = cleaned_data.get("hba1c_format")
         hba1c_date = cleaned_data.get("hba1c_date")
 
-        # For dataset years >= 2026 the `hba1c_format` column is absent;
-        # treat missing format as IFCC (1) for range validation in 2026+.
-        # Percentage→mmol/mol conversion for web submissions is handled by JS
-        # before the form is POSTed, so the value arriving here is always IFCC.
-        effective_hba1c_format = hba1c_format
-        if (
-            getattr(self, "dataset_year", 2021) >= 2026
-            and effective_hba1c_format is None
-        ):
-            effective_hba1c_format = 1
+        # The `hba1c_format` column was removed in the 2026 CSV dataset.
+        # We now infer the format based on the value (IFCC < 20 >= DCCT).
+        # The questionnaire runs some JS to convert to mmol/mol before the
+        # form is submitted but we still infer for CSV uploads.
+
+        if hba1c_format is not None:
+            effective_hba1c_format = hba1c_format
+        elif hba1c is not None and hba1c < 20:
+            effective_hba1c_format = 2  # DCCT (%)
+        else:
+            effective_hba1c_format = 1  # IFCC (mmol/mol)
+
+        def hba1c_error(msg):
+            return ValidationError({"hba1c": [msg]})
 
         if hba1c is not None:
-            if effective_hba1c_format == 1:
-                # mmol/mol
-                if hba1c < 20:
-                    # Debug: record when we trigger the low-IFCC validation branch
-                    raise ValidationError(
-                        {
-                            "hba1c": [
-                                "Hba1c Value out of range (mmol/mol). Cannot be below 20. Did you mean to enter a DCCT (%) value?"
-                            ]
-                        }
-                    )
-                elif hba1c > 195:
-                    raise ValidationError(
-                        {
-                            "hba1c": [
-                                "Hba1c Value out of range (mmol/mol). Cannot be above 195"
-                            ]
-                        }
-                    )
-            elif hba1c_format == 2:
-                # %
-                if hba1c < 3:
-                    raise ValidationError(
-                        {"hba1c": ["Hba1c Value out of range (%). Cannot be below 3"]}
-                    )
-                elif hba1c > 20:
-                    raise ValidationError(
-                        {
-                            "hba1c": [
-                                "Hba1c Value out of range (%). Cannot be above 20. Did you mean to enter an IFCC (mmol/mol) value?"
-                            ]
-                        }
-                    )
+            match effective_hba1c_format:
+                case 1:  # IFCC (mmol/mol)
+                    if hba1c < 20:
+                        raise hba1c_error(
+                            "Hba1c Value out of range (mmol/mol). Cannot be below 20. Did you mean to enter a DCCT (%) value?"
+                        )
+                    elif hba1c > 195:
+                        raise hba1c_error(
+                            "Hba1c Value out of range (mmol/mol). Cannot be above 195"
+                        )
+                case 2:  # DCCT (%)
+                    if hba1c < 3:
+                        raise hba1c_error(
+                            "Hba1c Value out of range (%). Cannot be below 3"
+                        )
+                    elif hba1c > 20:
+                        raise hba1c_error(
+                            "Hba1c Value out of range (%). Cannot be above 20. Did you mean to enter an IFCC (mmol/mol) value?"
+                        )
+
         # Require the format field only for dataset years < 2026. For 2026+ we
         # require the value and date only (format is assumed IFCC if missing).
         if getattr(self, "dataset_year", 2026) < 2026:

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1895,6 +1895,9 @@ HbA1c tests
 def test_hba1c_value_ifcc_less_than_20(
     test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
 ):
+    if dataset_year >= 2026:
+        pytest.skip("Test applies only to 2021 headings")
+
     hba1c_value = get_field_heading("hba1c", dataset_year)
     hba1c_date = get_field_heading("hba1c_date", dataset_year)
     visit_date = get_field_heading("visit_date", dataset_year)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1986,6 +1986,70 @@ def test_hba1c_value_dcct_more_than_20(
     assert "hba1c" in visit.errors
 
 
+def test_hba1c_value_dcct_inferred_in_2026_dataset(
+    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
+):
+    if dataset_year < 2026:
+        pytest.skip("Test applies only to 2026+ headings")
+
+    hba1c_value = get_field_heading("hba1c", dataset_year)
+    hba1c_date = get_field_heading("hba1c_date", dataset_year)
+    visit_date = get_field_heading("visit_date", dataset_year)
+    
+    single_row_valid_df.loc[0, hba1c_value] = 6
+    single_row_valid_df.loc[0, hba1c_date] = (
+        audit_period_for_dataset_year.start_date + relativedelta(months=1)
+    )
+    single_row_valid_df.loc[0, visit_date] = (
+        audit_period_for_dataset_year.start_date + relativedelta(months=1)
+    )
+
+    errors = csv_upload_sync(
+        test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
+    )
+
+    assert "hba1c" not in errors[0]
+
+    visit = Visit.objects.first()
+
+    assert visit.hba1c == 6
+    assert visit.hba1c_format == 2  # DCCT (%)
+
+    assert "hba1c" not in visit.errors
+
+
+def test_hba1c_value_ifcc_inferred_in_2026_dataset(
+    test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year
+):
+    if dataset_year < 2026:
+        pytest.skip("Test applies only to 2026+ headings")
+
+    hba1c_value = get_field_heading("hba1c", dataset_year)
+    hba1c_date = get_field_heading("hba1c_date", dataset_year)
+    visit_date = get_field_heading("visit_date", dataset_year)
+    
+    single_row_valid_df.loc[0, hba1c_value] = 64
+    single_row_valid_df.loc[0, hba1c_date] = (
+        audit_period_for_dataset_year.start_date + relativedelta(months=1)
+    )
+    single_row_valid_df.loc[0, visit_date] = (
+        audit_period_for_dataset_year.start_date + relativedelta(months=1)
+    )
+
+    errors = csv_upload_sync(
+        test_user, single_row_valid_df, _audit_period=audit_period_for_dataset_year
+    )
+
+    assert "hba1c" not in errors[0]
+
+    visit = Visit.objects.first()
+
+    assert visit.hba1c == 64
+    assert visit.hba1c_format == 1  # IFCC (mmol/mol)
+
+    assert "hba1c" not in visit.errors
+
+
 @pytest.mark.django_db
 def test_hba1c_value_dcct_less_than_3(
     test_user, single_row_valid_df, audit_period_for_dataset_year, dataset_year

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -2015,7 +2015,7 @@ def test_hba1c_value_dcct_inferred_in_2026_dataset(
     assert visit.hba1c == 6
     assert visit.hba1c_format == 2  # DCCT (%)
 
-    assert "hba1c" not in visit.errors
+    assert visit.errors is None
 
 
 def test_hba1c_value_ifcc_inferred_in_2026_dataset(
@@ -2047,7 +2047,7 @@ def test_hba1c_value_ifcc_inferred_in_2026_dataset(
     assert visit.hba1c == 64
     assert visit.hba1c_format == 1  # IFCC (mmol/mol)
 
-    assert "hba1c" not in visit.errors
+    assert visit.errors is None
 
 
 @pytest.mark.django_db

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -1995,7 +1995,7 @@ def test_hba1c_value_dcct_inferred_in_2026_dataset(
     hba1c_value = get_field_heading("hba1c", dataset_year)
     hba1c_date = get_field_heading("hba1c_date", dataset_year)
     visit_date = get_field_heading("visit_date", dataset_year)
-    
+
     single_row_valid_df.loc[0, hba1c_value] = 6
     single_row_valid_df.loc[0, hba1c_date] = (
         audit_period_for_dataset_year.start_date + relativedelta(months=1)
@@ -2027,7 +2027,7 @@ def test_hba1c_value_ifcc_inferred_in_2026_dataset(
     hba1c_value = get_field_heading("hba1c", dataset_year)
     hba1c_date = get_field_heading("hba1c_date", dataset_year)
     visit_date = get_field_heading("visit_date", dataset_year)
-    
+
     single_row_valid_df.loc[0, hba1c_value] = 64
     single_row_valid_df.loc[0, hba1c_date] = (
         audit_period_for_dataset_year.start_date + relativedelta(months=1)


### PR DESCRIPTION
Fixes #1459 

Follow on from #1421 to also infer the unit as part of a CSV upload (now the format column has been removed).

This PR ensures `hba1c_format` is always set if `hba1c` is present but the analysts will still have to use the same criteria to infer the unit (at least for the latest submission) as previous CSV uploads will not have it.