### PR TITLE
Reactivate correct submission after deleting one

### DIFF
--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -15,7 +15,7 @@ Tests for NPDAUser model actions.
 """
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 from http import HTTPStatus
 
 # Python imports
@@ -882,6 +882,128 @@ def test_users_can_download_report(
         response["Content-Type"]
         == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     )
+
+
+@pytest.mark.django_db
+def test_lead_clinician_cannot_delete_submission(
+    client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+    valid_df,
+):
+    """Test that lead-clinician-style users cannot delete a submission."""
+
+    lead_clinician_user = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    client = login_and_verify_user(client, lead_clinician_user)
+
+    audit_start_date, _ = get_audit_period_for_date(timezone.now())
+
+    submission = Submission.objects.create(
+        audit_year=audit_start_date.year,
+        submission_date=timezone.now(),
+        submission_active=False,
+        submission_by=lead_clinician_user,
+        paediatric_diabetes_unit=lead_clinician_user.organisation_employers.first(),
+        csv_file=valid_df.to_csv(index=False).encode("utf-8"),
+        csv_file_name="test_csv_file.csv",
+        errors={},
+    )
+
+    url = reverse(
+        "pdu-submissions",
+        kwargs={
+            "pz_code": lead_clinician_user.organisation_employers.first().pz_code,
+            "audit_period": f"{audit_start_date.year}-{audit_start_date.year + 1}",
+        },
+    )
+
+    response = client.post(
+        url,
+        {"submit-data": "delete-data", "audit_id": submission.pk},
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert Submission.objects.filter(pk=submission.pk).exists()
+
+
+@pytest.mark.django_db
+def test_deleting_submission_reactivates_previous_submission_for_same_pdu_only(
+    client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    """Deleting a submission should reactivate the previous submission for the same PDU, not the most recent submission globally."""
+
+    audit_team_user = NPDAUser.objects.filter(
+        role=test_user_rcpch_audit_team_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    client = login_and_verify_user(client, audit_team_user)
+
+    audit_start_date, _ = get_audit_period_for_date(timezone.now())
+    pdu = audit_team_user.organisation_employers.first()
+    other_pdu = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+
+    older_submission = Submission.objects.create(
+        audit_year=audit_start_date.year,
+        submission_date=timezone.now() - timedelta(days=2),
+        submission_active=True,
+        submission_by=audit_team_user,
+        paediatric_diabetes_unit=pdu,
+        csv_file=b"older_csv",
+        csv_file_name="older.csv",
+        errors={},
+    )
+    newer_submission = Submission.objects.create(
+        audit_year=audit_start_date.year,
+        submission_date=timezone.now() - timedelta(days=1),
+        submission_active=False,
+        submission_by=audit_team_user,
+        paediatric_diabetes_unit=pdu,
+        csv_file=b"newer_csv",
+        csv_file_name="newer.csv",
+        errors={},
+    )
+    unrelated_submission = Submission.objects.create(
+        audit_year=audit_start_date.year,
+        submission_date=timezone.now(),
+        submission_active=False,
+        submission_by=audit_team_user,
+        paediatric_diabetes_unit=other_pdu,
+        csv_file=b"other_csv",
+        csv_file_name="other.csv",
+        errors={},
+    )
+
+    url = reverse(
+        "pdu-submissions",
+        kwargs={
+            "pz_code": pdu.pz_code,
+            "audit_period": f"{audit_start_date.year}-{audit_start_date.year + 1}",
+        },
+    )
+
+    response = client.post(
+        url,
+        {"submit-data": "delete-data", "audit_id": newer_submission.pk},
+        follow=True,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert Submission.objects.filter(pk=newer_submission.pk).count() == 0
+
+    older_submission.refresh_from_db()
+    unrelated_submission.refresh_from_db()
+
+    assert older_submission.submission_active is True
+    assert unrelated_submission.submission_active is False
 
 
 @pytest.mark.django_db

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -271,10 +271,19 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to delete submissions.",
                 )
-            # retrieve the  submission instance
-            submission = self.get_queryset().filter(
+            # retrieve the submission instance
+            submission = Submission.objects.filter(
                 pk=request.POST.get("audit_id")
             ).get()
+
+            if not (
+                request.user.is_rcpch_audit_team_member
+                or submission.paediatric_diabetes_unit
+                in request.user.organisation_employers.all()
+            ):
+                raise PermissionDenied(
+                    f"User {request.user.email} does not have permission to delete data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
+                )
 
             # check if the submission is active - if so, do not allow deletion, and return an error message
             if submission.submission_active:
@@ -292,10 +301,21 @@ class SubmissionsListView(
             submission.delete()
 
             # set the submission_active flag to True for the most recent submission
-            if Submission.objects.count() > 0:
-                new_first = Submission.objects.order_by("-submission_date").first()
-                new_first.submission_active = True
-                new_first.save()
+            # for the same PDU and audit period/year.
+            reactivation_queryset = Submission.objects.filter(
+                paediatric_diabetes_unit=submission.paediatric_diabetes_unit,
+                audit_year=submission.audit_year,
+            )
+            if submission.audit_period_id is not None:
+                reactivation_queryset = reactivation_queryset.filter(
+                    audit_period=submission.audit_period
+                )
+
+            if reactivation_queryset.exists():
+                new_first = reactivation_queryset.order_by("-submission_date").first()
+                if new_first is not None:
+                    new_first.submission_active = True
+                    new_first.save()
             messages.success(request, "Cohort submission deleted successfully")
 
         if button_name == "download-data":

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -222,6 +222,20 @@ class SubmissionsListView(
 
         return context
 
+    def get_submission_checking_permission(self, user, submission_id):
+        submission = Submission.objects.get(pk=submission_id)
+
+        if (
+            user.is_rcpch_audit_team_member
+            or submission.paediatric_diabetes_unit
+            in user.organisation_employers.all()
+        ):
+            return submission
+        
+        raise PermissionDenied(
+            f"User {user.email} does not have permission to access submission {submission_id} under PDU {submission.paediatric_diabetes_unit.pz_code}.",
+        )
+
     def get(self, request, *args, **kwargs):
         """
         Handle the HTMX GET request to filter submissions based on the 'done' parameter.
@@ -265,25 +279,16 @@ class SubmissionsListView(
             return render(request=request, template_name=template, context=context)
 
         button_name = request.POST.get("submit-data")
+        submission_id = request.POST.get("audit_id")
+
         if button_name == "delete-data":
             # check if the user has permission to delete submissions
             if not request.user.has_perm("npda.delete_submission"):
                 raise PermissionDenied(
                     "You do not have permission to delete submissions.",
                 )
-            # retrieve the submission instance
-            submission = Submission.objects.filter(
-                pk=request.POST.get("audit_id")
-            ).get()
-
-            if not (
-                request.user.is_rcpch_audit_team_member
-                or submission.paediatric_diabetes_unit
-                in request.user.organisation_employers.all()
-            ):
-                raise PermissionDenied(
-                    f"User {request.user.email} does not have permission to delete data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
-                )
+            
+            submission = self.get_submission_checking_permission(request.user, submission_id)
 
             # check if the submission is active - if so, do not allow deletion, and return an error message
             if submission.submission_active:
@@ -324,22 +329,11 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to download CSVs.",
                 )
-            submission = Submission.objects.filter(
-                pk=request.POST.get("audit_id")
-            ).get()
-            if (
-                request.user.is_rcpch_audit_team_member
-                or submission.paediatric_diabetes_unit
-                in request.user.organisation_employers.all()
-            ):
-                if submission.csv_file_name:
-                    return download_csv_file(request, submission.id)
-                else:
-                    return export_as_csv(request, submission)
+            submission = self.get_submission_checking_permission(request.user, submission_id)
+            if submission.csv_file_name:
+                return download_csv_file(request, submission.id)
             else:
-                raise PermissionDenied(
-                    f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
-                )
+                return export_as_csv(request, submission)
 
         if button_name == "download-report":
             # check if the user has permission to download submissions
@@ -347,19 +341,8 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to download submissions.",
                 )
-            submission = Submission.objects.filter(
-                pk=request.POST.get("audit_id")
-            ).get()
-            if (
-                request.user.is_rcpch_audit_team_member
-                or submission.paediatric_diabetes_unit
-                in request.user.organisation_employers.all()
-            ):
-                return download_xlsx(request, submission.id)
-            else:
-                raise PermissionDenied(
-                    f"User {request.user.email} does not have permission to download data for PDU {submission.paediatric_diabetes_unit.pz_code}.",
-                )
+            submission = self.get_submission_checking_permission(request.user, submission_id)
+            return download_xlsx(request, submission.id)
 
         if button_name == "start-questionnaire-submission":
             previous_audit_period = self.audit_period.previous_audit_period()

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -227,11 +227,10 @@ class SubmissionsListView(
 
         if (
             user.is_rcpch_audit_team_member
-            or submission.paediatric_diabetes_unit
-            in user.organisation_employers.all()
+            or submission.paediatric_diabetes_unit in user.organisation_employers.all()
         ):
             return submission
-        
+
         raise PermissionDenied(
             f"User {user.email} does not have permission to access submission {submission_id} under PDU {submission.paediatric_diabetes_unit.pz_code}.",
         )
@@ -287,8 +286,10 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to delete submissions.",
                 )
-            
-            submission = self.get_submission_checking_permission(request.user, submission_id)
+
+            submission = self.get_submission_checking_permission(
+                request.user, submission_id
+            )
 
             # check if the submission is active - if so, do not allow deletion, and return an error message
             if submission.submission_active:
@@ -329,7 +330,9 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to download CSVs.",
                 )
-            submission = self.get_submission_checking_permission(request.user, submission_id)
+            submission = self.get_submission_checking_permission(
+                request.user, submission_id
+            )
             if submission.csv_file_name:
                 return download_csv_file(request, submission.id)
             else:
@@ -341,7 +344,9 @@ class SubmissionsListView(
                 raise PermissionDenied(
                     "You do not have permission to download submissions.",
                 )
-            submission = self.get_submission_checking_permission(request.user, submission_id)
+            submission = self.get_submission_checking_permission(
+                request.user, submission_id
+            )
             return download_xlsx(request, submission.id)
 
         if button_name == "start-questionnaire-submission":

--- a/project/npda/views/submissions.py
+++ b/project/npda/views/submissions.py
@@ -272,7 +272,7 @@ class SubmissionsListView(
                     "You do not have permission to delete submissions.",
                 )
             # retrieve the  submission instance
-            submission = Submission.objects.filter(
+            submission = self.get_queryset().filter(
                 pk=request.POST.get("audit_id")
             ).get()
 


### PR DESCRIPTION
When deleting a submission the code reactivated the previous one, except it searched for that globally when it should filtered to the correct PDU.

That's now fixed. This came about as part of our Fable 5 security review flagging what it thought was a wider issue where anyone could delete a submission if they knew the primary key. In practice this wasn't possible since we only grant `delete_submission` to audit team members. But better to check permission properly anyway as a defense in depth.