### PR TITLE
Fix accessing visit for other patient by changing the ID in the URL

### DIFF
--- a/project/npda/tests/permissions_tests/test_patient_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_patient_model_actions.py
@@ -8,6 +8,7 @@ from django.apps import apps
 from django.urls import reverse
 
 # RCPCH imports
+from project.constants import AUDIT_CENTRE_COORDINATOR
 from project.npda.models import AuditPeriod, NPDAUser, Submission
 from project.npda.tests.factories.patient_factory import PatientFactory
 from project.npda.tests.factories.visit_factory import VisitFactory
@@ -323,11 +324,11 @@ def test_users_can_only_edit_patient_visits_from_their_own_pdu(
     client,
 ):
     gosh_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=GOSH_PZ_CODE
+        organisation_employers__pz_code=GOSH_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
     ).first()
 
     ah_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=ALDER_HEY_PZ_CODE
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
     ).first()
 
     ah_patient = create_submission_with_patient(ah_user)
@@ -352,6 +353,44 @@ def test_users_can_only_edit_patient_visits_from_their_own_pdu(
 
 
 @pytest.mark.django_db
+def test_users_cannot_edit_visit_from_other_pdu_by_guessing_the_pk(
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    client,
+):
+    gosh_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=GOSH_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    ah_user = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE, role=AUDIT_CENTRE_COORDINATOR
+    ).first()
+
+    ah_patient = create_submission_with_patient(ah_user)
+    ah_visit = VisitFactory(patient=ah_patient)
+
+    gosh_patient = create_submission_with_patient(gosh_user)
+
+    client = login_and_verify_user(client, gosh_user)
+
+    audit_period = AuditPeriod.objects.get_default_audit_period()
+
+    url = reverse(
+        "pdu-visit-update",
+        kwargs={
+            "audit_period": audit_period.slug,
+            "pz_code": GOSH_PZ_CODE,
+            "patient_id": gosh_patient.pk,
+            "pk": ah_visit.pk,
+        },
+    )
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.django_db
 def test_rcpch_audit_team_can_edit_visits_from_all_pdus(
     seed_groups_fixture,
     seed_users_fixture,
@@ -359,7 +398,7 @@ def test_rcpch_audit_team_can_edit_visits_from_all_pdus(
     client,
 ):
     gosh_user = NPDAUser.objects.filter(
-        organisation_employers__pz_code=GOSH_PZ_CODE
+        organisation_employers__pz_code=GOSH_PZ_CODE,
     ).first()
 
     ah_user = NPDAUser.objects.filter(

--- a/project/npda/views/visit.py
+++ b/project/npda/views/visit.py
@@ -5,6 +5,7 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import PermissionDenied
 from django.forms import BaseModelForm
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -240,6 +241,17 @@ class VisitUpdateView(
     model = Visit
     form_class = VisitForm
 
+    def get_object(self, queryset=None):
+        # PDUPermissionMixin only authorises the patient_id in the URL, not the
+        # visit pk itself, so guard against a visit belonging to a different
+        # patient/PDU being edited by guessing its pk.
+        visit = super().get_object(queryset)
+        if visit.patient_id != int(self.kwargs["patient_id"]):
+            raise PermissionDenied(
+                "This visit does not belong to the specified patient."
+            )
+        return visit
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["pdu"] = self.pdu
@@ -359,6 +371,17 @@ class VisitDeleteView(
     permission_denied_message = "You do not have the appropriate permissions to access this page/feature. Contact your Coordinator for assistance."
     model = Visit
     success_message = "Visit removed successfully"
+
+    def get_object(self, queryset=None):
+        # PDUPermissionMixin only authorises the patient_id in the URL, not the
+        # visit pk itself, so guard against a visit belonging to a different
+        # patient/PDU being deleted by guessing its pk.
+        visit = super().get_object(queryset)
+        if visit.patient_id != int(self.kwargs["patient_id"]):
+            raise PermissionDenied(
+                "This visit does not belong to the specified patient."
+            )
+        return visit
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)


### PR DESCRIPTION
Thanks to Fable for finding this issue and writing a nice summary:

`project/npda/views/visit.py` — for these routes PDUPermissionMixin.dispatch authorises the URL patient_id (checking that patient’s Transfer PDU is one of the user’s employers), but both views use the default get_object() → Visit.objects.get(pk=self.kwargs["pk"]), which is not scoped to patient_id. There is no get_queryset/get_object override in the file.

*Impact**: a coordinator who legitimately owns patient A at their own PDU can pass the authorisation check with A’s patient_id while supplying the pk of a visit belonging to patient B at a different PDU, then edit or delete that visit. Cross-PDU clinical data can be modified or destroyed.

Exploit shape:

```
/period/<p>/pdu/<PZ-A>/patient/<patientA_id>/visits/<visitB_pk>/update
```