### PR TITLE
Remove unused geocordinates backfill

### DIFF
--- a/project/npda/tests/factories/paediatrics_diabetes_unit_factory.py
+++ b/project/npda/tests/factories/paediatrics_diabetes_unit_factory.py
@@ -5,6 +5,7 @@ import logging
 
 # third-party imports
 import factory
+from django.contrib.gis.geos import Point
 
 # rcpch imports
 from project.npda.models.paediatric_diabetes_unit import PaediatricDiabetesUnit
@@ -52,6 +53,7 @@ class PaediatricsDiabetesUnitFactory(factory.django.DjangoModelFactory):
         pdu, created = PaediatricDiabetesUnit.objects.get_or_create(pz_code=pz_code)
         pdu.pz_code = pz_code
         pdu.lead_organisation_ods_code = lead_organisation_ods_code
+        pdu.lead_organisation_geocoordinates = Point(-2.9, 53.4, srid=4326)
 
         pdu.save()
         return pdu

--- a/project/npda/tests/permissions_tests/test_patient_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_patient_model_actions.py
@@ -41,12 +41,7 @@ def create_submission_with_patient(user):
 
 
 @pytest.mark.django_db
-@patch(
-    "project.npda.views.patient.fetch_organisation_by_ods_code",
-    return_value={"longitude": -2.9, "latitude": 53.4},
-)
 def test_users_only_see_patients_from_their_pdu_using_session_url(
-    mock_fetch_org,
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,
@@ -85,12 +80,7 @@ def test_users_only_see_patients_from_their_pdu_using_session_url(
 
 
 @pytest.mark.django_db
-@patch(
-    "project.npda.views.patient.fetch_organisation_by_ods_code",
-    return_value={"longitude": -2.9, "latitude": 53.4},
-)
 def test_users_only_see_patients_from_their_pdu_using_data_url(
-    mock_fetch_org,
     seed_groups_fixture,
     seed_users_fixture,
     seed_audit_periods_fixture,

--- a/project/npda/tests/permissions_tests/test_patient_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_patient_model_actions.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from unittest.mock import patch
 
 import pytest
 

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -10,7 +10,6 @@ from django.apps import apps
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.gis.db.models.functions import Distance
-from django.contrib.gis.geos import Point
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ValidationError
 from django.db.models import Case, Count, F, Max, Q, When

--- a/project/npda/views/patient.py
+++ b/project/npda/views/patient.py
@@ -25,7 +25,6 @@ from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 # Project imports
 from project.npda.general_functions import (
     data_breadcrumbs,
-    fetch_organisation_by_ods_code,
     patient_breadcrumbs,
     retrieve_quarter_for_date,
     visit_falls_within_audit_period_Q_object,
@@ -90,20 +89,6 @@ class PatientListView(
 
     def get_queryset(self):
         patient_queryset = super().get_queryset()
-
-        if self.pdu.lead_organisation_geocoordinates is None:
-            # we cannot make an API call for each patient  every time we load the page,
-            # so we only do it if the geocoordinates are missing
-            # This should have been done when the PDU was created
-            paediatric_diabetes_unit_lead_organisation = fetch_organisation_by_ods_code(
-                ods_code=self.pdu.lead_organisation_ods_code
-            )
-            self.pdu.lead_organisation_geocoordinates = Point(
-                paediatric_diabetes_unit_lead_organisation["longitude"],
-                paediatric_diabetes_unit_lead_organisation["latitude"],
-                srid=4326,
-            )
-            self.pdu.save()
 
         filtered_patients = Q(
             submissions__submission_active=True,


### PR DESCRIPTION
All PDUs in live have these and doing the backfill was making my new tests introduced in https://github.com/rcpch/national-paediatric-diabetes-audit/pull/1473 fail