### PR TITLE
Remove pre 2026 download link

### DIFF
--- a/project/npda/templates/upload_csv/file_upload.html
+++ b/project/npda/templates/upload_csv/file_upload.html
@@ -28,9 +28,6 @@
             </button>
           </div>
         </div>
-          <a href="{% data_url 'pdu-download-template' %}?dataset_year=2021"
-            download="npda_template.csv"
-            class="bg-rcpch_light_blue border-rcpch_light_blue btn w-full text-lg text-white focus:bg-rcpch_pink hover:bg-rcpch_dark_blue"><i class="fa-file-arrow-down fa-solid"></i> Download NPDA CSV template</a>
           <a href="{% data_url 'pdu-download-template' %}?dataset_year=2026"
             download="npda_template.csv"
             class="bg-rcpch_light_blue border-rcpch_light_blue btn w-full text-lg text-white focus:bg-rcpch_pink hover:bg-rcpch_dark_blue"><i class="fa-file-arrow-down fa-solid"></i> Download 2026/2027 NPDA CSV template</a>


### PR DESCRIPTION
Unit reported confusion which template link they should use. Remove the old link as they will need to submit using the new dataset going forward.