### PR TITLE
Manage employer security fixes

### DIFF
--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -885,6 +885,49 @@ def test_users_can_download_report(
 
 
 @pytest.mark.django_db
+def test_coordinator_cannot_delete_employer_affiliation_for_other_pdu_user(
+    client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    """A coordinator should not be able to delete an employer affiliation for a user outside their PDU."""
+
+    coordinator_user = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+    target_user = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=GOSH_PZ_CODE,
+    ).first()
+
+    client = login_and_verify_user(client, coordinator_user)
+
+    # `organisation_employers` is a M2M *through* OrganisationEmployer, so the
+    # through-row (not the PaediatricDiabetesUnit) carries the pk the view deletes.
+    target_employer_row = target_user.paediatric_diabetes_units.first()
+
+    client.post(
+        reverse("npdauser-pdu-update", kwargs={"pk": target_user.pk}),
+        {
+            "update": "delete",
+            "organisation_employer_id": target_employer_row.pk,
+        },
+        follow=True,
+    )
+
+    # The target user's employer affiliations should be unchanged: still exactly
+    # one employer, and it should be the same PDU it started with.
+    target_user.refresh_from_db()
+    remaining_employers = list(target_user.organisation_employers.all())
+
+    assert len(remaining_employers) == 1
+    assert remaining_employers[0].pz_code == GOSH_PZ_CODE
+    assert OrganisationEmployer.objects.filter(pk=target_employer_row.pk).exists()
+
+
+@pytest.mark.django_db
 def test_lead_clinician_cannot_delete_submission(
     client,
     seed_groups_fixture,

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -928,6 +928,61 @@ def test_coordinator_cannot_delete_employer_affiliation_for_other_pdu_user(
 
 
 @pytest.mark.django_db
+def test_coordinator_cannot_set_primary_employer_for_pdu_they_do_not_administer(
+    client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    """A coordinator should not be able to set a shared user's primary employer to
+    a PDU the coordinator does not themselves administer, even though they share
+    a different PDU with the target user."""
+
+    coordinator_user = NPDAUser.objects.filter(
+        role=test_user_audit_centre_coordinator_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+    target_user = NPDAUser.objects.filter(
+        role=test_user_audit_centre_editor_data.role,
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+    ).first()
+
+    # Give the target user a second employer at a PDU the coordinator does not
+    # administer. This is the affiliation shared with ALDER_HEY_PZ_CODE.
+    original_primary_employer = target_user.paediatric_diabetes_units.get(
+        paediatric_diabetes_unit__pz_code=ALDER_HEY_PZ_CODE
+    )
+    GOSH = PaediatricDiabetesUnit.objects.get(pz_code=GOSH_PZ_CODE)
+    other_pdu_employer = OrganisationEmployer.objects.create(
+        npda_user=target_user,
+        paediatric_diabetes_unit=GOSH,
+        is_primary_employer=False,
+    )
+
+    client = login_and_verify_user(client, coordinator_user)
+
+    response = client.post(
+        reverse("npdauser-pdu-update", kwargs={"pk": target_user.pk}),
+        {
+            "update": "update",
+            "organisation_employer_id": other_pdu_employer.pk,
+        },
+        follow=True,
+    )
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+    # The target user's primary employer should be unchanged: the GOSH
+    # affiliation (outside the coordinator's remit) must still be non-primary,
+    # and the original ALDER_HEY affiliation must still be primary.
+    other_pdu_employer.refresh_from_db()
+    original_primary_employer.refresh_from_db()
+
+    assert other_pdu_employer.is_primary_employer is False
+    assert original_primary_employer.is_primary_employer is True
+
+
+@pytest.mark.django_db
 def test_lead_clinician_cannot_delete_submission(
     client,
     seed_groups_fixture,

--- a/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
+++ b/project/npda/tests/permissions_tests/test_npda_user_model_actions.py
@@ -983,6 +983,55 @@ def test_coordinator_cannot_set_primary_employer_for_pdu_they_do_not_administer(
 
 
 @pytest.mark.django_db
+def test_coordinator_cannot_add_arbitrary_user_to_their_own_pdu(
+    client,
+    seed_groups_fixture,
+    seed_users_fixture,
+    seed_audit_periods_fixture,
+):
+    """A coordinator should not be able to add an arbitrary existing user - who has
+    no prior relationship with the coordinator's PDU - to their own PDU via the
+    npdauser-pdu-update HTMX endpoint. The `add_employer` branch correctly checks
+    the target PDU against the requester's own PDUs, but does not check that the
+    requester has any authority over the target user (`pk`), so any existing user
+    could otherwise be granted access to the coordinator's PDU's patient data."""
+
+    ah_coordinator = NPDAUser.objects.filter(
+        organisation_employers__pz_code=ALDER_HEY_PZ_CODE,
+        role=test_user_audit_centre_coordinator_data.role,
+    ).first()
+
+    # An arbitrary existing user with no relationship whatsoever to Alder Hey.
+    arbitrary_user = (
+        NPDAUser.objects.filter(
+            organisation_employers__pz_code=GOSH_PZ_CODE,
+            role=test_user_audit_centre_editor_data.role,
+        )
+        .exclude(pk=ah_coordinator.pk)
+        .first()
+    )
+
+    client = login_and_verify_user(client, ah_coordinator)
+
+    client.post(
+        reverse("npdauser-pdu-update", kwargs={"pk": arbitrary_user.pk}),
+        data={"add_employer": ALDER_HEY_PZ_CODE},
+        **{
+            # Gated on request.htmx
+            "HTTP_HX-Request": "true",
+        },
+    )
+
+    arbitrary_user.refresh_from_db()
+    employers = {e.pz_code for e in arbitrary_user.organisation_employers.all()}
+
+    # The arbitrary user should NOT have been added to Alder Hey by a coordinator
+    # who has no authority over them.
+    assert ALDER_HEY_PZ_CODE not in employers
+    assert employers == {GOSH_PZ_CODE}
+
+
+@pytest.mark.django_db
 def test_lead_clinician_cannot_delete_submission(
     client,
     seed_groups_fixture,

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -590,24 +590,56 @@ def npdauser_pdu_update(request, pk):
         )
 
     selected_npda_user = NPDAUser.objects.get(pk=pk)
+
+    my_pz_codes = set(
+        request.user.organisation_employers.values_list("pz_code", flat=True)
+    )
+
     if request.POST.get("update") == "delete":
         # delete the selected employer
         # cannot delete the primary employer but can set another employer as primary first and then delete the employer
-        OrganisationEmployer.objects.filter(
-            pk=request.POST.get("organisation_employer_id")
-        ).delete()
+        # scope to the selected user's own employer rows to prevent an IDOR where
+        # an arbitrary organisation_employer_id could delete any user's affiliation
+        employer_to_delete = OrganisationEmployer.objects.filter(
+            pk=request.POST.get("organisation_employer_id"),
+            npda_user=selected_npda_user,
+        ).select_related("paediatric_diabetes_unit").first()
+
+        if employer_to_delete is not None and not (
+            request.user.is_superuser
+            or request.user.is_rcpch_audit_team_member
+            or employer_to_delete.paediatric_diabetes_unit.pz_code in my_pz_codes
+        ):
+            raise PermissionDenied(
+                f"You do not have permission to remove users from {employer_to_delete.paediatric_diabetes_unit.pz_code}. Contact the NPDA for assistance."
+            )
+
+        if employer_to_delete is not None:
+            employer_to_delete.delete()
         template = "partials/employers.html"
     elif request.POST.get("update") == "update":
         # set the selected employer as the primary employer. Reset all other employers to False before setting the selected employer to True since only one employer can be primary
-        # set all employers to False
+        # scope to the selected user's own employer rows to prevent an IDOR
+        selected_employer = OrganisationEmployer.objects.filter(
+            pk=request.POST.get("organisation_employer_id"),
+            npda_user=selected_npda_user,
+        ).select_related("paediatric_diabetes_unit").get()
+
+        if not (
+            request.user.is_superuser
+            or request.user.is_rcpch_audit_team_member
+            or selected_employer.paediatric_diabetes_unit.pz_code in my_pz_codes
+        ):
+            raise PermissionDenied(
+                f"You do not have permission to set the primary employer to {selected_employer.paediatric_diabetes_unit.pz_code}. Contact the NPDA for assistance."
+            )
+
         template = "partials/employers.html"
+        # set all employers to False
         OrganisationEmployer.objects.filter(npda_user=selected_npda_user).update(
             is_primary_employer=False
         )
         # set the selected employer to True
-        selected_employer = OrganisationEmployer.objects.filter(
-            pk=request.POST.get("organisation_employer_id")
-        ).get()
         selected_employer.is_primary_employer = True
         selected_employer.save()
 

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -617,10 +617,14 @@ def npdauser_pdu_update(request, pk):
         # cannot delete the primary employer but can set another employer as primary first and then delete the employer
         # scope to the selected user's own employer rows to prevent an IDOR where
         # an arbitrary organisation_employer_id could delete any user's affiliation
-        employer_to_delete = OrganisationEmployer.objects.filter(
-            pk=request.POST.get("organisation_employer_id"),
-            npda_user=selected_npda_user,
-        ).select_related("paediatric_diabetes_unit").first()
+        employer_to_delete = (
+            OrganisationEmployer.objects.filter(
+                pk=request.POST.get("organisation_employer_id"),
+                npda_user=selected_npda_user,
+            )
+            .select_related("paediatric_diabetes_unit")
+            .first()
+        )
 
         if employer_to_delete is not None and not (
             request.user.is_superuser
@@ -637,10 +641,14 @@ def npdauser_pdu_update(request, pk):
     elif request.POST.get("update") == "update":
         # set the selected employer as the primary employer. Reset all other employers to False before setting the selected employer to True since only one employer can be primary
         # scope to the selected user's own employer rows to prevent an IDOR
-        selected_employer = OrganisationEmployer.objects.filter(
-            pk=request.POST.get("organisation_employer_id"),
-            npda_user=selected_npda_user,
-        ).select_related("paediatric_diabetes_unit").get()
+        selected_employer = (
+            OrganisationEmployer.objects.filter(
+                pk=request.POST.get("organisation_employer_id"),
+                npda_user=selected_npda_user,
+            )
+            .select_related("paediatric_diabetes_unit")
+            .get()
+        )
 
         if not (
             request.user.is_superuser

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -594,6 +594,23 @@ def npdauser_pdu_update(request, pk):
     my_pz_codes = set(
         request.user.organisation_employers.values_list("pz_code", flat=True)
     )
+    their_pz_codes = set(
+        selected_npda_user.organisation_employers.values_list("pz_code", flat=True)
+    )
+
+    # The requester must already have some legitimate relationship with the
+    # target user (i.e. they already share a PDU) before they can manage that
+    # user's employer affiliations at all. Without this, the target PDU checks
+    # further down could otherwise be satisfied while the target user (`pk`) is
+    # a completely arbitrary existing user unrelated to the requester.
+    if not (
+        request.user.is_superuser
+        or request.user.is_rcpch_audit_team_member
+        or my_pz_codes & their_pz_codes
+    ):
+        raise PermissionDenied(
+            f"You do not have permission to edit user {selected_npda_user}. Contact the NPDA for assistance."
+        )
 
     if request.POST.get("update") == "delete":
         # delete the selected employer


### PR DESCRIPTION
As discovered through our Fable 5 security review.

**IDOR: unscoped employer management (npdauser_pdu_update)**

`project/npda/views/npda_users.py` — the `npdauser_pdu_update` view is gated by `can_transfer_npda_lead_centre` + `change_npdauser`, but unlike `NPDAUserUpdateView.dispatch` it **never checks that the requesting user shares a PDU with (or administers) the target user** `pk`, and it operates on `OrganisationEmployer` rows by a **POST-supplied `organisation_employer_id` with no ownership scoping**:

- **Delete branch:** `OrganisationEmployer.objects.filter(pk=request.POST.get("organisation_employer_id")).delete()` — deletes *any* employer row by enumerating integer PKs, so a coordinator can remove **any user from any PDU** across the whole instance (account lockout / access-control tampering / DoS).
- **Set-primary branch:** same unscoped `pk`, allowing manipulation of another user's primary-employer state.
- **Add-employer branch:** the *target PDU* is correctly checked against the requester's PDUs, but the *target user* `pk` is not — so an arbitrary existing user can be added to the requester's PDU (granting that user access to its patient data).
