### PR TITLE
Fix uploading CSV for units where PDU number ends in zero

### DIFF
--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -105,12 +105,24 @@ def AUDIT_END_DATE():
 
 @pytest.fixture(scope="session")
 def test_pz_codes_fixture():
-    return ["PZ196", "PZ074", "PZ248", "PZ004", "PZ180"]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital"
+    return [
+        "PZ196",
+        "PZ074",
+        "PZ248",
+        "PZ004",
+        "PZ180",
+    ]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital"
 
 
 @pytest.fixture(scope="function")
 def test_pz_codes_function_fixture():
-    return ["PZ196", "PZ074", "PZ248", "PZ004", "PZ180"]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital
+    return [
+        "PZ196",
+        "PZ074",
+        "PZ248",
+        "PZ004",
+        "PZ180",
+    ]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital
 
 
 @pytest.fixture(autouse=True)

--- a/project/npda/tests/conftest.py
+++ b/project/npda/tests/conftest.py
@@ -105,12 +105,12 @@ def AUDIT_END_DATE():
 
 @pytest.fixture(scope="session")
 def test_pz_codes_fixture():
-    return ["PZ196", "PZ074", "PZ248", "PZ004"]  # GOSH, Alder Hey, Jersey, Northampton
+    return ["PZ196", "PZ074", "PZ248", "PZ004", "PZ180"]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital"
 
 
 @pytest.fixture(scope="function")
 def test_pz_codes_function_fixture():
-    return ["PZ196", "PZ074", "PZ248", "PZ004"]  # GOSH, Alder Hey, Jersey, Northampton
+    return ["PZ196", "PZ074", "PZ248", "PZ004", "PZ180"]  # GOSH, Alder Hey, Jersey, Northampton, Kings Mill Hospital
 
 
 @pytest.fixture(autouse=True)

--- a/project/npda/tests/test_csv_upload.py
+++ b/project/npda/tests/test_csv_upload.py
@@ -5668,6 +5668,46 @@ def test_uploading_csv_with_pdu_number_missing_leading_zeros(
 
 
 @pytest.mark.django_db
+def test_uploading_csv_with_pdu_number_ending_in_zero(
+    two_patients_with_one_visit_each, tmp_path, client, test_rcpch_user
+):
+    two_patients_with_one_visit_each = two_patients_with_one_visit_each.assign(
+        **{"PDU Number": "PZ180"}
+    )
+
+    # write back into temp
+    tmp_csv_path = (
+        tmp_path
+        / "dummy_sheet_test_csv_upload_ttest_uploading_csv_with_pdu_number_ending_in_zero.csv"
+    )
+    two_patients_with_one_visit_each.to_csv(tmp_csv_path, index=False)
+
+    # Log in user
+    client = login_and_verify_user(client, test_rcpch_user)
+
+    url = reverse(
+        "pdu-upload-csv", kwargs={"pz_code": "PZ180", "audit_period": "2025-2026"}
+    )
+
+    # Feed file to view
+    with open(tmp_csv_path, "rb") as csv_file:
+        response = client.post(url, {"csv_upload": csv_file}, format="multipart")
+
+    assert response.status_code == 302
+
+    redirect_url = reverse(
+        "pdu-upload-csv-in-progress",
+        kwargs={"pz_code": "PZ180", "audit_period": "2025-2026"},
+    )
+    assert response.url == redirect_url
+
+    assert Submission.objects.count() == 1, (
+        "Submission should be created for PDU with missing leading zeroes"
+    )
+    assert Submission.objects.first().paediatric_diabetes_unit.pz_code == "PZ180"
+
+
+@pytest.mark.django_db
 def test_conflicting_stated_gender(test_user, one_patient_with_four_visits):
     df = one_patient_with_four_visits
 

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -535,8 +535,11 @@ def upload_csv(request, audit_period, pdu):
         expected_pdu_number = pdu.pz_code[2:].lstrip("0")
         
         if len(unique_pdu_numbers) > 0:
-            pdu_number_in_csv = unique_pdu_numbers[0][2:]
-            
+            pdu_number_in_csv = unique_pdu_numbers[0]
+
+            if pdu_number_in_csv.startswith("PZ"):
+                pdu_number_in_csv = pdu_number_in_csv[2:]
+
             # 1464 - Twinkle outputs PDU number as a decimal (e.g. "180.0")
             if pdu_number_in_csv.endswith(".0"):
                 pdu_number_in_csv = pdu_number_in_csv[:-2]
@@ -544,6 +547,8 @@ def upload_csv(request, audit_period, pdu):
             pdu_number_in_csv = pdu_number_in_csv.lstrip("0")
         else:
             pdu_number_in_csv = None
+
+        print(f"PDU number in CSV: {pdu_number_in_csv}, expected PDU number: {expected_pdu_number}")
 
         if pdu_number_in_csv != expected_pdu_number:
             message = f"PDU Number in CSV file ({unique_pdu_numbers[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -532,13 +532,18 @@ def upload_csv(request, audit_period, pdu):
             return upload_error(message)
 
         # 1316 - Twinkle/Diamond outputs PDU number without leading PZ and zeros
-        # 1464 - Twinkle outputs PDU number as a decimal
-        expected_pdu_number = pdu.pz_code.lstrip("PZ").lstrip("0")
-        pdu_number_in_csv = (
-            unique_pdu_numbers[0].lstrip("PZ").lstrip("0").rstrip(".0")
-            if len(unique_pdu_numbers) > 0
-            else None
-        )
+        expected_pdu_number = pdu.pz_code[2:].lstrip("0")
+        
+        if len(unique_pdu_numbers) > 0:
+            pdu_number_in_csv = unique_pdu_numbers[0][2:]
+            
+            # 1464 - Twinkle outputs PDU number as a decimal (e.g. "180.0")
+            if pdu_number_in_csv.endswith(".0"):
+                pdu_number_in_csv = pdu_number_in_csv[:-2]
+            
+            pdu_number_in_csv = pdu_number_in_csv.lstrip("0")
+        else:
+            pdu_number_in_csv = None
 
         if pdu_number_in_csv != expected_pdu_number:
             message = f"PDU Number in CSV file ({unique_pdu_numbers[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -526,7 +526,7 @@ def upload_csv(request, audit_period, pdu):
 
         # 1316 - Twinkle/Diamond outputs PDU number without leading PZ and zeros
         expected_pdu_number = pdu.pz_code[2:].lstrip("0")
-        
+
         if len(unique_pdu_numbers) > 0:
             pdu_number_in_csv = unique_pdu_numbers[0]
 
@@ -536,7 +536,7 @@ def upload_csv(request, audit_period, pdu):
             # 1464 - Twinkle outputs PDU number as a decimal (e.g. "180.0")
             if pdu_number_in_csv.endswith(".0"):
                 pdu_number_in_csv = pdu_number_in_csv[:-2]
-            
+
             pdu_number_in_csv = pdu_number_in_csv.lstrip("0")
         else:
             pdu_number_in_csv = None

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -541,8 +541,6 @@ def upload_csv(request, audit_period, pdu):
         else:
             pdu_number_in_csv = None
 
-        print(f"PDU number in CSV: {pdu_number_in_csv}, expected PDU number: {expected_pdu_number}")
-
         if pdu_number_in_csv != expected_pdu_number:
             message = f"PDU Number in CSV file ({unique_pdu_numbers[0]}) does not match the PDU you are looking at ({pdu.pz_code}). Please upload a file with the correct PDU Number."
             return upload_error(message)


### PR DESCRIPTION
My fix for Twinkle decimal PDU numbers (#1465) incorrectly used rstrip for the whole string rather than individual characters.