### PR TITLE
Separate setting to bypass 2fa for local dev

### DIFF
--- a/envs/example.env
+++ b/envs/example.env
@@ -48,6 +48,7 @@ DJANGO_STARTUP_COMMAND="python manage.py runserver 0.0.0.0:8008" # for local dev
 # FOR LOCAL DEVELOPMENT
 LOCAL_DEV_ADMIN_EMAIL="incubator@rcpch.ac.uk"
 LOCAL_DEV_ADMIN_PASSWORD="devp@ssword12345"
+LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA="True"
 
 SITE_CONTACT_EMAIL="npda@rcpch.ac.uk"
 EMAIL_DEFAULT_FROM_EMAIL = "npda@rcpch.ac.uk"

--- a/project/npda/admin.py
+++ b/project/npda/admin.py
@@ -19,7 +19,9 @@ from .models import (
 
 class NPDAAdminSite(AdminSiteOTPRequiredMixin, admin.AdminSite):
     def has_permission(self, request):
-        if settings.DEBUG and (request.user.is_superuser or request.user.is_staff):
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA and (
+            request.user.is_superuser or request.user.is_staff
+        ):
             return True
 
         return super().has_permission(request)

--- a/project/npda/forms/npda_user_form.py
+++ b/project/npda/forms/npda_user_form.py
@@ -155,7 +155,11 @@ class DebugCaptchaField(CaptchaField):
 
 
 class CaptchaAuthenticationForm(AuthenticationForm):
-    captcha = DebugCaptchaField() if settings.DEBUG else CaptchaField()
+    captcha = (
+        DebugCaptchaField()
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA
+        else CaptchaField()
+    )
 
     def __init__(self, request, *args, **kwargs) -> None:
         super().__init__(request, *args, **kwargs)
@@ -163,8 +167,8 @@ class CaptchaAuthenticationForm(AuthenticationForm):
         self.fields["password"].widget.attrs.update({"class": TEXT_INPUT})
         self.fields["captcha"].widget.attrs.update({"class": TEXT_INPUT})
 
-        # If in DEBUG -> don't require captch, pre fill fields
-        if settings.DEBUG:
+        # If bypassing 2FA/captcha for local dev -> don't require captcha, pre fill fields
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA:
             logger.warning("IN LOCAL DEVELOPMENT, BYPASSING LOGIN BY PREFILLING FIELDS")
             self.fields["username"].widget.attrs["value"] = (
                 settings.LOCAL_DEV_ADMIN_EMAIL

--- a/project/npda/views/decorators.py
+++ b/project/npda/views/decorators.py
@@ -19,12 +19,12 @@ def login_and_otp_required():
         # Then, ensure 2fa verified
         user = request.user
         # Bypass 2fa if local dev, with warning message
-        if settings.DEBUG and user.is_authenticated:
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA and user.is_authenticated:
             logger.warning(
-                "User %s has bypassed 2FA for %s as settings.DEBUG is %s",
+                "User %s has bypassed 2FA for %s as settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA is %s",
                 user,
                 view,
-                settings.DEBUG,
+                settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA,
             )
             return True
 

--- a/project/npda/views/mixins.py
+++ b/project/npda/views/mixins.py
@@ -21,7 +21,7 @@ class LoginAndOTPRequiredMixin(AccessMixin):
     """
     Mixin that ensures the user is logged in and has verified via OTP.
 
-    Bypassed in local development is user.is_superuser AND settings.DEBUG==True.
+    Bypassed in local development if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA==True.
     """
 
     def dispatch(self, request, *args, **kwargs):
@@ -30,13 +30,13 @@ class LoginAndOTPRequiredMixin(AccessMixin):
         if not request.user.is_authenticated:
             return self.handle_no_permission()
 
-        # Check if the user is superuser and bypass 2FA in debug mode
-        if settings.DEBUG and request.user.is_authenticated:
+        # Bypass 2FA in local development if enabled
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA and request.user.is_authenticated:
             logger.warning(
-                "User %s has bypassed 2FA for %s as settings.DEBUG is %s and user has role %s and is superuser status: %s",
+                "User %s has bypassed 2FA for %s as settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA is %s and user has role %s and is superuser status: %s",
                 request.user,
                 self.__class__.__name__,
-                settings.DEBUG,
+                settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA,
                 request.user.get_role_display(),
                 request.user.is_superuser,
             )

--- a/project/npda/views/npda_users.py
+++ b/project/npda/views/npda_users.py
@@ -894,7 +894,7 @@ class RCPCHLoginView(TwoFactorLoginView):
     def post(self, *args, **kwargs):
         # In local development, override the token workflow, just sign in
         # the user without 2FA token
-        if settings.DEBUG:
+        if settings.LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA:
             user = authenticate(
                 self.request,
                 username=self.request.POST.get("auth-username"),

--- a/project/settings.py
+++ b/project/settings.py
@@ -79,11 +79,18 @@ DOCS_URL = os.getenv("DOCS_URL", "/docs/")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
-if DEBUG is True:
-    CAPTCHA_TEST_MODE = True  # if in debug mode, can just type 'PASSED' and captcha validates. Default value is False
-    LOCAL_DEV_ADMIN_EMAIL = os.getenv("LOCAL_DEV_ADMIN_EMAIL")
-    LOCAL_DEV_ADMIN_PASSWORD = os.getenv("LOCAL_DEV_ADMIN_PASSWORD")
+LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA = (
+    os.getenv("LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA", "False") == "True"
+)
+if LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA:
+    # Allows typing 'PASSED' to validate the captcha
+    # NB this is a django-simple-captcha setting so it is not unused!
+    CAPTCHA_TEST_MODE = True
 
+LOCAL_DEV_ADMIN_EMAIL = os.getenv("LOCAL_DEV_ADMIN_EMAIL")
+LOCAL_DEV_ADMIN_PASSWORD = os.getenv("LOCAL_DEV_ADMIN_PASSWORD")
+
+if DEBUG is True:
     if (
         os.environ.get("RUN_MAIN") == "true"
     ):  # Prevent double execution during reloading

--- a/project/settings.py
+++ b/project/settings.py
@@ -409,7 +409,7 @@ SILKY_AUTHORISATION = True  # User must have permissions
 def silky_permissions(user):
     if user.is_superuser:
         # 2fa bypass for local dev
-        if DEBUG and user.is_authenticated:
+        if LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA and user.is_authenticated:
             return True
 
         # 2fa enabled

--- a/s/start-prod
+++ b/s/start-prod
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+if [ "$LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA" = "True" ]; then
+    echo "FATAL: LOCAL_DEV_BYPASS_2FA_AND_CAPTCHA is set to True. Refusing to start in production mode with 2FA/captcha bypass enabled." >&2
+    exit 1
+fi
+
 python manage.py write_azure_pg_password_file
 python manage.py makemigrations
 python manage.py migrate


### PR DESCRIPTION
As recommended by [Fable security review (M2)](https://forum.rcpch.tech/t/july-2026-npda-ai-security-review/740). Have a separate setting to DEBUG for bypassing 2fa in local dev and refuse to start in prod script if enabled.

Ported by Kimi K3 from the original change in E12 that I did manually (https://github.com/rcpch/rcpch-audit-engine/pull/1417/)