### PR TITLE
Remove Celery test task

### DIFF
--- a/project/npda/templates/navbar/components/avatar_dropdown.html
+++ b/project/npda/templates/navbar/components/avatar_dropdown.html
@@ -47,14 +47,6 @@
         <li>
           <a href="{% url 'admin:index' %}"><i class="fa-solid fa-toolbox"></i>Django Admin</a>
         </li>
-        <form method="post" action="{% url 'celery_test_task' %}">
-          <li>
-              {% csrf_token %}
-              <button type="submit">
-                Trigger Celery test task
-              </button>
-          </li>
-        </form>
       {% endif %}
       <form method="post" action="{% url 'logout' %}">
         <li>

--- a/project/npda/tests/view_tests/test_basic_loads.py
+++ b/project/npda/tests/view_tests/test_basic_loads.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 import pytest
 from django.test import Client
-from django.urls import NoReverseMatch, reverse
+from django.urls import reverse
 
 from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.npda_user import NPDAUser
@@ -93,4 +93,3 @@ def test_login_from_direct_link_to_function_based_view(
 
     assert response.status_code == HTTPStatus.FOUND
     assert response.url == reverse("login") + "?next=" + url
-

--- a/project/npda/tests/view_tests/test_basic_loads.py
+++ b/project/npda/tests/view_tests/test_basic_loads.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 import pytest
 from django.test import Client
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.npda_user import NPDAUser
@@ -93,3 +93,4 @@ def test_login_from_direct_link_to_function_based_view(
 
     assert response.status_code == HTTPStatus.FOUND
     assert response.url == reverse("login") + "?next=" + url
+

--- a/project/npda/urls.py
+++ b/project/npda/urls.py
@@ -21,7 +21,6 @@ from project.npda.views import (
     npdauser_pdu_update,
 )
 
-from .tasks import test_task as celery_test_task
 from .views import (
     csrf_fail,
     download_template,
@@ -137,8 +136,6 @@ urlpatterns = [
         name="password_reset_confirm",
     ),
     path("csrf_fail/", csrf_fail, name="csrf_fail"),
-    # Debugging
-    path("celery_test_task/", celery_test_task, name="celery_test_task"),
 ]
 
 dashboard_urlpatterns = [

--- a/project/npda/views/__init__.py
+++ b/project/npda/views/__init__.py
@@ -16,7 +16,6 @@ from project.npda.views.dashboard.partials import (
 from .dashboard.dashboard import dashboard as dashboard
 from .errors import csrf_fail, error_400, error_403, error_404, error_500
 from .home import (
-    celery_test_task,
     download_template,
     feature_flags,
     home,

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -191,13 +191,6 @@ def download_template(request, audit_period, pdu):
 
 
 @login_and_otp_required()
-def celery_test_task(request):
-    test_task.delay()
-
-    return HttpResponse(status=204)
-
-
-@login_and_otp_required()
 def feature_flags(request):
     if not (request.user.is_superuser or request.user.is_rcpch_audit_team_member):
         raise PermissionDenied("Feature previews are restricted to audit team.")

--- a/project/npda/views/home.py
+++ b/project/npda/views/home.py
@@ -20,7 +20,6 @@ from project.npda.general_functions.organisations_adapter import (
 from project.npda.general_functions.session import get_user_feature_flags
 from project.npda.models.audit_period import AuditPeriod
 from project.npda.models.submission import Submission
-from project.npda.tasks import test_task
 from project.npda.views.npda_users import get_user_home_page
 
 # RCPCH imports


### PR DESCRIPTION
Fable 5 security review quite rightly pointed out the celery test task was unauthenticated. As a punishment I have removed it entirely. Goodbye Celery test task thank you for your service.